### PR TITLE
LinearNode optional flattenting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,20 @@
 # Changelog
 
-## [0.2.1] - 2025-12-04
-- Node autograd is the default behavior now; can override by subclassing a node and implementing manual gradients
-- N-dimensional tensor support: breaking changes to shape conventions
-  - Linear nodes: shape=(features,) e.g., (128,) for 128-dimensional vector
-  - 2D Conv nodes: shape=(H, W, C) e.g., (28, 28, 64) for 28x28 image with 64 channels (NHWC)
-- Plugin architecture for custom nodes with two choices for registration: decorator or setuptools entry points
+## [0.2.3] - 2025-12-18
+- Change Linear node default behavior to perform matmul on the last tensor dimension. Flattening inputs now requires flag `flatten_input=True`.
+- Removed gain_mod_error from NodeState, as it was not used by anything other than explicit grad linear node.
+- Added softmax and Gelu activation functions.
+- Added KL Divergence energy functional.
 
 ## [0.2.2] - 2025-12-05
 - Unified config validation and registry pattern across nodes, energy functionals, and activations
 - Custom objects now follow a consistent extensibility pattern with `CONFIG_SCHEMA` and `@register_*` decorators
 - Node construction delegated to `NodeBase.from_config()` for cleaner separation of concerns
 - CONFIG_SCHEMA is now a required class variable for easier access and introspection
+
+## [0.2.1] - 2025-12-04
+- Node autograd is the default behavior now; can override by subclassing a node and implementing manual gradients
+- N-dimensional tensor support: breaking changes to shape conventions
+  - Linear nodes: shape=(features,) e.g., (128,) for 128-dimensional vector
+  - 2D Conv nodes: shape=(H, W, C) e.g., (28, 28, 64) for 28x28 image with 64 channels (NHWC)
+- Plugin architecture for custom nodes with two choices for registration: decorator or setuptools entry points

--- a/README.md
+++ b/README.md
@@ -44,10 +44,14 @@ python examples/mnist_demo.py
 
 ## Contributions
 Contributions are welcome! Please open issues or pull requests on the GitHub repository.
+- Develop on a branch using convention "feature/your_feature_name"
+- All demos must match baseline results and test suites must pass before merging new code.
+- Write unit tests and docstrings for new code
+- Follow PEP8 style guidelines
 
-This is a research-first project. APIs may change frequently until v1.0 release. Any breaking changes are documented in the changelog.
-
-All demos must match baseline results and test suites must pass before merging new code.
+This is a research-first project.
+- APIs may change frequently until v1.0 release.
+- Any breaking changes are documented in the changelog.
 
 ## License: private until officially released. Please do not distribute.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,8 +143,9 @@ class LayerNormNode(NodeBase):
         return {"in": SlotSpec(name="in", is_multi_input=False)}
 
     @staticmethod
-    def initialize_params(key, node_dim, input_dims, config):
+    def initialize_params(key, node_shape, input_shapes, config):
         eps = config.get("eps", 1e-5)
+        node_dim = int(jnp.prod(jnp.array(node_shape)))
         return NodeParams(
             weights={"gamma": jnp.ones((1, node_dim))},
             biases={"beta": jnp.zeros((1, node_dim))}
@@ -175,7 +176,6 @@ class LayerNormNode(NodeBase):
             pre_activation=pre_activation,
             error=error,
             energy=energy,
-            gain_mod_error=error,  # identity activation derivative = 1
             substructure={"mean": mean, "var": var, "x_norm": x_norm}
         )
 
@@ -203,7 +203,8 @@ class BatchNormNode(NodeBase):
         return {"in": SlotSpec(name="in", is_multi_input=False)}
 
     @staticmethod
-    def initialize_params(key, node_dim, input_dims, config):
+    def initialize_params(key, node_shape, input_shapes, config):
+        node_dim = int(jnp.prod(jnp.array(node_shape)))
         return NodeParams(
             weights={
                 "gamma": jnp.ones((1, node_dim)),
@@ -265,7 +266,6 @@ class SoftmaxNode(NodeBase):
             pre_activation=pre_activation,
             error=error,
             energy=energy,
-            gain_mod_error=gain_mod_error,
             substructure={}
         )
 
@@ -295,10 +295,10 @@ class Conv2DNode(NodeBase):
         return {"in": SlotSpec(name="in", is_multi_input=True)}
 
     @staticmethod
-    def initialize_params(key, node_dim, input_dims, config):
+    def initialize_params(key, node_shape, input_shapes, config):
         kernel_size = config.get("kernel_size", (3, 3))
-        in_channels = config.get("in_channels", sum(input_dims.values()))
-        out_channels = config.get("out_channels", node_dim)
+        in_channels = config.get("in_channels", sum(s[-1] for s in input_shapes.values()))
+        out_channels = config.get("out_channels", node_shape[-1])
 
         # Xavier initialization for conv kernels
         fan_in = in_channels * kernel_size[0] * kernel_size[1]
@@ -336,7 +336,7 @@ class Conv2DNode(NodeBase):
             pre_activation = pre_activation + params.biases["b"]
 
         # Apply activation
-        activation_fn, activation_deriv = get_activation(node_info.activation_config)
+        activation_fn, activation_deriv = get_activation(node_info.node_config["activation"])
         z_mu = activation_fn(pre_activation)
 
         # Compute error and energy
@@ -348,7 +348,6 @@ class Conv2DNode(NodeBase):
             pre_activation=pre_activation,
             error=error,
             energy=energy,
-            gain_mod_error=gain_mod_error,
             substructure={}
         )
 
@@ -399,9 +398,9 @@ class MultiHeadAttentionNode(NodeBase):
         }
 
     @staticmethod
-    def initialize_params(key, node_dim, input_dims, config):
+    def initialize_params(key, node_shape, input_shapes, config):
         num_heads = config.get("num_heads", 8)
-        embed_dim = node_dim
+        embed_dim = node_shape[-1]  # Last dimension is embed_dim
         head_dim = embed_dim // num_heads
 
         assert embed_dim % num_heads == 0, "embed_dim must be divisible by num_heads"
@@ -465,7 +464,7 @@ class MultiHeadAttentionNode(NodeBase):
         pre_activation = jnp.matmul(attn_output, params.weights["W_o"]) + params.biases["b_o"]
 
         # Apply activation (typically identity for attention output)
-        activation_fn, activation_deriv = get_activation(node_info.activation_config)
+        activation_fn, activation_deriv = get_activation(node_info.node_config["activation"])
         z_mu = activation_fn(pre_activation)
 
         # Compute error and energy
@@ -483,7 +482,6 @@ class MultiHeadAttentionNode(NodeBase):
             pre_activation=pre_activation,
             error=error,
             energy=energy,
-            gain_mod_error=gain_mod_error,
             substructure=substructure
         )
 
@@ -513,10 +511,10 @@ class TransformerBlockNode(NodeBase):
         return {"in": SlotSpec(name="in", is_multi_input=False)}
 
     @staticmethod
-    def initialize_params(key, node_dim, input_dims, config):
+    def initialize_params(key, node_shape, input_shapes, config):
         num_heads = config.get("num_heads", 8)
-        ffn_dim = config.get("ffn_dim", node_dim * 4)
-        embed_dim = node_dim
+        embed_dim = node_shape[-1]  # Last dimension is embed_dim
+        ffn_dim = config.get("ffn_dim")
 
         keys = jax.random.split(key, 8)
         std = 1.0 / jnp.sqrt(embed_dim)
@@ -951,10 +949,11 @@ class HyperNode(NodeBase):
         }
 
     @staticmethod
-    def initialize_params(key, node_dim, input_dims, config):
+    def initialize_params(key, node_shape, input_shapes, config):
         """
         Initialize both the hypernode's own parameters and its subgraph.
         """
+        import numpy as np
         from fabricpc.graph.graph_net import create_pc_graph
 
         subgraph_config = config["subgraph_config"]
@@ -966,12 +965,14 @@ class HyperNode(NodeBase):
         )
 
         # Boundary transformation weights (optional)
-        # Maps from external input dim to subgraph input dim
+        # Maps from external input shape to subgraph input shape
         boundary_weights = {}
-        for slot_name, ext_dim in input_dims.items():
+        for slot_name, ext_shape in input_shapes.items():
             internal_input = config["input_mapping"].get(slot_name)
             if internal_input:
-                int_dim = subgraph_structure.nodes[internal_input].dim
+                ext_dim = int(np.prod(ext_shape))
+                int_shape = subgraph_structure.nodes[internal_input].shape
+                int_dim = int(np.prod(int_shape))
                 key_boundary, subkey = jax.random.split(key_boundary)
                 boundary_weights[f"boundary_{slot_name}"] = (
                     jax.random.normal(subkey, (ext_dim, int_dim)) * 0.01
@@ -1036,7 +1037,6 @@ class HyperNode(NodeBase):
             pre_activation=z_mu,
             error=error,
             energy=energy,
-            gain_mod_error=error,  # identity activation
             substructure={"_subgraph_state": subgraph_state}
         )
 
@@ -1436,7 +1436,7 @@ def create_pc_transformer(
     vocab_size: int,
     embed_dim: int = 256,
     num_heads: int = 8,
-    num_layers: int = 4,
+    num_blocks: int = 4,
     num_classes: int = 2,
     max_seq_len: int = 512,
 ):
@@ -1454,7 +1454,7 @@ def create_pc_transformer(
 
     # Transformer layers
     prev_layer = "embedding"
-    for i in range(num_layers):
+    for i in range(num_blocks):
         layer_name = f"transformer_{i}"
         net.add_node(layer_name, dim=embed_dim, node_type="transformer_block",
                     num_heads=num_heads, ffn_dim=embed_dim * 4)
@@ -1489,7 +1489,7 @@ if __name__ == "__main__":
         vocab_size=len(vocab),
         embed_dim=256,
         num_heads=8,
-        num_layers=4,
+        num_blocks=4,
         num_classes=2,
     )
     model.init(jax.random.PRNGKey(42))

--- a/examples/custom_node.py
+++ b/examples/custom_node.py
@@ -144,7 +144,6 @@ class Conv2DNode(NodeBase):
             z_mu = state.z_latent
             pre_activation = jnp.zeros_like(state.z_latent)
             error = jnp.zeros_like(state.z_latent)
-            gain_mod_error = jnp.zeros_like(state.z_latent)
         else:
             # Accumulate convolution outputs from all inputs
             pre_activation = jnp.zeros((batch_size, *out_shape))
@@ -172,16 +171,11 @@ class Conv2DNode(NodeBase):
             # Compute error
             error = state.z_latent - z_mu
 
-            # Gain-modulated error
-            f_prime = activation_deriv(pre_activation)
-            gain_mod_error = error * f_prime
-
         # Update state
         state = state._replace(
             pre_activation=pre_activation,
             z_mu=z_mu,
             error=error,
-            gain_mod_error=gain_mod_error
         )
 
         # Compute energy

--- a/examples/mnist_advanced.py
+++ b/examples/mnist_advanced.py
@@ -10,6 +10,9 @@ This example demonstrates:
 
 Compared to mnist_demo.py, this shows a customizable training loop
 """
+import os
+os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+os.environ.setdefault("JAX_PLATFORMS", "cuda")
 
 import jax
 import jax.numpy as jnp

--- a/examples/mnist_demo.py
+++ b/examples/mnist_demo.py
@@ -9,18 +9,18 @@ This is the absolute SIMPLEST example showing how to:
 
 Total code: ~60 lines. That's it!
 """
+import os
+os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+os.environ.setdefault("JAX_PLATFORMS", "cuda")  # change to "cpu", "cuda" or "tpu" if available
 
 import jax
 from torch.utils.data import DataLoader
 from torchvision import datasets, transforms
 import time
-import os
 
 from fabricpc.graph import create_pc_graph
 from fabricpc.training import train_pcn, evaluate_pcn
 from fabricpc.training.data_utils import OneHotWrapper
-
-os.environ["JAX_PLATFORMS"] = "cuda"  # change to "cpu", "cuda" or "tpu" if available
 
 # jax.config.update("jax_traceback_filtering", "off")
 

--- a/fabricpc/core/activations.py
+++ b/fabricpc/core/activations.py
@@ -307,6 +307,40 @@ class LeakyReLUActivation(ActivationBase):
         alpha = config.get("alpha", 0.01) if config else 0.01
         return jnp.where(x > 0, 1.0, alpha)
 
+@register_activation("gelu")
+class GeluActivation(ActivationBase):
+    """GELU activation: x * 0.5 * (1 + erf(x / sqrt(2)))"""
+
+    CONFIG_SCHEMA = {}
+
+    @staticmethod
+    def forward(x: jnp.ndarray, config: Dict[str, Any] = None) -> jnp.ndarray:
+        return nn.gelu(x)
+
+    @staticmethod
+    def derivative(x: jnp.ndarray, config: Dict[str, Any] = None) -> jnp.ndarray:
+        # Gelu(x): = x * normal_CDF
+        sqrt_2_over_pi = jnp.sqrt(2 / jnp.pi)
+        x_cubed = x ** 3
+        apx_norm_cdf = 0.5 * (1 + jnp.tanh(sqrt_2_over_pi * (x + 0.044715 * x_cubed)))  # Approximation of normal CDF via tanh
+        norm_cdf_prime = (0.5 * sqrt_2_over_pi * (1 + 3 * 0.044715 * x ** 2)) * (1 - jnp.tanh(sqrt_2_over_pi * (x + 0.044715 * x_cubed)) ** 2)
+        return apx_norm_cdf + x * norm_cdf_prime
+
+@register_activation("softmax")
+class SoftmaxActivation(ActivationBase):
+    """Softmax activation: exp(x) / sum(exp(x)) along the last axis"""
+
+    CONFIG_SCHEMA = {}
+
+    @staticmethod
+    def forward(x: jnp.ndarray, config: Dict[str, Any] = None) -> jnp.ndarray:
+        exp_x = jnp.exp(x - jnp.max(x, axis=-1, keepdims=True))  # relative to max value for numerical stability
+        return exp_x / jnp.sum(exp_x, axis=-1, keepdims=True)
+
+    @staticmethod
+    def derivative(x: jnp.ndarray, config: Dict[str, Any] = None) -> jnp.ndarray:
+        s = SoftmaxActivation.forward(x)
+        return s * (1 - s)  # Note: This is a simplification; full Jacobian is more complex
 
 @register_activation("hard_tanh")
 class HardTanhActivation(ActivationBase):

--- a/fabricpc/core/energy.py
+++ b/fabricpc/core/energy.py
@@ -562,6 +562,101 @@ class HuberEnergy(EnergyFunctional):
         return jnp.clip(diff, -delta, delta)
 
 
+@register_energy("kl_divergence")
+class KLDivergenceEnergy(EnergyFunctional):
+    """
+    KL Divergence energy functional.
+
+    E = Σ z * log(z / μ) = Σ z * (log(z) - log(μ))
+
+    Computes D_KL(z || μ), the Kullback-Leibler divergence from μ to z.
+    Both z_latent and z_mu should be valid probability distributions
+    (non-negative, summing to 1 along the specified axis).
+
+    Use for:
+    - Matching probability distributions
+    - Variational inference objectives
+    - Information-theoretic losses
+
+    Config options:
+        - eps: Small constant for numerical stability (default: 1e-7)
+        - axis: Axis along which probabilities sum to 1 (default: -1)
+
+    Note:
+        KL divergence is asymmetric: D_KL(z || μ) ≠ D_KL(μ || z).
+        This implementation computes D_KL(z_latent || z_mu), penalizing
+        cases where z_latent has mass but z_mu does not.
+    """
+
+    CONFIG_SCHEMA = {
+        "eps": {
+            "type": (int, float),
+            "default": 1e-7,
+            "description": "Small constant for numerical stability in log"
+        },
+        "axis": {
+            "type": int,
+            "default": -1,
+            "description": "Axis along which probabilities sum to 1"
+        }
+    }
+
+    @staticmethod
+    def energy(
+        z_latent: jnp.ndarray,
+        z_mu: jnp.ndarray,
+        config: Dict[str, Any] = None
+    ) -> jnp.ndarray:
+        """
+        Compute KL divergence energy: E = Σ z * log(z / μ)
+
+        For numerical stability, uses: z * log(z) - z * log(μ)
+        with clipping to avoid log(0).
+        """
+        eps = config.get("eps", 1e-7) if config else 1e-7
+
+        # Clip for numerical stability
+        z_latent_safe = jnp.clip(z_latent, eps, 1.0)
+        z_mu_safe = jnp.clip(z_mu, eps, 1.0)
+
+        # KL divergence: z * log(z) - z * log(μ)
+        # Note: z * log(z) term handles the case where z -> 0 (gives 0, not -inf)
+        kl = z_latent_safe * (jnp.log(z_latent_safe) - jnp.log(z_mu_safe))
+
+        # Handle z = 0 case: 0 * log(0) should be 0, not nan
+        kl = jnp.where(z_latent < eps, 0.0, kl)
+
+        # Sum over all non-batch dimensions
+        axes_to_sum = tuple(range(1, len(kl.shape)))
+        return jnp.sum(kl, axis=axes_to_sum)
+
+    @staticmethod
+    def grad_latent(
+        z_latent: jnp.ndarray,
+        z_mu: jnp.ndarray,
+        config: Dict[str, Any] = None
+    ) -> jnp.ndarray:
+        """
+        Compute gradient: ∂E/∂z = log(z / μ) + 1 = log(z) - log(μ) + 1
+
+        For KL(z || μ):
+            ∂/∂z [z * log(z) - z * log(μ)] = log(z) + 1 - log(μ)
+        """
+        eps = config.get("eps", 1e-7) if config else 1e-7
+
+        z_latent_safe = jnp.clip(z_latent, eps, 1.0)
+        z_mu_safe = jnp.clip(z_mu, eps, 1.0)
+
+        # Gradient: log(z) - log(μ) + 1
+        grad = jnp.log(z_latent_safe) - jnp.log(z_mu_safe) + 1.0
+
+        # For z near 0, gradient should push toward matching μ
+        # Use a smooth approximation
+        grad = jnp.where(z_latent < eps, -jnp.log(z_mu_safe), grad)
+
+        return grad
+
+
 # =============================================================================
 # Convenience Functions
 # =============================================================================

--- a/fabricpc/core/inference.py
+++ b/fabricpc/core/inference.py
@@ -89,7 +89,7 @@ def inference_step(
     #     for node_name in structure.nodes:
     #         node_state = state.nodes[node_name]
     #         node_info = structure.nodes[node_name]
-    #         _, act_deriv = get_activation(node_info.activation_config)
+    #         _, act_deriv = get_activation(node_info.node_config["activation"])
     #         latent_grad = state.nodes[node_name].latent_grad
     #         latent_grad = latent_grad * act_deriv(node_state.pre_activation)
     #         # Update the state with new latent gradients
@@ -106,6 +106,10 @@ def inference_step(
             new_z_latent = node_state.z_latent - eta_infer * node_state.latent_grad
         # Update state
         state = update_node_in_state(state, node_name, z_latent=new_z_latent)
+
+    for node_name in structure.nodes:
+        # Reset substructure
+        state = update_node_in_state(state, node_name, substructure={})
 
     return state
 

--- a/fabricpc/core/initialization.py
+++ b/fabricpc/core/initialization.py
@@ -116,6 +116,7 @@ def get_default_weight_init() -> Dict[str, Any]:
 # STATE INITIALIZATION
 # ==============================================================================
 
+# TODO define schema for state initialization configs
 def initialize_state_values(
     config: Dict[str, Any],
     key: jax.Array,  # from jax.random.PRNGKey

--- a/fabricpc/core/types.py
+++ b/fabricpc/core/types.py
@@ -143,7 +143,6 @@ class NodeState(NamedTuple):
         energy: Energy
         pre_activation: Pre-activation values (before activation function)
         latent_grad: Gradients w.r.t. latent states for inference updates
-        gain_mod_error: Gain-modulated errors (error * activation_derivative)
         substructure: Dictionary of node internal states for complex nodes
     """
 
@@ -153,7 +152,6 @@ class NodeState(NamedTuple):
     energy: jnp.ndarray  # per-sample energy, shape (batch_size,)
     pre_activation: jnp.ndarray
     latent_grad: jnp.ndarray  # For local gradient accumulation
-    gain_mod_error: jnp.ndarray  # gain modulated error per node, for gradient computation
     substructure: Dict[str, jnp.ndarray]  # substructure of node internal states
 
 class GraphState(NamedTuple):
@@ -348,7 +346,7 @@ tree_util.register_pytree_node(
 tree_util.register_pytree_node(
     NodeState,
     lambda ns: (
-        (ns.z_latent, ns.z_mu, ns.error, ns.energy, ns.pre_activation, ns.latent_grad, ns.gain_mod_error, ns.substructure),
+        (ns.z_latent, ns.z_mu, ns.error, ns.energy, ns.pre_activation, ns.latent_grad, ns.substructure),
         None,
     ),
     lambda aux, children: NodeState(*children),

--- a/fabricpc/graph/graph_net.py
+++ b/fabricpc/graph/graph_net.py
@@ -178,7 +178,6 @@ def initialize_state(
             error=jnp.zeros(shape),
             energy=jnp.zeros((batch_size,)),  # Per-sample energy
             pre_activation=jnp.zeros(shape),
-            gain_mod_error=jnp.zeros(shape),
             latent_grad=jnp.zeros(shape),
             substructure={},
         )

--- a/fabricpc/nodes/base.py
+++ b/fabricpc/nodes/base.py
@@ -241,7 +241,7 @@ class NodeBase(ABC):
         """
         Forward pass: update state and compute gradients of weights for local learning.
 
-        The local gradient for weights is: -(input.T @ gain_mod_error)
+        The local gradient for weights is: delE/delW
 
         Args:
             params: Current node parameters

--- a/fabricpc/nodes/linear.py
+++ b/fabricpc/nodes/linear.py
@@ -4,9 +4,14 @@ Linear node implementation for JAX predictive coding networks.
 This implements a linear transformation node with configurable activation functions.
 The node has a single multi-input slot that accepts multiple incoming connections.
 
-Linear nodes flatten all non-batch dimensions of inputs for the matrix multiplication,
-then reshape outputs back to the target shape. This makes them function as dense/fully-connected
-layers regardless of input tensor dimensionality.
+By default, linear nodes apply matrix multiplication on the **last axis only**, which is
+standard for embeddings, projections, and transformer layers. This means:
+- Input shape: (batch, ..., in_features)
+- Weight shape: (in_features, out_features)
+- Output shape: (batch, ..., out_features)
+
+For fully-connected (dense) behavior that flattens all dimensions, set `flatten_input: true`
+in the node config. This creates weights of shape (total_in_numel, total_out_numel) and reshapes output to the node's shape tuple.
 """
 
 from typing import Dict, Any, Tuple
@@ -45,6 +50,12 @@ class LinearNode(FlattenInputMixin, NodeBase):
             "type": bool,
             "default": True,
             "description": "Whether to use bias"
+        },
+        "flatten_input": {
+            "type": bool,
+            "default": False,
+            "description": "If True, flatten all input dimensions for dense/fully-connected behavior and reshape the output to the node's shape tuple. "
+                          "If False (default), apply matmul on last axis only (standard for embeddings)."
         }
     }
 
@@ -71,11 +82,12 @@ class LinearNode(FlattenInputMixin, NodeBase):
     ) -> NodeParams:
         """
         Initialize weight matrix and bias vector.
-        Linear node weights structure:
-            NodeParams.weights: is a dict keyed by EdgeInfo.key for each incoming edge.
-            NodeParams.biases: Dict['b': bias vector]
 
-        Linear nodes flatten inputs before matmul, so weights have shape (in_numel, out_numel).
+        Weight shape depends on `flatten_input` config:
+        - flatten_input=False (default): weights have shape (in_features, out_features)
+          where in_features and out_features are the last dimensions of input/output.
+          This applies the same weights at each position (standard for embeddings).
+        - flatten_input=True: weights have shape (in_numel, out_numel) for dense layers.
 
         Args:
             key: JAX random key
@@ -86,8 +98,7 @@ class LinearNode(FlattenInputMixin, NodeBase):
         Returns:
             NodeParams with initialized W and b
         """
-        # Compute output numel (flattened dimension)
-        out_numel = int(np.prod(node_shape))
+        flatten_input = config["flatten_input"]
 
         # Get weight initialization config
         default_cfg = {"type": "normal", "mean": 0.0, "std": 0.05}
@@ -96,15 +107,29 @@ class LinearNode(FlattenInputMixin, NodeBase):
         # Split key for weights and biases
         key_w, key_b = jax.random.split(key)
 
-        # Initialize weight matrix
-        # this node class uses multi-input "in" slot; create weights for each incoming edge
+        # Initialize weight matrix for each incoming edge
+        # this node class uses multi-input "in" slot
         weights_dict = {}
         rand_key_w = dict(zip(input_shapes.keys(), jax.random.split(key_w, len(input_shapes))))
+
         for edge_key, in_shape in input_shapes.items():
             if ":in" not in edge_key:
-                raise ValueError(f"linear node requires 'in' slot dimension. got edge key {edge_key}")  # validate that edges correspond to "in" slot
-            in_numel = int(np.prod(in_shape))
-            weights_dict[edge_key] = initialize_weights(weight_init_config, rand_key_w[edge_key], (in_numel, out_numel))
+                raise ValueError(f"linear node requires 'in' slot dimension. got edge key {edge_key}")
+
+            if flatten_input:
+                # Dense/fully-connected: flatten all dimensions
+                in_numel = int(np.prod(in_shape))
+                out_numel = int(np.prod(node_shape))
+                weight_shape = (in_numel, out_numel)
+            else:
+                # Per-position: only last axis (standard for embeddings/projections)
+                in_features = in_shape[-1]
+                out_features = node_shape[-1]
+                weight_shape = (in_features, out_features)
+
+            weights_dict[edge_key] = initialize_weights(
+                weight_init_config, rand_key_w[edge_key], weight_shape
+            )
 
         # Initialize bias (usually zeros)
         # Bias shape is (1,) + node_shape for proper broadcasting
@@ -132,7 +157,8 @@ class LinearNode(FlattenInputMixin, NodeBase):
         Computes:
             forward pass -> compute error -> compute energy -> total energy
 
-        Inputs are flattened before matmul, outputs are reshaped to node_info.shape.
+        When flatten_input=False (default): applies matmul on last axis only.
+        When flatten_input=True: flattens all dimensions for dense behavior.
 
         Args:
             params: Node parameters (weights, biases)
@@ -151,40 +177,45 @@ class LinearNode(FlattenInputMixin, NodeBase):
         # Get batch size and output shape
         batch_size = state.z_latent.shape[0]
         out_shape = node_info.shape  # e.g., (128,) or (28, 28, 1)
+        flatten_input = node_info.node_config["flatten_input"]
 
         if node_info.in_degree == 0:
             # Source nodes: no inputs
             z_mu = state.z_latent  # prediction is the latent state itself
             pre_activation = jnp.zeros_like(state.z_latent)
             error = jnp.zeros_like(state.z_latent)
-            gain_mod_error = jnp.zeros_like(state.z_latent)
         else:
-            # Linear transformation using mixin
-            pre_activation = FlattenInputMixin.compute_linear(
-                inputs, params.weights, batch_size, out_shape
-            )
+            if flatten_input:
+                # Dense/fully-connected: flatten all dimensions
+                pre_activation = FlattenInputMixin.compute_linear(
+                    inputs, params.weights, batch_size, out_shape
+                )
+            else:
+                # Per-position: matmul on last axis only (standard for embeddings)
+                # Input shape: (batch, ..., in_features)
+                # Weight shape: (in_features, out_features)
+                # Output shape: (batch, ..., out_features)
+                pre_activation = jnp.zeros((batch_size,) + out_shape)
+                for edge_key, x in inputs.items():
+                    # jnp.matmul broadcasts over leading dimensions
+                    pre_activation = pre_activation + jnp.matmul(x, params.weights[edge_key])
 
             # Add bias if present (bias already has shape (1, *out_shape))
             if "b" in params.biases and params.biases["b"].size > 0:
                 pre_activation = pre_activation + params.biases["b"]
 
             # Apply activation function
-            activation_fn, activation_deriv = get_activation(node_info.node_config["activation"])
+            activation_fn, _ = get_activation(node_info.node_config["activation"])
             z_mu = activation_fn(pre_activation)
 
             # Error
             error = state.z_latent - z_mu
 
-            # Gain-modulated error (use newly computed pre_activation, not state.pre_activation)
-            f_prime = activation_deriv(pre_activation)  # shape (batch_size, *out_shape)
-            gain_mod_error = error * f_prime  # element-wise multiplication
-
         # Update node state
         state = state._replace(
             pre_activation=pre_activation,
             z_mu=z_mu,
-            error=error,
-            gain_mod_error=gain_mod_error)
+            error=error)
 
         # Compute energy, accumulate the self-latent gradient
         state = node_class.energy_functional(state, node_info)
@@ -218,7 +249,8 @@ class LinearExplicitGrad(LinearNode):
         Forward pass: updates node state and computes gradients w.r.t. inputs.
         Explicitly compute gradients
 
-        Gradients are computed in flat space and reshaped back to source shapes.
+        When flatten_input=False: gradients computed via matmul on last axis.
+        When flatten_input=True: gradients computed in flat space and reshaped.
 
         Args:
             params: Node parameters (weights, biases)
@@ -238,9 +270,13 @@ class LinearExplicitGrad(LinearNode):
         _, state = node_class.forward(params, inputs, state, node_info)
         # Note: the self-latent gradient is accumulated in state.latent_grad by the forward method
 
+        # Gain-modulated error computation
+        state = node_class.compute_gain_mod_error(state, node_info)
+
         # Determine the energy functional to use for the node from its config
         energy_functional = node_info.node_config.get("energy", {}).get("type", None)
         latent_is_preactivation = node_info.node_config.get("latent_type") == "preactivation"
+        flatten_input = node_info.node_config["flatten_input"]
         input_grads = {}
 
         # Back-synapse gradients for each edge, and accumulate to source nodes
@@ -252,14 +288,18 @@ class LinearExplicitGrad(LinearNode):
             if energy_functional == "gaussian":
                 if latent_is_preactivation:
                     raise NotImplementedError("pre-activation latent type not implemented for LinearExplicitGrad with Gaussian energy.")
-                    grad_contribution = -jnp.matmul(state.error, params.weights[edge_key].T)
-                    # error (batch, dim_tgt)
-                    # weights{s->t} (dim_src, dim_tgt)
                 else:
-                    # Flatten gain_mod_error and compute gradient in flat space
-                    gain_mod_error_flat = FlattenInputMixin.flatten_input(state.gain_mod_error)
-                    grad_flat = -jnp.matmul(gain_mod_error_flat, params.weights[edge_key].T)
-                    grad_contribution = FlattenInputMixin.reshape_output(grad_flat, source_shape)
+                    if flatten_input:
+                        # Flatten gain_mod_error and compute gradient in flat space
+                        gain_mod_error_flat = FlattenInputMixin.flatten_input(state.substructure["gain_mod_error"])
+                        grad_flat = -jnp.matmul(gain_mod_error_flat, params.weights[edge_key].T)
+                        grad_contribution = FlattenInputMixin.reshape_output(grad_flat, source_shape)
+                    else:
+                        # Per-position: matmul on last axis (broadcasts over leading dims)
+                        # gain_mod_error: (batch, ..., out_features)
+                        # weights: (in_features, out_features)
+                        # grad: (batch, ..., in_features)
+                        grad_contribution = -jnp.matmul(state.substructure["gain_mod_error"], params.weights[edge_key].T)
             else:
                 raise NotImplementedError(f"energy functional '{energy_functional}' not implemented in LinearExplicitGrad.")
 
@@ -278,8 +318,8 @@ class LinearExplicitGrad(LinearNode):
         Forward pass: update state and compute gradients of weights for local learning.
         Explicitly compute gradients
 
-        The local gradient for weights is: -(input_flat.T @ gain_mod_error_flat)
-        Inputs and errors are flattened before computing gradients.
+        When flatten_input=False: gradient is -(input.T @ gain_mod_error) on last axes.
+        When flatten_input=True: inputs/errors flattened before computing gradients.
 
         Args:
             params: Current node parameters
@@ -298,23 +338,59 @@ class LinearExplicitGrad(LinearNode):
         # Forward pass to get new state
         _, state = node_class.forward(params, inputs, state, node_info)
 
+        # Gain-modulated error computation
+        state = node_class.compute_gain_mod_error(state, node_info)
+
+        flatten_input = node_info.node_config["flatten_input"]
         weight_grads = {}
         bias_grads = {}
 
-        # Flatten gain_mod_error using mixin
-        gain_mod_error_flat = FlattenInputMixin.flatten_input(state.gain_mod_error)
-
         # Weight gradient
         for edge_key, in_tensor in inputs.items():
-            in_flat = FlattenInputMixin.flatten_input(in_tensor)
-            # Compute gradient: (in_numel, batch) @ (batch, out_numel) -> (in_numel, out_numel)
-            grad_w = -jnp.matmul(in_flat.T, gain_mod_error_flat)
+            if flatten_input:
+                # Flatten inputs and errors for dense gradient computation
+                in_flat = FlattenInputMixin.flatten_input(in_tensor)
+                gain_mod_error_flat = FlattenInputMixin.flatten_input(state.substructure["gain_mod_error"])
+                # Compute gradient: (in_numel, batch) @ (batch, out_numel) -> (in_numel, out_numel)
+                grad_w = -jnp.matmul(in_flat.T, gain_mod_error_flat)
+            else:
+                # Per-position gradient: contract over batch and position dims
+                # in_tensor: (batch, ..., in_features)
+                # gain_mod_error: (batch, ..., out_features)
+                # grad_w: (in_features, out_features)
+                # Reshape to (batch*positions, features) for efficient matmul
+                in_shape = in_tensor.shape
+                err_shape = state.substructure["gain_mod_error"].shape
+                in_flat = in_tensor.reshape(-1, in_shape[-1])  # (batch*pos, in_features)
+                err_flat = state.substructure["gain_mod_error"].reshape(-1, err_shape[-1])  # (batch*pos, out_features)
+                grad_w = -jnp.matmul(in_flat.T, err_flat)  # (in_features, out_features)
             weight_grads[edge_key] = grad_w
 
         # Bias gradient - sum over batch, keep shape (1, *out_shape)
         if "b" in params.biases:
             # Sum over batch (axis=0), keepdims to get (1, *out_shape)
-            grad_b = -jnp.sum(state.gain_mod_error, axis=0, keepdims=True)
+            grad_b = -jnp.sum(state.substructure["gain_mod_error"], axis=0, keepdims=True)
             bias_grads["b"] = grad_b
 
         return state, NodeParams(weights=weight_grads, biases=bias_grads)
+
+    @staticmethod
+    def compute_gain_mod_error(
+        state: NodeState,
+        node_info: NodeInfo
+    ) -> NodeState:
+        """
+        Compute gain-modulated error for this node.
+
+        Args:
+            state: NodeState containing current error and pre_activation
+            node_info: NodeInfo object
+        """
+        _, activation_deriv = get_activation(node_info.node_config["activation"])
+
+        # Gain-modulated error computation
+        f_prime = activation_deriv(state.pre_activation)  # shape (batch_size, *out_shape)
+        gain_mod_error = state.error * f_prime  # element-wise multiplication
+
+        state = state._replace(substructure={"gain_mod_error": gain_mod_error})
+        return state

--- a/fabricpc/training/__init__.py
+++ b/fabricpc/training/__init__.py
@@ -14,16 +14,35 @@ from fabricpc.training.data_utils import (
     OneHotWrapper,
     # TODO: jax data loaders)
 )
+from fabricpc.training.train_backprop import (
+    compute_loss,
+    train_step_backprop,
+    train_backprop,
+    compute_loss_autoregressive,
+    train_step_backprop_autoregressive,
+    train_backprop_autoregressive,
+    evaluate_backprop,
+)
 
 
 __all__ = [
+    # Predictive coding training
     "train_step",
     "train_pcn",
     "evaluate_pcn",
     "compute_local_weight_gradients",
     "create_optimizer",
+    # Multi-GPU
     "train_pcn_multi_gpu",
     "evaluate_pcn_multi_gpu",
     "replicate_params",
     "shard_batch",
+    # Backprop training
+    "compute_loss",
+    "train_step_backprop",
+    "train_backprop",
+    "compute_loss_autoregressive",
+    "train_step_backprop_autoregressive",
+    "train_backprop_autoregressive",
+    "evaluate_backprop",
 ]

--- a/fabricpc/training/train.py
+++ b/fabricpc/training/train.py
@@ -25,8 +25,6 @@ def compute_local_weight_gradients(
     Compute local weight gradients for each node using its own error signal.
 
     This implements the local Hebbian learning rule for predictive coding:
-    - Weight gradient: -(input.T @ gain_mod_error)
-    - Bias gradient: -sum(gain_mod_error)
 
     Args:
         params: Current model parameters

--- a/fabricpc/training/train_autoregressive.py
+++ b/fabricpc/training/train_autoregressive.py
@@ -1,0 +1,640 @@
+"""
+Autoregressive training loop for transformer predictive coding networks.
+
+This module implements training for autoregressive (next-token prediction) tasks
+using the predictive coding framework. Key features:
+
+1. Teacher forcing: During training, use ground truth tokens as input
+2. Causal masking: Ensure predictions only depend on past tokens
+3. Sequence-level energy: Aggregate prediction errors across positions
+4. Local Hebbian learning: Weight updates based on local gradients
+
+The training loop supports both:
+- Full sequence prediction (all positions predict next token)
+- Last-token prediction (only predict final token, for efficiency)
+"""
+
+from typing import Dict, Tuple, Any, List, Optional, Callable, cast
+import jax
+import jax.numpy as jnp
+import optax
+
+from fabricpc.core.types import GraphParams, GraphState, GraphStructure, NodeParams
+from fabricpc.core.inference import run_inference, gather_inputs
+from fabricpc.graph.graph_net import initialize_state
+from fabricpc.nodes import get_node_class
+
+
+def create_causal_mask(seq_len: int) -> jnp.ndarray:
+    """
+    Create a causal attention mask for autoregressive modeling.
+
+    Returns:
+        Mask of shape (seq_len, seq_len) where mask[i,j] = 1 if j <= i else 0
+        This ensures position i can only attend to positions 0..i
+    """
+    return jnp.tril(jnp.ones((seq_len, seq_len)))
+
+
+def compute_autoregressive_energy(
+    final_state: GraphState,
+    structure: GraphStructure,
+    targets: jnp.ndarray,
+    output_node: str,
+    loss_type: str = "cross_entropy",
+) -> jnp.ndarray:
+    """
+    Compute autoregressive prediction loss.
+
+    Args:
+        final_state: Converged state after inference
+        structure: Graph structure
+        targets: Target tokens, shape (batch, seq_len) or (batch, seq_len, vocab_size)
+        output_node: Name of the output node
+        loss_type: "cross_entropy" or "mse"
+
+    Returns:
+        Scalar loss value
+    """
+    predictions = final_state.nodes[output_node].z_latent  # (batch, seq_len, vocab_size)
+
+    if loss_type == "cross_entropy":
+        # Targets should be one-hot or indices
+        if targets.ndim == 2:
+            # Convert indices to one-hot
+            vocab_size = predictions.shape[-1]
+            targets = jax.nn.one_hot(targets, vocab_size)
+
+        # Cross-entropy loss: -sum(target * log(pred))
+        # Add small epsilon for numerical stability
+        log_preds = jnp.log(predictions + 1e-10)
+        loss = -jnp.sum(targets * log_preds) / targets.shape[0]
+
+    elif loss_type == "mse":
+        # Mean squared error
+        loss = jnp.mean((predictions - targets) ** 2)
+
+    else:
+        raise ValueError(f"Unknown loss_type: {loss_type}")
+
+    return loss
+
+
+def compute_local_weight_gradients_ar(
+    params: GraphParams,
+    final_state: GraphState,
+    structure: GraphStructure,
+) -> GraphParams:
+    """
+    Compute local weight gradients for autoregressive training.
+
+    This is similar to the standard local gradient computation but
+    can be extended for sequence-specific optimizations.
+
+    Args:
+        params: Current model parameters
+        final_state: Converged state after inference
+        structure: Graph structure
+
+    Returns:
+        GraphParams containing gradients
+    """
+    gradients = {}
+
+    for node_name, node_info in structure.nodes.items():
+        if node_info.in_degree == 0:
+            gradients[node_name] = NodeParams(weights={}, biases={})
+            continue
+
+        in_edges_data = gather_inputs(node_info, structure, final_state)
+        node_class = get_node_class(node_info.node_type)
+
+        # Compute local gradients
+        node_state, grad_params = node_class.forward_learning(
+            params.nodes[node_name],
+            in_edges_data,
+            final_state.nodes[node_name],
+            node_info
+        )
+
+        gradients[node_name] = grad_params
+
+    return GraphParams(nodes=gradients)
+
+
+def train_step_autoregressive(
+    params: GraphParams,
+    opt_state: optax.OptState,
+    batch: Dict[str, jnp.ndarray],
+    structure: GraphStructure,
+    optimizer: optax.GradientTransformation,
+    rng_key: jax.Array,
+    infer_steps: int,
+    eta_infer: float = 0.1,
+    use_causal_mask: bool = True,
+) -> Tuple[GraphParams, optax.OptState, float, GraphState]:
+    """
+    Single autoregressive training step.
+
+    This implements the predictive coding training loop for sequence prediction:
+    1. Clamp input sequence and target sequence using task_map
+    2. Generate and apply causal masking via task_map["causal_mask"]
+    3. Run inference to convergence
+    4. Compute local gradients
+    5. Update weights
+
+    Args:
+        params: Current model parameters
+        opt_state: Optimizer state
+        batch: Batch with keys matching task_map (e.g., 'x' for input, 'y' for target)
+            x: (batch, seq_len, vocab_size) or (batch, seq_len)
+            y: (batch, seq_len, vocab_size) or (batch, seq_len)
+        structure: Graph structure with task_map defining input/output nodes.
+            For causal masking, task_map should include "causal_mask" -> node_name
+        optimizer: Optax optimizer
+        rng_key: JAX random key
+        infer_steps: Number of inference steps
+        eta_infer: Inference learning rate
+        use_causal_mask: Whether to apply causal masking
+
+    Returns:
+        Tuple of (updated_params, updated_opt_state, loss, final_state)
+    """
+    batch_size = batch["x"].shape[0]
+    seq_len = batch["x"].shape[1]
+
+    # Map tasks to nodes using task_map
+    clamps = {}
+    for task_name, task_value in batch.items():
+        if task_name in structure.task_map:
+            node_name = structure.task_map[task_name]
+            clamps[node_name] = task_value
+
+    # Generate and clamp causal mask if enabled and configured in task_map
+    if use_causal_mask and "causal_mask" in structure.task_map:
+        # Create causal mask: (seq_len, seq_len) where mask[i,j] = 1 if j <= i
+        causal_mask = create_causal_mask(seq_len)
+        # Broadcast to (batch, 1, seq_len, seq_len) for attention scores
+        causal_mask = causal_mask[None, None, :, :]
+        causal_mask = jnp.broadcast_to(causal_mask, (batch_size, 1, seq_len, seq_len))
+
+        # Clamp the causal mask to the node specified in task_map
+        mask_node = structure.task_map["causal_mask"]
+        clamps[mask_node] = causal_mask
+
+    # Initialize state
+    init_state = initialize_state(
+        structure, batch_size, rng_key, clamps=clamps, params=params
+    )
+
+    # Run inference
+    final_state = run_inference(
+        params, init_state, clamps, structure, infer_steps, eta_infer
+    )
+
+    # Compute energy (sum over non-source nodes)
+    energy = jnp.array(0.0)
+    for node_name, node_info in structure.nodes.items():
+        if node_info.in_degree > 0:
+            energy = energy + jnp.sum(final_state.nodes[node_name].energy)
+
+    loss = energy / batch_size
+
+    # Compute local gradients
+    grads = compute_local_weight_gradients_ar(params, final_state, structure)
+
+    # Update parameters
+    updates, opt_state = optimizer.update(grads, opt_state, params)
+    params = cast(GraphParams, optax.apply_updates(params, updates))
+
+    return params, opt_state, loss.astype(float), final_state
+
+
+def train_autoregressive(
+    params: GraphParams,
+    structure: GraphStructure,
+    train_loader: Any,
+    config: dict,
+    rng_key: jax.Array,
+    verbose: bool = True,
+    epoch_callback: Optional[Callable] = None,
+    iter_callback: Optional[Callable] = None,
+) -> Tuple[GraphParams, List[List[float]], List[Any]]:
+    """
+    Main training loop for autoregressive predictive coding.
+
+    Args:
+        params: Initial parameters
+        structure: Graph structure
+        train_loader: Data loader yielding batches with 'x' and 'y' keys
+        config: Training configuration:
+            - optimizer: Optimizer config dict
+            - num_epochs: Number of training epochs
+            - infer_steps: Inference steps per training step
+            - eta_infer: Inference learning rate
+            - use_causal_mask: Whether to use causal masking (default True)
+            - gradient_accumulation_steps: Steps to accumulate gradients (default 1)
+        rng_key: JAX random key
+        verbose: Whether to print progress
+        epoch_callback: Optional callback (epoch, params, structure, config, rng) -> any
+        iter_callback: Optional callback (epoch, batch_idx, loss) -> any
+
+    Returns:
+        Tuple of (trained_params, energy_history, epoch_results)
+    """
+    from fabricpc.training.optimizers import create_optimizer
+
+    # Create optimizer
+    optimizer = create_optimizer(config.get("optimizer", {"type": "adam", "lr": 1e-3}))
+    opt_state = optimizer.init(params)
+
+    # Training hyperparameters
+    infer_steps = config.get("infer_steps", 20)
+    eta_infer = config.get("eta_infer", 0.1)
+    num_epochs = config.get("num_epochs", 10)
+    use_causal_mask = config.get("use_causal_mask", True)
+    grad_accum_steps = config.get("gradient_accumulation_steps", 1)
+
+    # JIT compile training step
+    jit_train_step = jax.jit(
+        lambda p, o, b, k: train_step_autoregressive(
+            p, o, b, structure, optimizer, k, infer_steps, eta_infer, use_causal_mask
+        )
+    )
+
+    iter_results = []
+    epoch_results = []
+
+    for epoch_idx in range(num_epochs):
+        try:
+            num_batches = len(train_loader)
+        except TypeError:
+            raise TypeError("train_loader must support len()")
+
+        # Split keys for batches
+        epoch_rng_key, rng_key = jax.random.split(rng_key)
+        batch_keys = jax.random.split(epoch_rng_key, num_batches)
+
+        batch_energies = []
+        epoch_loss = 0.0
+
+        for batch_idx, batch_data in enumerate(train_loader):
+            # Convert batch to JAX format
+            if isinstance(batch_data, dict):
+                batch = {k: jnp.array(v) for k, v in batch_data.items()}
+            elif isinstance(batch_data, (list, tuple)):
+                batch = {
+                    "x": jnp.array(batch_data[0]),
+                    "y": jnp.array(batch_data[1]),
+                }
+            else:
+                raise ValueError(f"Unsupported batch format: {type(batch_data)}")
+
+            # Training step
+            params, opt_state, loss, _ = jit_train_step(
+                params, opt_state, batch, batch_keys[batch_idx]
+            )
+
+            epoch_loss += loss
+
+            if iter_callback is not None:
+                batch_energies.append(iter_callback(epoch_idx, batch_idx, loss))
+            else:
+                batch_energies.append(loss)
+
+        iter_results.append(batch_energies)
+        avg_loss = epoch_loss / num_batches
+
+        # Epoch callback
+        if epoch_callback is not None:
+            epoch_results.append(
+                epoch_callback(epoch_idx, params, structure, config, rng_key)
+            )
+        else:
+            epoch_results.append(None)
+
+        if verbose:
+            print(f"Epoch {epoch_idx + 1}/{num_epochs}, Loss: {avg_loss:.4f}")
+
+    return params, iter_results, epoch_results
+
+
+def _generation_step(
+    carry: Tuple[jnp.ndarray, jnp.ndarray, jax.Array],
+    step_idx: int,
+    params: GraphParams,
+    structure: GraphStructure,
+    input_node: str,
+    output_node: str,
+    seq_len: int,
+    vocab_size: int,
+    batch_size: int,
+    infer_steps: int,
+    eta_infer: float,
+    temperature: float,
+    top_k: Optional[int],
+    top_p: Optional[float],
+) -> Tuple[Tuple[jnp.ndarray, jnp.ndarray, jax.Array], jnp.ndarray]:
+    """
+    Single generation step for use with jax.lax.scan.
+
+    Uses a sliding window approach with fixed-size buffers to maintain
+    constant shapes required by JAX scan.
+
+    Args:
+        carry: Tuple of (context_window, output_buffer, rng_key)
+            - context_window: Fixed-size (batch, seq_len) window of recent tokens
+            - output_buffer: Fixed-size (batch, max_new_tokens) buffer for generated tokens
+            - rng_key: JAX random key
+        step_idx: Current step index, used to write to output buffer
+        params, structure, etc.: Static parameters passed via closure
+
+    Returns:
+        Tuple of (new_carry, next_token)
+    """
+    context_window, output_buffer, rng_key = carry
+    rng_key, sample_key, init_key = jax.random.split(rng_key, 3)
+
+    # Convert context window to one-hot
+    input_onehot = jax.nn.one_hot(context_window, vocab_size)
+
+    # Create clamps (only input, not output)
+    clamps = {input_node: input_onehot}
+
+    # Initialize and run inference
+    state = initialize_state(
+        structure, batch_size, init_key, clamps=clamps, params=params
+    )
+    final_state = run_inference(
+        params, state, clamps, structure, infer_steps, eta_infer
+    )
+
+    # Get output for the last position
+    # z_mu contains the predicted output after activation (softmax for output node)
+    # z_latent is the raw latent state before activation
+    output_probs = final_state.nodes[output_node].z_mu
+    output_last = output_probs[:, -1, :]  # (batch, vocab_size)
+
+    # Convert to log-probabilities for sampling
+    # z_mu after softmax should be probabilities, convert to log-probs
+    # Adding epsilon avoids log(0)
+    logits = jnp.log(output_last + 1e-10)
+
+    # Apply temperature (divide log-probs, equivalent to taking prob^(1/T))
+    logits = logits / temperature
+
+    # Apply top-k filtering (always run but with large k if not specified)
+    effective_top_k = top_k if top_k is not None else vocab_size
+    top_k_logits, top_k_indices = jax.lax.top_k(logits, effective_top_k)
+    # Set non-top-k logits to -inf
+    neg_inf_mask = jnp.full_like(logits, float('-inf'))
+    logits = neg_inf_mask.at[
+        jnp.arange(batch_size)[:, None], top_k_indices
+    ].set(top_k_logits)
+
+    # Apply top-p (nucleus) filtering
+    if top_p is not None:
+        sorted_indices = jnp.argsort(-logits, axis=-1)
+        sorted_logits = jnp.take_along_axis(logits, sorted_indices, axis=-1)
+        sorted_probs = jax.nn.softmax(sorted_logits, axis=-1)
+        cumsum_probs = jnp.cumsum(sorted_probs, axis=-1)
+        # Find cutoff
+        cutoff_mask = cumsum_probs > top_p
+        # Shift mask to keep at least one token
+        cutoff_mask = jnp.concatenate([
+            jnp.zeros((batch_size, 1), dtype=bool),
+            cutoff_mask[:, :-1]
+        ], axis=-1)
+        sorted_logits = jnp.where(cutoff_mask, float('-inf'), sorted_logits)
+        # Unsort
+        unsort_indices = jnp.argsort(sorted_indices, axis=-1)
+        logits = jnp.take_along_axis(sorted_logits, unsort_indices, axis=-1)
+
+    # Sample from distribution
+    next_token = jax.random.categorical(sample_key, logits, axis=-1)  # (batch,)
+
+    # Update context window: shift left and append new token
+    new_context = jnp.concatenate([
+        context_window[:, 1:],
+        next_token[:, None]
+    ], axis=1)
+
+    # Write to output buffer at current step index
+    new_output_buffer = output_buffer.at[:, step_idx].set(next_token)
+
+    return (new_context, new_output_buffer, rng_key), next_token
+
+
+def generate_autoregressive(
+    params: GraphParams,
+    structure: GraphStructure,
+    prompt: jnp.ndarray,
+    max_new_tokens: int,
+    rng_key: jax.Array,
+    temperature: float = 1.0,
+    infer_steps: int = 20,
+    eta_infer: float = 0.1,
+    top_k: Optional[int] = None,
+    top_p: Optional[float] = None,
+) -> jnp.ndarray:
+    """
+    Generate tokens autoregressively using the trained model.
+
+    This function is JIT-compiled for efficient generation. The inner loop
+    uses jax.lax.scan with fixed-size buffers for optimal performance.
+
+    Args:
+        params: Trained model parameters
+        structure: Graph structure
+        prompt: Initial token indices, shape (seq_len,) or (batch, seq_len)
+        max_new_tokens: Number of new tokens to generate
+        rng_key: JAX random key
+        temperature: Sampling temperature (higher = more random, 1=neutral, <1=less random)
+        infer_steps: Inference steps per generation step
+        eta_infer: Inference learning rate
+        top_k: If set, only sample from top-k tokens
+        top_p: If set, use nucleus sampling with this probability threshold
+
+    Returns:
+        Generated token indices, shape (prompt_len + max_new_tokens,) or (batch, prompt_len + max_new_tokens)
+    """
+    # Handle batched vs unbatched input
+    if prompt.ndim == 1:
+        prompt = prompt[None, :]  # Add batch dimension
+        unbatch = True
+    else:
+        unbatch = False
+
+    batch_size, prompt_len = prompt.shape
+    input_node = structure.task_map.get("x")
+    output_node = structure.task_map.get("y")
+
+    if input_node is None or output_node is None:
+        raise ValueError("Structure must have 'x' and 'y' in task_map")
+
+    vocab_size = structure.nodes[output_node].shape[-1]
+    seq_len = structure.nodes[input_node].shape[0]
+
+    # Prepare initial context window (pad or truncate prompt to seq_len)
+    if prompt_len >= seq_len:
+        # Use last seq_len tokens as context
+        context_window = prompt[:, -seq_len:]
+    else:
+        # Pad at the beginning with zeros
+        pad_len = seq_len - prompt_len
+        context_window = jnp.pad(prompt, ((0, 0), (pad_len, 0)), constant_values=0)
+
+    # Create JIT-compiled generation step with static arguments closed over
+    @jax.jit
+    def jit_generate_loop(context: jnp.ndarray, rng: jax.Array) -> jnp.ndarray:
+        """JIT-compiled generation loop using lax.scan."""
+
+        def scan_fn(carry, step_idx):
+            return _generation_step(
+                carry, step_idx,
+                params=params,
+                structure=structure,
+                input_node=input_node,
+                output_node=output_node,
+                seq_len=seq_len,
+                vocab_size=vocab_size,
+                batch_size=batch_size,
+                infer_steps=infer_steps,
+                eta_infer=eta_infer,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+            )
+
+        # Initialize output buffer for generated tokens
+        output_buffer = jnp.zeros((batch_size, max_new_tokens), dtype=jnp.int32)
+
+        # Run the generation loop
+        init_carry = (context, output_buffer, rng)
+        (_, final_output_buffer, _), _ = jax.lax.scan(
+            scan_fn,
+            init_carry,
+            jnp.arange(max_new_tokens)
+        )
+
+        return final_output_buffer
+
+    # Run the JIT-compiled generation
+    generated_tokens = jit_generate_loop(context_window, rng_key)
+
+    # Concatenate prompt with generated tokens
+    result = jnp.concatenate([prompt, generated_tokens], axis=1)
+
+    if unbatch:
+        result = result[0]  # Remove batch dimension
+
+    return result
+
+
+def evaluate_autoregressive(
+    params: GraphParams,
+    structure: GraphStructure,
+    test_loader: Any,
+    config: dict,
+    rng_key: jax.Array,
+) -> Dict[str, float]:
+    """
+    Evaluate autoregressive model on test data.
+
+    Computes:
+    - Average loss (energy)
+    - Perplexity (if cross-entropy loss)
+    - Accuracy (next-token prediction)
+
+    Args:
+        params: Trained parameters
+        structure: Graph structure
+        test_loader: Test data loader
+        config: Evaluation config (infer_steps, eta_infer)
+        rng_key: Random key
+
+    Returns:
+        Dictionary of metrics
+    """
+    infer_steps = config.get("infer_steps", 20)
+    eta_infer = config.get("eta_infer", 0.1)
+
+    output_node = structure.task_map.get("y")
+    if output_node is None:
+        raise ValueError("Structure must have 'y' in task_map")
+
+    total_loss = 0.0
+    total_correct = 0
+    total_tokens = 0
+    num_batches = 0
+
+    try:
+        num_batches_total = len(test_loader)
+    except TypeError:
+        num_batches_total = 1000
+
+    batch_keys = jax.random.split(rng_key, num_batches_total)
+
+    for batch_idx, batch_data in enumerate(test_loader):
+        # Convert batch
+        if isinstance(batch_data, dict):
+            batch = {k: jnp.array(v) for k, v in batch_data.items()}
+        elif isinstance(batch_data, (list, tuple)):
+            batch = {"x": jnp.array(batch_data[0]), "y": jnp.array(batch_data[1])}
+        else:
+            raise ValueError(f"Unsupported batch format: {type(batch_data)}")
+
+        batch_size = batch["x"].shape[0]
+
+        # Create clamps (input only for evaluation)
+        clamps = {}
+        if "x" in structure.task_map:
+            clamps[structure.task_map["x"]] = batch["x"]
+
+        # Initialize and run inference
+        state = initialize_state(
+            structure, batch_size, batch_keys[batch_idx],
+            clamps=clamps, params=params
+        )
+        final_state = run_inference(
+            params, state, clamps, structure, infer_steps, eta_infer
+        )
+
+        # Get predictions
+        predictions = final_state.nodes[output_node].z_latent
+        targets = batch["y"]
+
+        # Compute loss
+        if targets.ndim == 2:
+            vocab_size = predictions.shape[-1]
+            targets_onehot = jax.nn.one_hot(targets, vocab_size)
+        else:
+            targets_onehot = targets
+
+        # Cross-entropy loss
+        log_preds = jnp.log(predictions + 1e-10)
+        batch_loss = -jnp.sum(targets_onehot * log_preds)
+        total_loss += float(batch_loss)
+
+        # Accuracy
+        pred_tokens = jnp.argmax(predictions, axis=-1)
+        if targets.ndim == 3:
+            target_tokens = jnp.argmax(targets, axis=-1)
+        else:
+            target_tokens = targets
+
+        correct = jnp.sum(pred_tokens == target_tokens)
+        total_correct += int(correct)
+        total_tokens += int(batch_size * predictions.shape[1])
+        num_batches += 1
+
+    avg_loss = total_loss / total_tokens if total_tokens > 0 else 0.0
+    perplexity = float(jnp.exp(avg_loss))
+    accuracy = total_correct / total_tokens if total_tokens > 0 else 0.0
+
+    return {
+        "loss": avg_loss,
+        "perplexity": perplexity,
+        "accuracy": accuracy,
+        "num_tokens": total_tokens,
+    }

--- a/fabricpc/training/train_backprop.py
+++ b/fabricpc/training/train_backprop.py
@@ -1,0 +1,558 @@
+"""
+Backpropagation training for FabricPC networks.
+
+This module provides standard end-to-end backpropagation training as an
+alternative to iterative predictive coding inference. Key differences:
+
+1. No iterative latent inference - single forward pass
+2. Latent states set to projections: z_latent = z_mu
+3. End-to-end autodiff via jax.grad
+4. Only input nodes are clamped (output computes freely)
+
+Use cases:
+- Baseline comparison with predictive coding
+- Faster training when PC dynamics not needed
+- Standard deep learning workflows
+"""
+
+from typing import Dict, Tuple, Any, List, Optional, Callable, cast
+import jax
+import jax.numpy as jnp
+import optax
+
+from fabricpc.core.types import GraphParams, GraphStructure
+from fabricpc.graph.graph_net import initialize_state
+from fabricpc.training.train_autoregressive import create_causal_mask
+
+
+def compute_loss(
+    params: GraphParams,
+    structure: GraphStructure,
+    batch: Dict[str, jnp.ndarray],
+    rng_key: jax.Array,
+    loss_type: str = "cross_entropy",
+) -> jnp.ndarray:
+    """
+    Compute differentiable loss for backpropagation training.
+
+    This runs a single forward pass through the network (no iterative
+    inference) and computes loss at the output node.
+
+    Args:
+        params: Model parameters
+        structure: Graph structure
+        batch: Batch data with keys matching task_map (e.g., 'x', 'y')
+        rng_key: JAX random key for state initialization
+        loss_type: Loss function type: "cross_entropy" or "mse"
+
+    Returns:
+        Scalar loss value (mean over batch)
+    """
+    batch_size = batch["x"].shape[0]
+
+    # Clamp ONLY input node (not output!) - key difference from PC
+    clamps = {}
+    if "x" in structure.task_map:
+        clamps[structure.task_map["x"]] = batch["x"]
+
+    # Single forward pass via initialize_state with feedforward init
+    state = initialize_state(
+        structure, batch_size, rng_key,
+        clamps=clamps,
+        params=params
+    )
+
+    # Get prediction from output node
+    output_node = structure.task_map["y"]
+    predictions = state.nodes[output_node].z_mu
+    targets = batch["y"]
+
+    # Compute loss
+    if loss_type == "cross_entropy":
+        log_preds = jnp.log(predictions + 1e-10)
+        loss = -jnp.sum(targets * log_preds) / batch_size
+    elif loss_type == "mse":
+        loss = jnp.mean((predictions - targets) ** 2)
+    else:
+        raise ValueError(f"Unknown loss_type: {loss_type}")
+
+    return loss
+
+
+def train_step_backprop(
+    params: GraphParams,
+    opt_state: optax.OptState,
+    batch: Dict[str, jnp.ndarray],
+    structure: GraphStructure,
+    optimizer: optax.GradientTransformation,
+    rng_key: jax.Array,
+    loss_type: str = "cross_entropy",
+) -> Tuple[GraphParams, optax.OptState, float]:
+    """
+    Single backprop training step.
+
+    Args:
+        params: Current model parameters
+        opt_state: Optimizer state
+        batch: Batch data
+        structure: Graph structure
+        optimizer: Optax optimizer
+        rng_key: JAX random key
+        loss_type: Loss function type
+
+    Returns:
+        Tuple of (updated_params, updated_opt_state, loss_value)
+    """
+    def loss_fn(p):
+        return compute_loss(p, structure, batch, rng_key, loss_type)
+
+    loss, grads = jax.value_and_grad(loss_fn)(params)
+    updates, opt_state = optimizer.update(grads, opt_state, params)
+    params = cast(GraphParams, optax.apply_updates(params, updates))
+
+    return params, opt_state, loss
+
+
+def train_backprop(
+    params: GraphParams,
+    structure: GraphStructure,
+    train_loader: Any,
+    config: dict,
+    rng_key: jax.Array,
+    verbose: bool = True,
+    epoch_callback: Optional[Callable] = None,
+    iter_callback: Optional[Callable] = None,
+) -> Tuple[GraphParams, List[List[float]], List[Any]]:
+    """
+    Main backprop training loop.
+
+    This provides standard end-to-end backpropagation training for FabricPC
+    models, using the same graph structure but skipping iterative inference.
+
+    Args:
+        params: Initial parameters
+        structure: Graph structure
+        train_loader: Data loader yielding batches
+        config: Training configuration:
+            - optimizer: Optimizer config dict (type, lr, weight_decay)
+            - num_epochs: Number of training epochs
+            - loss_type: "cross_entropy" or "mse" (default: "cross_entropy")
+        rng_key: JAX random key
+        verbose: Print progress
+        epoch_callback: Optional (epoch, params, structure, config, rng) -> any
+        iter_callback: Optional (epoch, batch_idx, loss) -> any
+
+    Returns:
+        Tuple of (trained_params, loss_history, epoch_results)
+
+    Example:
+        >>> params, structure = create_pc_graph(config, rng_key)
+        >>> train_config = {
+        ...     "num_epochs": 10,
+        ...     "optimizer": {"type": "adam", "lr": 1e-3},
+        ...     "loss_type": "cross_entropy",
+        ... }
+        >>> trained_params, losses, _ = train_backprop(
+        ...     params, structure, train_loader, train_config, rng_key
+        ... )
+    """
+    from fabricpc.training.optimizers import create_optimizer
+
+    # Create optimizer
+    optimizer = create_optimizer(config.get("optimizer", {"type": "adam", "lr": 1e-3}))
+    opt_state = optimizer.init(params)
+
+    # Training hyperparameters
+    num_epochs = config.get("num_epochs", 10)
+    loss_type = config.get("loss_type", "cross_entropy")
+
+    # JIT compile training step
+    jit_train_step = jax.jit(
+        lambda p, o, b, k: train_step_backprop(
+            p, o, b, structure, optimizer, k, loss_type
+        )
+    )
+
+    iter_results = []
+    epoch_results = []
+
+    for epoch_idx in range(num_epochs):
+        try:
+            num_batches = len(train_loader)
+        except TypeError:
+            raise TypeError("train_loader must support len()")
+
+        # Split keys for batches
+        epoch_rng_key, rng_key = jax.random.split(rng_key)
+        batch_keys = jax.random.split(epoch_rng_key, num_batches)
+
+        batch_losses = []
+        epoch_loss = 0.0
+
+        for batch_idx, batch_data in enumerate(train_loader):
+            # Convert batch to JAX format
+            if isinstance(batch_data, dict):
+                batch = {k: jnp.array(v) for k, v in batch_data.items()}
+            elif isinstance(batch_data, (list, tuple)):
+                batch = {
+                    "x": jnp.array(batch_data[0]),
+                    "y": jnp.array(batch_data[1]),
+                }
+            else:
+                raise ValueError(f"Unsupported batch format: {type(batch_data)}")
+
+            # Training step
+            params, opt_state, loss = jit_train_step(
+                params, opt_state, batch, batch_keys[batch_idx]
+            )
+
+            epoch_loss += float(loss)
+
+            if iter_callback is not None:
+                batch_losses.append(iter_callback(epoch_idx, batch_idx, loss))
+            else:
+                batch_losses.append(float(loss))
+
+        iter_results.append(batch_losses)
+        avg_loss = epoch_loss / num_batches
+
+        # Epoch callback
+        if epoch_callback is not None:
+            epoch_results.append(
+                epoch_callback(epoch_idx, params, structure, config, rng_key)
+            )
+        else:
+            epoch_results.append(None)
+
+        if verbose:
+            print(f"Epoch {epoch_idx + 1}/{num_epochs}, Loss: {avg_loss:.4f}")
+
+    return params, iter_results, epoch_results
+
+
+def compute_loss_autoregressive(
+    params: GraphParams,
+    structure: GraphStructure,
+    batch: Dict[str, jnp.ndarray],
+    rng_key: jax.Array,
+    use_causal_mask: bool = True,
+) -> jnp.ndarray:
+    """
+    Compute loss for autoregressive (next-token) prediction with backprop.
+
+    This runs a single forward pass with causal masking and computes
+    cross-entropy loss over all sequence positions.
+
+    Args:
+        params: Model parameters
+        structure: Graph structure
+        batch: Batch with "x" (input) and "y" (target) sequences
+        rng_key: JAX random key
+        use_causal_mask: Whether to apply causal masking
+
+    Returns:
+        Scalar loss (mean over batch)
+    """
+    batch_size = batch["x"].shape[0]
+    seq_len = batch["x"].shape[1]
+
+    # Clamp input only (not output)
+    clamps = {structure.task_map["x"]: batch["x"]}
+
+    # Add causal mask if enabled
+    if use_causal_mask and "causal_mask" in structure.task_map:
+        causal_mask = create_causal_mask(seq_len)
+        causal_mask = causal_mask[None, None, :, :]  # (1, 1, seq, seq)
+        causal_mask = jnp.broadcast_to(causal_mask, (batch_size, 1, seq_len, seq_len))
+        clamps[structure.task_map["causal_mask"]] = causal_mask
+
+    # Single forward pass
+    state = initialize_state(
+        structure, batch_size, rng_key,
+        clamps=clamps,
+        params=params
+    )
+
+    # Cross-entropy over all positions
+    output_node = structure.task_map["y"]
+    predictions = state.nodes[output_node].z_mu
+    targets = batch["y"]
+
+    # Handle different target formats
+    if targets.ndim == 2:
+        # Convert indices to one-hot
+        vocab_size = predictions.shape[-1]
+        targets = jax.nn.one_hot(targets, vocab_size)
+
+    log_preds = jnp.log(predictions + 1e-10)
+    loss = -jnp.sum(targets * log_preds) / batch_size
+
+    return loss
+
+
+def train_step_backprop_autoregressive(
+    params: GraphParams,
+    opt_state: optax.OptState,
+    batch: Dict[str, jnp.ndarray],
+    structure: GraphStructure,
+    optimizer: optax.GradientTransformation,
+    rng_key: jax.Array,
+    use_causal_mask: bool = True,
+) -> Tuple[GraphParams, optax.OptState, float]:
+    """
+    Single autoregressive backprop training step.
+
+    Args:
+        params: Current model parameters
+        opt_state: Optimizer state
+        batch: Batch data with 'x' and 'y' sequences
+        structure: Graph structure
+        optimizer: Optax optimizer
+        rng_key: JAX random key
+        use_causal_mask: Whether to apply causal masking
+
+    Returns:
+        Tuple of (updated_params, updated_opt_state, loss_value)
+    """
+    def loss_fn(p):
+        return compute_loss_autoregressive(p, structure, batch, rng_key, use_causal_mask)
+
+    loss, grads = jax.value_and_grad(loss_fn)(params)
+    updates, opt_state = optimizer.update(grads, opt_state, params)
+    params = cast(GraphParams, optax.apply_updates(params, updates))
+
+    return params, opt_state, loss
+
+
+def train_backprop_autoregressive(
+    params: GraphParams,
+    structure: GraphStructure,
+    train_loader: Any,
+    config: dict,
+    rng_key: jax.Array,
+    verbose: bool = True,
+    epoch_callback: Optional[Callable] = None,
+    iter_callback: Optional[Callable] = None,
+) -> Tuple[GraphParams, List[List[float]], List[Any]]:
+    """
+    Main autoregressive backprop training loop.
+
+    This provides standard end-to-end backpropagation training for
+    autoregressive models (e.g., transformers for language modeling).
+
+    Args:
+        params: Initial parameters
+        structure: Graph structure
+        train_loader: Data loader yielding batches with 'x' and 'y' keys
+        config: Training configuration:
+            - optimizer: Optimizer config dict
+            - num_epochs: Number of training epochs
+            - use_causal_mask: Whether to use causal masking (default True)
+        rng_key: JAX random key
+        verbose: Print progress
+        epoch_callback: Optional callback per epoch
+        iter_callback: Optional callback per batch
+
+    Returns:
+        Tuple of (trained_params, loss_history, epoch_results)
+    """
+    from fabricpc.training.optimizers import create_optimizer
+
+    # Create optimizer
+    optimizer = create_optimizer(config.get("optimizer", {"type": "adam", "lr": 1e-3}))
+    opt_state = optimizer.init(params)
+
+    # Training hyperparameters
+    num_epochs = config.get("num_epochs", 10)
+    use_causal_mask = config.get("use_causal_mask", True)
+
+    # JIT compile training step
+    jit_train_step = jax.jit(
+        lambda p, o, b, k: train_step_backprop_autoregressive(
+            p, o, b, structure, optimizer, k, use_causal_mask
+        )
+    )
+
+    iter_results = []
+    epoch_results = []
+
+    for epoch_idx in range(num_epochs):
+        try:
+            num_batches = len(train_loader)
+        except TypeError:
+            raise TypeError("train_loader must support len()")
+
+        # Split keys for batches
+        epoch_rng_key, rng_key = jax.random.split(rng_key)
+        batch_keys = jax.random.split(epoch_rng_key, num_batches)
+
+        batch_losses = []
+        epoch_loss = 0.0
+
+        for batch_idx, batch_data in enumerate(train_loader):
+            # Convert batch to JAX format
+            if isinstance(batch_data, dict):
+                batch = {k: jnp.array(v) for k, v in batch_data.items()}
+            elif isinstance(batch_data, (list, tuple)):
+                batch = {
+                    "x": jnp.array(batch_data[0]),
+                    "y": jnp.array(batch_data[1]),
+                }
+            else:
+                raise ValueError(f"Unsupported batch format: {type(batch_data)}")
+
+            # Training step
+            params, opt_state, loss = jit_train_step(
+                params, opt_state, batch, batch_keys[batch_idx]
+            )
+
+            epoch_loss += float(loss)
+
+            if iter_callback is not None:
+                batch_losses.append(iter_callback(epoch_idx, batch_idx, loss))
+            else:
+                batch_losses.append(float(loss))
+
+        iter_results.append(batch_losses)
+        avg_loss = epoch_loss / num_batches
+
+        # Epoch callback
+        if epoch_callback is not None:
+            epoch_results.append(
+                epoch_callback(epoch_idx, params, structure, config, rng_key)
+            )
+        else:
+            epoch_results.append(None)
+
+        if verbose:
+            print(f"Epoch {epoch_idx + 1}/{num_epochs}, Loss: {avg_loss:.4f}")
+
+    return params, iter_results, epoch_results
+
+
+def eval_step_backprop(
+    params: GraphParams,
+    batch: Dict[str, jnp.ndarray],
+    structure: GraphStructure,
+    rng_key: jax.Array,
+    loss_type: str = "cross_entropy",
+) -> Tuple[float, int, int]:
+    """
+    Single evaluation step for backprop-trained model.
+
+    Args:
+        params: Model parameters
+        batch: Batch data
+        structure: Graph structure
+        rng_key: Random key for initialization
+        loss_type: Loss function type
+
+    Returns:
+        Tuple of (loss, correct_predictions, batch_size)
+    """
+    batch_size = batch["x"].shape[0]
+
+    # Forward pass (input only clamped)
+    clamps = {structure.task_map["x"]: batch["x"]}
+    state = initialize_state(
+        structure, batch_size, rng_key,
+        clamps=clamps,
+        params=params
+    )
+
+    # Get predictions
+    output_node = structure.task_map["y"]
+    predictions = state.nodes[output_node].z_mu
+    targets = batch["y"]
+
+    # Compute loss
+    if loss_type == "cross_entropy":
+        log_preds = jnp.log(predictions + 1e-10)
+        loss = -jnp.sum(targets * log_preds) / batch_size
+    elif loss_type == "mse":
+        loss = jnp.mean((predictions - targets) ** 2)
+    else:
+        raise ValueError(f"Unknown loss_type: {loss_type}")
+
+    # Compute accuracy (for classification)
+    pred_labels = jnp.argmax(predictions, axis=-1)
+    if targets.ndim > 1 and targets.shape[-1] > 1:
+        true_labels = jnp.argmax(targets, axis=-1)
+    else:
+        true_labels = targets
+
+    # Handle sequence vs non-sequence
+    correct = jnp.sum(pred_labels == true_labels)
+
+    return float(loss), int(correct), int(jnp.prod(jnp.array(pred_labels.shape)))
+
+
+def evaluate_backprop(
+    params: GraphParams,
+    structure: GraphStructure,
+    test_loader: Any,
+    config: dict,
+    rng_key: jax.Array = None,
+) -> Dict[str, float]:
+    """
+    Evaluate backprop-trained model on test data.
+
+    Args:
+        params: Trained parameters
+        structure: Graph structure
+        test_loader: Test data loader
+        config: Evaluation config with loss_type
+        rng_key: Random key (optional, uses fixed key if None)
+
+    Returns:
+        Dictionary with "loss", "accuracy", and optionally "perplexity"
+    """
+    if rng_key is None:
+        rng_key = jax.random.PRNGKey(0)
+
+    loss_type = config.get("loss_type", "cross_entropy")
+
+    # JIT compile eval step
+    jit_eval_step = jax.jit(
+        lambda p, b, k: eval_step_backprop(p, b, structure, k, loss_type)
+    )
+
+    try:
+        num_batches = len(test_loader)
+    except TypeError:
+        num_batches = 1000
+
+    batch_keys = jax.random.split(rng_key, num_batches)
+
+    total_loss = 0.0
+    total_correct = 0
+    total_samples = 0
+
+    for batch_idx, batch_data in enumerate(test_loader):
+        # Convert batch
+        if isinstance(batch_data, dict):
+            batch = {k: jnp.array(v) for k, v in batch_data.items()}
+        elif isinstance(batch_data, (list, tuple)):
+            batch = {"x": jnp.array(batch_data[0]), "y": jnp.array(batch_data[1])}
+        else:
+            raise ValueError(f"Unsupported batch format: {type(batch_data)}")
+
+        loss, correct, count = jit_eval_step(params, batch, batch_keys[batch_idx])
+
+        total_loss += loss * count
+        total_correct += correct
+        total_samples += count
+
+    avg_loss = total_loss / total_samples if total_samples > 0 else 0.0
+    accuracy = total_correct / total_samples if total_samples > 0 else 0.0
+
+    result = {
+        "loss": avg_loss,
+        "accuracy": accuracy,
+    }
+
+    # Add perplexity for cross-entropy loss
+    if loss_type == "cross_entropy":
+        result["perplexity"] = float(jnp.exp(avg_loss))
+
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fabricpc"
-version = "0.2.2"
+version = "0.2.3"
 description = "A flexible, performant predictive coding library using JAX"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_auto_node_grad.py
+++ b/tests/test_auto_node_grad.py
@@ -13,12 +13,34 @@ import pytest
 import jax
 import jax.numpy as jnp
 
-from fabricpc.core.types import NodeState, NodeParams, NodeInfo, EdgeInfo, GraphStructure
+from fabricpc.core.types import NodeState, NodeParams, NodeInfo
 from fabricpc.graph.graph_net import create_pc_graph, initialize_state
 from fabricpc.core.inference import run_inference, gather_inputs
-from fabricpc.nodes import get_node_class, LinearNode, LinearExplicitGrad
+from fabricpc.nodes import get_node_class, LinearNode, LinearExplicitGrad, validate_node_config
 
 jax.config.update("jax_platform_name", "cpu")  # using cuda causes larger numerical differences because of TF32 precision
+
+
+def make_node_config(node_type: str, activation: str) -> dict:
+    """
+    Create a properly validated node config with all defaults from the schema.
+
+    Uses validate_node_config to ensure all defaults (e.g., flatten_input, use_bias)
+    are populated from the node class's CONFIG_SCHEMA. Also resolves energy and
+    activation configs using the node class's default resolvers.
+    """
+    node_class = get_node_class(node_type)
+    raw_config = {
+        "name": "test_node",
+        "shape": (1,),  # placeholder, will be overridden
+        "type": node_type,
+        "activation": {"type": activation},
+    }
+    validated_config = validate_node_config(node_class, raw_config)
+    # Resolve energy and activation configs (normally done by from_config)
+    validated_config["energy"] = node_class._resolve_energy_config(raw_config)
+    validated_config["activation"] = node_class._resolve_activation_config(raw_config)
+    return validated_config
 
 
 @pytest.fixture
@@ -81,11 +103,26 @@ class TestLinearAutoGradNode:
         )
         inputs = {edge_key: jax.random.normal(rngkey_inputs, (batch_size, input_dim))}
 
+        # Create validated node_config with all defaults from schema
+        validated_config = make_node_config("linear", activation)
         node_info = NodeInfo(
             name="dst",
             shape=(output_dim,),
             node_type="linear",
-            node_config={"activation": {"type": activation}, "energy": {"type": "gaussian"}},
+            node_config=validated_config,
+            slots={},
+            in_degree=1,
+            out_degree=0,
+            in_edges=(edge_key,),
+            out_edges=(),
+        )
+        # Override node_type for autograd version
+        validated_config_explicit = make_node_config("linear_explicit_grad", activation)
+        node_info_explicit = NodeInfo(
+            name="dst",
+            shape=(output_dim,),
+            node_type="linear_explicit_grad",
+            node_config=validated_config_explicit,
             slots={},
             in_degree=1,
             out_degree=0,
@@ -102,13 +139,12 @@ class TestLinearAutoGradNode:
             error=jnp.zeros((batch_size, output_dim)),
             energy=jnp.zeros((batch_size,)),
             pre_activation=jnp.zeros((batch_size, output_dim)),
-            gain_mod_error=jnp.zeros((batch_size, output_dim)),
             substructure={},
         )
 
         # Compare forward_inference results
         state_linear, grads_linear = LinearNode.forward_inference(params, inputs, node_state, node_info)
-        state_autograd, grads_autograd = LinearExplicitGrad.forward_inference(params, inputs, node_state, node_info)
+        state_autograd, grads_autograd = LinearExplicitGrad.forward_inference(params, inputs, node_state, node_info_explicit)
 
         # Compare input gradients
         for edge_key in grads_linear:
@@ -138,11 +174,26 @@ class TestLinearAutoGradNode:
         )
         inputs = {edge_key: jax.random.normal(rngkey_inputs, (batch_size, input_dim))}
 
+        # Create validated node_config with all defaults from schema
+        validated_config = make_node_config("linear", activation)
         node_info = NodeInfo(
             name="dst",
             shape=(output_dim,),
             node_type="linear",
-            node_config={"activation": {"type": activation}, "energy": {"type": "gaussian"}},
+            node_config=validated_config,
+            slots={},
+            in_degree=1,
+            out_degree=0,
+            in_edges=(edge_key,),
+            out_edges=(),
+        )
+        # Override node_type for autograd version
+        validated_config_explicit = make_node_config("linear_explicit_grad", activation)
+        node_info_explicit = NodeInfo(
+            name="dst",
+            shape=(output_dim,),
+            node_type="linear_explicit_grad",
+            node_config=validated_config_explicit,
             slots={},
             in_degree=1,
             out_degree=0,
@@ -159,13 +210,12 @@ class TestLinearAutoGradNode:
             error=jnp.zeros((batch_size, output_dim)),
             energy=jnp.zeros((batch_size,)),
             pre_activation=jnp.zeros((batch_size, output_dim)),
-            gain_mod_error=jnp.zeros((batch_size, output_dim)),
             substructure={},
         )
 
         # Compare forward_learning results
         state_linear, grads_linear = LinearNode.forward_learning(params, inputs, node_state, node_info)
-        state_autograd, grads_autograd = LinearExplicitGrad.forward_learning(params, inputs, node_state, node_info)
+        state_autograd, grads_autograd = LinearExplicitGrad.forward_learning(params, inputs, node_state, node_info_explicit)
 
         # Compare weight gradients
         for edge_key in grads_linear.weights:
@@ -220,6 +270,9 @@ class TestLinearAutoGradNode:
         # Compare gradients for each non-input node using forward_inference
         for node_name in ["hidden", "output"]:
             node_info = structure_linear.nodes[node_name]
+            # Override node_type for autograd version
+            info_fields = node_info.__dict__.copy()
+            node_info_explicit = NodeInfo(**{**info_fields, "node_type": "linear_explicit_grad"})
 
             # Gather inputs for gradient computation
             inputs = gather_inputs(node_info, structure_linear, state_linear)
@@ -235,7 +288,7 @@ class TestLinearAutoGradNode:
                 params_autograd.nodes[node_name],
                 inputs,
                 state_autograd.nodes[node_name],
-                node_info
+                node_info_explicit
             )
 
             # Compare
@@ -243,7 +296,6 @@ class TestLinearAutoGradNode:
                 max_diff = jnp.max(jnp.abs(grads_linear[edge_key] - grads_autograd[edge_key]))
                 assert max_diff < grad_tolerance, \
                     f"Input gradient mismatch at {node_name} for {edge_key}: max diff = {max_diff}"
-
 
 class TestLinearAutoGradNodeRegistration:
     """Test that LinearExplicitGrad is properly registered."""

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -30,6 +30,7 @@ from fabricpc.core.energy import (
     CrossEntropyEnergy,
     LaplacianEnergy,
     HuberEnergy,
+    KLDivergenceEnergy,
     _ENERGY_REGISTRY,
 )
 from fabricpc.graph.graph_net import create_pc_graph
@@ -290,6 +291,87 @@ class TestHuberEnergy:
         # In linear region: E = delta * (|diff| - 0.5 * delta) = 1.0 * (2.0 - 0.5) = 1.5
         assert jnp.allclose(energy[0], 1.5)
 
+
+class TestKLDivergenceEnergy:
+    """Test KL Divergence energy functional."""
+
+    def test_kl_divergence_registered(self):
+        """Test that KL divergence is registered."""
+        types = list_energy_types()
+        assert "kl_divergence" in types
+        assert get_energy_class("kl_divergence") is KLDivergenceEnergy
+
+    def test_kl_divergence_identical_distributions(self):
+        """Test KL divergence is zero for identical distributions."""
+        # When z == mu, KL divergence should be 0
+        z_latent = jnp.array([[0.2, 0.3, 0.4, 0.1]])
+        z_mu = jnp.array([[0.2, 0.3, 0.4, 0.1]])
+
+        energy = KLDivergenceEnergy.energy(z_latent, z_mu)
+
+        assert energy.shape == (1,)
+        assert jnp.allclose(energy[0], 0.0, atol=1e-6)
+
+    def test_kl_divergence_batch_computation(self):
+        """Test KL divergence computes correct numerical values."""
+        z_latent = jnp.array([
+            [0.7, 0.2, 0.1],
+            [0.3, 0.3, 0.4],
+        ])
+        z_mu = jnp.array([
+            [0.6, 0.3, 0.1],
+            [0.5, 0.25, 0.25],
+        ])
+
+        energy = KLDivergenceEnergy.energy(z_latent, z_mu)
+
+        assert energy.shape == (2,)
+
+        # Manually compute expected values
+        expected_0 = (
+            0.7 * jnp.log(0.7 / 0.6) +
+            0.2 * jnp.log(0.2 / 0.3) +
+            0.1 * jnp.log(0.1 / 0.1)
+        )
+        expected_1 = (
+            0.3 * jnp.log(0.3 / 0.5) +
+            0.3 * jnp.log(0.3 / 0.25) +
+            0.4 * jnp.log(0.4 / 0.25)
+        )
+
+        assert jnp.allclose(energy[0], expected_0, atol=1e-5)
+        assert jnp.allclose(energy[1], expected_1, atol=1e-5)
+
+    def test_kl_divergence_always_non_negative(self):
+        """Test that KL divergence is always >= 0 (Gibbs' inequality)."""
+        # Random probability distributions
+        key = jax.random.PRNGKey(42)
+        key1, key2 = jax.random.split(key)
+
+        # Generate random positive values and normalize
+        raw_z = jax.random.uniform(key1, (10, 5)) + 0.01
+        raw_mu = jax.random.uniform(key2, (10, 5)) + 0.01
+        z_latent = raw_z / raw_z.sum(axis=-1, keepdims=True)
+        z_mu = raw_mu / raw_mu.sum(axis=-1, keepdims=True)
+
+        energy = KLDivergenceEnergy.energy(z_latent, z_mu)
+
+        # KL divergence should always be non-negative
+        assert jnp.all(energy >= -1e-6)  # Small tolerance for numerical precision
+
+    def test_kl_divergence_zero_probability_handling(self):
+        """Test that zero probabilities are handled correctly."""
+        # When z has zeros, those terms should contribute 0 (0 * log(0) = 0)
+        z_latent = jnp.array([[1.0, 0.0, 0.0]])
+        z_mu = jnp.array([[0.8, 0.1, 0.1]])
+
+        energy = KLDivergenceEnergy.energy(z_latent, z_mu)
+
+        # Only the first term contributes: 1.0 * log(1.0 / 0.8)
+        expected = 1.0 * jnp.log(1.0 / 0.8)
+
+        assert jnp.isfinite(energy[0])  # Should not be inf or nan
+        assert jnp.allclose(energy[0], expected, atol=1e-5)
 
 class TestConfigValidation:
     """Test energy config validation."""

--- a/tests/test_fabricpc.py
+++ b/tests/test_fabricpc.py
@@ -319,7 +319,6 @@ class TestForwardMethods:
                 error=jnp.zeros(full_shape),
                 energy=jnp.zeros((batch_size,)),
                 pre_activation=jnp.zeros(full_shape),
-                gain_mod_error=jnp.zeros(full_shape),
                 substructure={}
             )
 

--- a/tests/test_fabricpc_extended.py
+++ b/tests/test_fabricpc_extended.py
@@ -144,8 +144,6 @@ class TestShapeConsistency:
                 f"z_mu shape mismatch for {node_name}"
             assert node_state.pre_activation.shape == expected_shape, \
                 f"pre_activation shape mismatch for {node_name}"
-            assert node_state.gain_mod_error.shape == expected_shape, \
-                f"gain_mod_error shape mismatch for {node_name}"
 
     def test_projection_shapes_match(self, simple_chain_config):
         """Test that projections maintain correct shapes."""
@@ -218,7 +216,6 @@ class TestPropertyBased:
             assert node_state.error.shape == expected_shape
             assert node_state.z_mu.shape == expected_shape
             assert node_state.pre_activation.shape == expected_shape
-            assert node_state.gain_mod_error.shape == expected_shape
 
     @given(
         infer_steps=st.integers(min_value=1, max_value=20),

--- a/tests/test_ndim_shapes.py
+++ b/tests/test_ndim_shapes.py
@@ -83,7 +83,7 @@ class TestNDimShapes:
         config = {
             "node_list": [
                 {"name": "image", "shape": (28, 28), "type": "linear"},
-                {"name": "hidden", "shape": (128,), "type": "linear", "activation": {"type": "relu"}},
+                {"name": "hidden", "shape": (128,), "type": "linear", "flatten_input": True, "activation": {"type": "relu"}},
                 {"name": "output", "shape": (10,), "type": "linear"},
             ],
             "edge_list": [
@@ -127,7 +127,7 @@ class TestNDimShapes:
         config = {
             "node_list": [
                 {"name": "image", "shape": (28, 28, 1), "type": "linear"},
-                {"name": "hidden", "shape": (64,), "type": "linear", "activation": {"type": "tanh"}},
+                {"name": "hidden", "shape": (64,), "type": "linear", "flatten_input": True, "activation": {"type": "tanh"}},
                 {"name": "output", "shape": (10,), "type": "linear"},
             ],
             "edge_list": [
@@ -164,7 +164,7 @@ class TestNDimShapes:
         config = {
             "node_list": [
                 {"name": "rgb_image", "shape": (32, 32, 3), "type": "linear"},
-                {"name": "hidden", "shape": (256,), "type": "linear", "activation": {"type": "relu"}},
+                {"name": "hidden", "shape": (256,), "type": "linear", "flatten_input": True, "activation": {"type": "relu"}},
                 {"name": "output", "shape": (100,), "type": "linear"},
             ],
             "edge_list": [
@@ -199,7 +199,7 @@ class TestNDimShapes:
         config = {
             "node_list": [
                 {"name": "image", "shape": (28, 28), "type": "linear"},
-                {"name": "hidden1", "shape": (256,), "type": "linear", "activation": {"type": "relu"}},
+                {"name": "hidden1", "shape": (256,), "type": "linear", "flatten_input": True, "activation": {"type": "relu"}},
                 {"name": "hidden2", "shape": (128,), "type": "linear", "activation": {"type": "relu"}},
                 {"name": "output", "shape": (10,), "type": "linear"},
             ],
@@ -293,7 +293,7 @@ class TestSameParamsDifferentBatchSizes:
         config = {
             "node_list": [
                 {"name": "image", "shape": (28, 28), "type": "linear"},
-                {"name": "hidden", "shape": (64,), "type": "linear", "activation": {"type": "tanh"}},
+                {"name": "hidden", "shape": (64,), "type": "linear", "flatten_input": True, "activation": {"type": "tanh"}},
                 {"name": "output", "shape": (10,), "type": "linear"},
             ],
             "edge_list": [
@@ -330,7 +330,7 @@ class TestNDimTraining:
         config = {
             "node_list": [
                 {"name": "image", "shape": (28, 28), "type": "linear"},
-                {"name": "hidden", "shape": (64,), "type": "linear", "activation": {"type": "sigmoid"}},
+                {"name": "hidden", "shape": (64,), "type": "linear", "flatten_input": True, "activation": {"type": "sigmoid"}},
                 {"name": "output", "shape": (10,), "type": "linear"},
             ],
             "edge_list": [
@@ -373,7 +373,7 @@ class TestNDimTraining:
         config = {
             "node_list": [
                 {"name": "image", "shape": (16, 16, 3), "type": "linear"},
-                {"name": "hidden", "shape": (32,), "type": "linear", "activation": {"type": "relu"}},
+                {"name": "hidden", "shape": (32,), "type": "linear", "flatten_input": True, "activation": {"type": "relu"}},
                 {"name": "output", "shape": (5,), "type": "linear"},
             ],
             "edge_list": [
@@ -410,7 +410,7 @@ class TestEnergyWithNDimShapes:
         config = {
             "node_list": [
                 {"name": "image", "shape": (14, 14), "type": "linear"},
-                {"name": "hidden", "shape": (32,), "type": "linear", "activation": {"type": "tanh"}},
+                {"name": "hidden", "shape": (32,), "type": "linear", "flatten_input": True, "activation": {"type": "tanh"}},
                 {"name": "output", "shape": (5,), "type": "linear"},
             ],
             "edge_list": [


### PR DESCRIPTION
Add KL Divergence energy functional and update linear node default behavior to not flatten inputs.

- Introduced KLDivergenceEnergy class for computing KL divergence.
- Updated linear node to default matmul on the last tensor dimension. Support `flatten_input` configuration for dense behavior.
- Added softmax and Gelu activations.
- Refactored gradient computations in LinearExplicitGrad node to accommodate new flattening logic.
- Removed gain-modulated error from state.
- Updated tests to validate new energy functional and linear node configurations.