### PR TITLE
Integration of the hidden Hopfield network to the storkey_hopfield_demo.py examples directory for the ilustrative comparison with MLP

### DIFF
--- a/examples/storkey_hopfield_demo.py
+++ b/examples/storkey_hopfield_demo.py
@@ -119,6 +119,18 @@ def parse_args():
         help="Hopfield strength: float >=0 or 'None' for learnable (default: 2.0)",
     )
     parser.add_argument(
+        "--all_hopfield",
+        action="store_true",
+        default=False,
+        help=(
+            "Fully-Hopfield MLP: run a Hopfield hidden layer at input width (784) "
+            "with no entry projection (only the Linear softmax head remains), "
+            "compared vs a vanilla MLP of the same shape. Default (off) reproduces "
+            "the original single-Hopfield-node architecture (784->128(Linear)->"
+            "128(StorkeyHopfield)->10)."
+        ),
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         default=False,
@@ -134,22 +146,61 @@ def parse_args():
 BATCH_SIZE = 64
 
 
-def make_hopfield_factory(hopfield_strength=None):
-    """Return a model factory closure with the given hopfield_strength."""
+def make_model_factory(hidden_type, width, depth, hopfield_strength):
+    """Return a model_factory(rng_key) for a classifier whose hidden stack is
+    either all StorkeyHopfield ('hopfield') or all Linear ('linear') nodes.
 
-    def create_hopfield_model(rng_key):
+    StorkeyHopfield is width-preserving (square W), so a Linear entry projection
+    (784 -> width) is inserted only when width != 784. The output is always a
+    Linear softmax + CrossEntropy head -- the classifier readout (an output node,
+    not a hidden node), so "all hidden nodes Hopfield" still holds when
+    hidden_type == 'hopfield'.
+
+    Reproduces the original demo arms when (width=128, depth=1):
+        'hopfield' -> pixels(784) -> entry(128,Linear) -> hidden0(128,SH) -> class(10)
+        'linear'   -> pixels(784) -> entry(128,Linear) -> hidden0(128,Linear) -> class(10)
+    Fully-Hopfield arm when (width=784, depth=1):
+        'hopfield' -> pixels(784) -> hidden0(784,SH) -> class(10)   (no entry projection)
+    """
+
+    def create_model(rng_key):
         pixels = IdentityNode(shape=(784,), name="pixels")
-        hidden = Linear(
-            shape=(128,),
-            activation=TanhActivation(),
-            name="hidden",
-            weight_init=XavierInitializer(),
-        )
-        hopfield = StorkeyHopfield(
-            shape=(128,),
-            name="hopfield",
-            hopfield_strength=hopfield_strength,
-        )
+        nodes = [pixels]
+        edges = []
+        prev = pixels
+
+        # Entry projection only needed to change width into the hidden stack.
+        if width != 784:
+            entry = Linear(
+                shape=(width,),
+                activation=TanhActivation(),
+                name="entry",
+                weight_init=XavierInitializer(),
+            )
+            nodes.append(entry)
+            edges.append(Edge(source=prev, target=entry.slot("in")))
+            prev = entry
+
+        # Hidden stack: all StorkeyHopfield or all Linear, at constant width.
+        for i in range(depth):
+            if hidden_type == "hopfield":
+                hidden = StorkeyHopfield(
+                    shape=(width,),
+                    name=f"hidden{i}",
+                    hopfield_strength=hopfield_strength,
+                )
+            else:
+                hidden = Linear(
+                    shape=(width,),
+                    activation=TanhActivation(),
+                    name=f"hidden{i}",
+                    weight_init=XavierInitializer(),
+                )
+            nodes.append(hidden)
+            edges.append(Edge(source=prev, target=hidden.slot("in")))
+            prev = hidden
+
+        # Linear softmax classifier head (output node, not a hidden node).
         output = Linear(
             shape=(10,),
             activation=SoftmaxActivation(),
@@ -157,58 +208,31 @@ def make_hopfield_factory(hopfield_strength=None):
             name="class",
             weight_init=XavierInitializer(),
         )
+        nodes.append(output)
+        edges.append(Edge(source=prev, target=output.slot("in")))
 
         structure = graph(
-            nodes=[pixels, hidden, hopfield, output],
-            edges=[
-                Edge(source=pixels, target=hidden.slot("in")),
-                Edge(source=hidden, target=hopfield.slot("in")),
-                Edge(source=hopfield, target=output.slot("in")),
-            ],
+            nodes=nodes,
+            edges=edges,
             task_map=TaskMap(x=pixels, y=output),
             inference=InferenceSGD(eta_infer=0.05, infer_steps=20),
         )
         params = initialize_params(structure, rng_key)
         return params, structure
 
-    return create_hopfield_model
+    return create_model
 
 
-def create_mlp_model(rng_key):
-    """Standard MLP baseline with identical capacity."""
-    pixels = IdentityNode(shape=(784,), name="pixels")
-    hidden1 = Linear(
-        shape=(128,),
-        activation=TanhActivation(),
-        name="hidden1",
-        weight_init=XavierInitializer(),
-    )
-    hidden2 = Linear(
-        shape=(128,),
-        activation=TanhActivation(),
-        name="hidden2",
-        weight_init=XavierInitializer(),
-    )
-    output = Linear(
-        shape=(10,),
-        activation=SoftmaxActivation(),
-        energy=CrossEntropyEnergy(),
-        name="class",
-        weight_init=XavierInitializer(),
-    )
-
-    structure = graph(
-        nodes=[pixels, hidden1, hidden2, output],
-        edges=[
-            Edge(source=pixels, target=hidden1.slot("in")),
-            Edge(source=hidden1, target=hidden2.slot("in")),
-            Edge(source=hidden2, target=output.slot("in")),
-        ],
-        task_map=TaskMap(x=pixels, y=output),
-        inference=InferenceSGD(eta_infer=0.05, infer_steps=20),
-    )
-    params = initialize_params(structure, rng_key)
-    return params, structure
+def arch_str(hidden_type, width, depth):
+    """Human-readable architecture string for the header print."""
+    parts = ["784"]
+    if width != 784:
+        parts.append(f"{width}(Linear, tanh)")
+    node = "StorkeyHopfield" if hidden_type == "hopfield" else "Linear"
+    for _ in range(depth):
+        parts.append(f"{width}({node}, tanh)")
+    parts.append("10(softmax, CE)")
+    return " -> ".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -292,12 +316,24 @@ def main():
         "learnable" if hopfield_strength is None else f"{hopfield_strength}"
     )
 
+    # Architecture: --all_hopfield runs the Hopfield layer at input width (784)
+    # with no entry projection (fully-Hopfield MLP); default keeps the original
+    # 128-width single-Hopfield-node architecture.
+    hidden_width = 784 if args.all_hopfield else 128
+    hidden_depth = 1
+
+    title = (
+        "Fully-Hopfield MLP vs vanilla MLP"
+        if args.all_hopfield
+        else "Few-Shot + Noise Robustness: StorkeyHopfield vs MLP"
+    )
+
     print("=" * 70)
-    print("Few-Shot + Noise Robustness: StorkeyHopfield vs MLP")
+    print(title)
     print("=" * 70)
     print("Dataset: Fashion-MNIST")
-    print("Hopfield: 784 -> 128(tanh) -> 128(StorkeyHopfield, tanh) -> 10(softmax, CE)")
-    print("MLP:      784 -> 128(tanh) -> 128(tanh) -> 10(softmax, CE)")
+    print(f"Hopfield: {arch_str('hopfield', hidden_width, hidden_depth)}")
+    print(f"MLP:      {arch_str('linear', hidden_width, hidden_depth)}")
     print(f"Hopfield strength: {strength_label}")
     print(f"Epochs per trial: {args.num_epochs}")
     print(f"Trials per condition: {args.n_trials}")
@@ -307,7 +343,9 @@ def main():
 
     arm_hop = ExperimentArm(
         name="Hopfield",
-        model_factory=make_hopfield_factory(hopfield_strength),
+        model_factory=make_model_factory(
+            "hopfield", hidden_width, hidden_depth, hopfield_strength
+        ),
         train_fn=train_pcn,
         eval_fn=evaluate_pcn,
         optimizer=optimizer,
@@ -316,7 +354,9 @@ def main():
 
     arm_mlp = ExperimentArm(
         name="MLP",
-        model_factory=create_mlp_model,
+        model_factory=make_model_factory(
+            "linear", hidden_width, hidden_depth, hopfield_strength
+        ),
         train_fn=train_pcn,
         eval_fn=evaluate_pcn,
         optimizer=optimizer,

--- a/examples/storkey_hopfield_demo.py
+++ b/examples/storkey_hopfield_demo.py
@@ -4,8 +4,9 @@ StorkeyHopfield vs MLP — Depth, Few-Shot, and Noise-Robustness Demo
 
 Demonstrates that StorkeyHopfield behaves as a composable graph element in
 FabricPC: substituting one or more Linear hidden layers with StorkeyHopfield
-should produce cumulative accuracy gains under data scarcity and input noise,
-where memorized class prototypes and attractor denoising help.
+should produce accuracy gains that accumulate with the *number* of
+substitutions, particularly when the input is noisy and the training set
+has enough samples for the attractors to form usable class prototypes.
 
 Architecture (same depth-4 graph across all arms, hidden width = 64)::
 
@@ -13,63 +14,108 @@ Architecture (same depth-4 graph across all arms, hidden width = 64)::
     "1hopfield"  pixels(784) -> 64(Linear) -> 64(StorkeyHopfield) -> 64(Linear)          -> 10(softmax+CE)
     "2hopfield"  pixels(784) -> 64(Linear) -> 64(StorkeyHopfield) -> 64(StorkeyHopfield) -> 10(softmax+CE)
 
-The first hidden layer is always Linear (the 784->64 feature-extraction
-projection — StorkeyHopfield is width-preserving and cannot reduce dimension).
-The classifier head is always Linear with Softmax + CrossEntropy energy.
+Position 0 is always Linear (the 784 -> 64 feature-extraction projection;
+StorkeyHopfield is width-preserving and cannot reduce dimension). The
+classifier head is always Linear with Softmax + CrossEntropy energy.
 
-Hypothesis: a higher fraction of hidden layers converted from Linear to
-StorkeyHopfield produces cumulative accuracy gains under scarcity + noise.
-The MLP arm is the baseline; deltas are computed per (K, noise) cell against
-MLP.
+Hypothesis
+----------
+Accuracy gains are cumulative in the number of Linear -> StorkeyHopfield
+substitutions in the hidden stack. Concretely, two adjacent paired
+contrasts on the per-trial accuracy differences:
+
+    substitution 1:   acc(1hopfield) - acc(MLP)       > 0
+    substitution 2:   acc(2hopfield) - acc(1hopfield) > 0
+
+are each predicted to be positive on average, and the per-cell cumulative
+claim ("substituting more layers helps further") is the conjunction: both
+contrasts positive AND each starred (two-sided paired t-test p<0.05). The
+K x noise grid is a *sensitivity analysis* of where the per-substitution
+gain is positive: it grows with input noise, requires K large enough for
+the attractors to form class prototypes (deltas grow with K and are
+typically negative at K=10 with low noise), and scarcity alone is not
+sufficient to produce a Hopfield advantage. The reported 2hopfield - MLP
+delta is the *total* effect (both substitutions combined), which is
+informative descriptively but not tested as a planned contrast.
 
 Experiment grid: K (shots per class) x noise_std
-    - K controls data scarcity: fewer examples -> more reliance on memory
-    - noise_std controls input corruption: more noise -> more reliance on
-      attractor denoising
+    - K controls data scarcity: how many samples each arm trains on.
+    - noise_std controls input corruption: more noise -> more reliance
+      on attractor denoising.
 
-Setup (one-time):
-    pip install tensorflow_datasets tensorflow-cpu
-    (`tensorflow-cpu` keeps TF off the GPU so it does not contend with JAX
-    for device memory; `tensorflow_datasets` is the dataset backend used by
-    `FashionMnistLoader` / `FewShotLoader`. Neither is currently declared
-    in pyproject.toml — should be added there in a follow-up.)
+Setup (one-time)::
 
-Usage:
+    pip install -e ".[tfds]"
+
+(installs ``tensorflow-datasets`` and ``tensorflow``, the dataset backend
+used by FashionMnistLoader / FewShotLoader; declared as the ``tfds`` extra
+in pyproject.toml. Both loaders call ``tf.config.set_visible_devices([],
+"GPU")`` at construction so TF stays off the GPU and does not contend with
+JAX.)
+
+Usage::
+
+    # Full default sweep: K in {500}, noise in {2.0}, n_trials=5, epochs=1.
+    # Bare invocation is intentionally fast so that JIT compilation, the
+    # tfds download, and the printed pipeline are visible in well under a
+    # minute on a GPU. The documented Results block below was produced with
+    # --n_trials 10 --num_epochs 20 on the full grid (see the explicit
+    # commands beneath it).
     python examples/storkey_hopfield_demo.py
-    python examples/storkey_hopfield_demo.py --networks 1hopfield 2hopfield
-    python examples/storkey_hopfield_demo.py --networks 2hopfield --k_values 50,500 --noise_levels 0.0,2.0
-    python examples/storkey_hopfield_demo.py --k_values 50 --noise_levels 0.0 --n_trials 2 --num_epochs 1
 
-Results (Fashion-MNIST, --strength 2.0, --n_trials 10, --num_epochs 20)::
+    # All three arms, both planned contrasts; K x noise grid; long run:
+    python examples/storkey_hopfield_demo.py --networks 1hopfield 2hopfield \\
+        --k_values 10,50,100,500 --noise_levels 0.0,0.5,1.0,2.0 \\
+        --n_trials 10 --num_epochs 20
+
+    # 2hopfield only (total-effect contrast against MLP, no second-increment
+    # test):
+    python examples/storkey_hopfield_demo.py --networks 2hopfield \\
+        --k_values 50,500 --noise_levels 0.0,2.0
+
+Results (Fashion-MNIST, paired runner; --strength 2.0, n_trials=10,
+num_epochs=20). Numbers below are from the paired-runner re-run on the
+GPU server. Each trial's seed flows through all three arms and the
+train loader is reset() between arms, so the per-trial difference vector
+is a clean within-trial paired contrast. Stars are two-sided paired
+t-tests at p<0.05, uncorrected. Both heatmaps below are the *planned*
+contrasts; the total effect (2hopfield - MLP), which equals the sum of
+the two heatmap cells, is reported descriptively in the demo output but
+is not a planned contrast.
 
     Delta Accuracy Heatmap (1hopfield - MLP, percentage points):
 
          K  n=0.0  n=0.5  n=1.0  n=2.0
     ----------------------------------
-        10  -1.7*  -0.9   +0.5   +2.8*
-        50  -0.2   +0.6   +3.0*  +7.6*
-       100  +0.1   +1.0*  +3.3*  +8.5*
-       500  -0.3   +0.8*  +3.2*  +7.2*
+        10  -1.8*  -1.0   +0.4   +2.6*
+        50  -0.1   +0.8*  +3.1*  +7.6*
+       100  +0.1   +1.1*  +3.5*  +8.3*
+       500  +0.3   +1.5*  +3.6*  +7.4*
 
-    Delta Accuracy Heatmap (2hopfield - MLP, percentage points):
+    Delta Accuracy Heatmap (2hopfield - 1hopfield, percentage points):
 
          K  n=0.0  n=0.5  n=1.0  n=2.0
     ----------------------------------
-        10  -4.6*  -3.5*  -1.0   +3.4*
-        50  -0.4   +0.7*  +4.0* +10.5*
-       100  +0.3   +1.5*  +4.8* +11.6*
-       500  +0.8*  +2.4*  +5.9* +13.1*
+        10  -2.9*  -2.7*  -1.5*  +0.7
+        50  -0.3   -0.1   +0.8*  +2.9*
+       100  +0.2   +0.5   +1.3*  +3.2*
+       500  +0.3*  +0.8*  +2.4*  +5.9*
 
-      * = significant at p<0.05
+      * = significant at p<0.05 (two-sided paired t-test, uncorrected)
 
-The results support the hypothesis: more `Linear -> StorkeyHopfield`
-substitutions produce cumulative accuracy gains under data-abundance combined
-with input noise. The 2hopfield arm consistently beats the 1hopfield arm at
-K >= 50 and any nonzero noise, and the gap widens as noise grows (e.g.
-K=500, n=2.0: 1hopfield delta = +7.2 pp, 2hopfield delta = +13.1 pp — nearly
-double). At K=10 / no noise both Hopfield arms underperform MLP, as expected:
-with almost no data and no corruption, attractor memory has nothing to
-retrieve or denoise, so the extra Hopfield constraints only slow learning.
+Cumulative gain (BOTH planned contrasts starred-positive in the same
+cell) is attained in 7 of 16 cells: every cell of K in {50, 100, 500}
+crossed with n in {1.0, 2.0}, plus K=500 at n=0.5. The K=10 row is the
+clear inverse zone -- with so few examples per class the Storkey
+attractors do not form usable class prototypes and Hopfield
+substitutions cost accuracy at low noise. At clean inputs (n=0.0) both
+contrasts are near zero across the rest of the grid -- when there is
+no noise to denoise, the attractor does not pay rent.
+
+Caveat on K=10: ``FewShotLoader`` drops the remainder batch, so K=10
+trains on 64 of 100 samples per epoch (one 64-sample batch); the K=10
+row is confounded with that truncation and should be read with that
+in mind. Use a smaller batch size at low K to remove this confound.
 """
 
 from jax_setup import set_jax_flags_before_importing_jax
@@ -77,8 +123,7 @@ from jax_setup import set_jax_flags_before_importing_jax
 set_jax_flags_before_importing_jax()
 
 import argparse
-import time
-from typing import Dict, List, Sequence
+from typing import Dict, List, Sequence, Tuple
 
 import numpy as np
 import jax
@@ -94,8 +139,7 @@ from fabricpc.core.energy import CrossEntropyEnergy
 from fabricpc.core.inference import InferenceSGD
 from fabricpc.core.initializers import XavierInitializer
 from fabricpc.training import train_pcn, evaluate_pcn
-from fabricpc.experiments import ExperimentArm
-from fabricpc.experiments.statistics import paired_ttest, cohens_d
+from fabricpc.experiments import ExperimentArm, PlannedMultiContrastExperiment
 from fabricpc.utils.data.dataloader import (
     FashionMnistLoader,
     FewShotLoader,
@@ -113,7 +157,7 @@ BATCH_SIZE = 64
 HIDDEN_WIDTH = 64
 
 # Each entry lists the hidden-layer types between the input and the Linear
-# softmax readout. Position 0 must be Linear (784->HIDDEN_WIDTH projection);
+# softmax readout. Position 0 must be Linear (784 -> HIDDEN_WIDTH projection);
 # StorkeyHopfield is width-preserving and cannot reduce dimension.
 ARCH_CONFIGS: Dict[str, List[str]] = {
     "MLP": ["Linear", "Linear", "Linear"],
@@ -129,7 +173,10 @@ ARCH_CONFIGS: Dict[str, List[str]] = {
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Depth + Few-Shot + Noise: StorkeyHopfield as a composable graph element on Fashion-MNIST"
+        description=(
+            "Depth + Few-Shot + Noise: StorkeyHopfield as a composable graph "
+            "element on Fashion-MNIST."
+        )
     )
     parser.add_argument(
         "--k_values",
@@ -153,13 +200,16 @@ def parse_args():
         "--num_epochs",
         type=int,
         default=1,
-        help="Training epochs per trial (default: 1)",
+        help=(
+            "Training epochs per trial (default: 1). The bare command is "
+            "intentionally fast; the documented Results block uses 20."
+        ),
     )
     parser.add_argument(
         "--strength",
         type=str,
         default="2.0",
-        help="Hopfield strength: float >=0 or 'None' for learnable (default: 2.0)",
+        help="Hopfield strength: float >= 0 or 'None' for learnable (default: 2.0)",
     )
     parser.add_argument(
         "--networks",
@@ -168,9 +218,8 @@ def parse_args():
         default=["1hopfield", "2hopfield"],
         choices=["1hopfield", "2hopfield"],
         help=(
-            "Which Hopfield-substituted variants to compare against the MLP "
-            "baseline. MLP is always included implicitly. "
-            "Default: 1hopfield 2hopfield."
+            "Which Hopfield-substituted variants to run alongside the MLP "
+            "baseline. MLP is always included implicitly. Default: both."
         ),
     )
     parser.add_argument(
@@ -192,25 +241,36 @@ def make_model_factory(
     hopfield_strength,
     width: int = HIDDEN_WIDTH,
 ):
-    """Return a model_factory(rng_key) for a classifier with a heterogeneous
-    hidden stack defined by ``layer_types``.
+    """Return a ``model_factory(rng_key)`` for a classifier whose hidden
+    stack is defined by ``layer_types``.
 
-    Architecture (depth-3 hidden + readout):
+    Architecture (depth-3 hidden + readout)::
+
         pixels(784) -> hidden0(width) -> hidden1(width) -> hidden2(width) -> class(10)
 
-    Each hidden layer is either Linear(tanh) or StorkeyHopfield, per the
-    corresponding entry of layer_types. Position 0 must be Linear because
-    StorkeyHopfield is width-preserving (square W, in_dim == out_dim) and
-    cannot perform the 784->width projection.
+    Each hidden layer is either ``Linear(tanh)`` or ``StorkeyHopfield`` per
+    the corresponding entry of ``layer_types``. **Position 0 must be
+    Linear** because ``StorkeyHopfield`` is width-preserving (square W,
+    ``in_dim == out_dim``) and cannot perform the 784 -> width projection
+    -- the call below raises ``ValueError`` instead of failing later with
+    an opaque shape error from graph wiring.
 
     The classifier head is always Linear with Softmax + CrossEntropy energy.
     """
+    if not layer_types:
+        raise ValueError("layer_types must contain at least one layer.")
+    if layer_types[0] != "Linear":
+        raise ValueError(
+            f"Position 0 of layer_types must be 'Linear' (the 784 -> {width} "
+            f"feature-extraction projection); got {layer_types[0]!r}. "
+            "StorkeyHopfield is width-preserving and cannot change dimension."
+        )
 
     def create_model(rng_key):
         pixels = IdentityNode(shape=(784,), name="pixels")
         # Annotate as List[NodeBase] so Pylance allows appending Linear /
-        # StorkeyHopfield / etc. without inferring the narrower IdentityNode
-        # type from the initial single-element list.
+        # StorkeyHopfield without inferring the narrower IdentityNode type
+        # from the initial single-element list.
         nodes: List[NodeBase] = [pixels]
         edges: List[Edge] = []
         prev: NodeBase = pixels
@@ -276,14 +336,17 @@ def arch_str(layer_types: Sequence[str], width: int = HIDDEN_WIDTH) -> str:
 
 
 def make_data_factory(k_per_class, noise_std, batch_size):
-    """Return a data_loader_factory(seed) for the multi-arm trial loop.
+    """Return a ``data_loader_factory(seed)`` for the experiment runner.
 
     Each trial seed produces a deterministic K-shot subsample (function of
     trial seed only) and an independent test-noise realization (function of
-    trial seed and noise_std). Identical training data is reused across noise
-    levels for a clean isolation of the noise effect, while different noise
-    levels draw independent realizations rather than rescaled copies of one
-    shared noise stream.
+    trial seed and noise_std). Identical training data is reused across
+    noise levels for a clean isolation of the noise effect, while different
+    noise levels draw independent realizations rather than rescaled copies
+    of one shared noise stream.
+
+    Pairing of the *minibatch order* across arms within a trial is handled
+    by the runner via the loaders' ``reset()`` method, not here.
     """
     # Stable integer fingerprint of noise_std used as RNG entropy.
     noise_level_id = int(round(noise_std * 1_000_000))
@@ -326,81 +389,162 @@ def make_data_factory(k_per_class, noise_std, batch_size):
 
 
 # ---------------------------------------------------------------------------
-# Multi-Arm Trial Runner
+# Planned contrasts
 # ---------------------------------------------------------------------------
 
 
-def run_multi_arm_trials(
-    arms: List[ExperimentArm],
-    data_factory,
-    n_trials: int,
-    metric: str = "accuracy",
-    seed_offset: int = 0,
-    verbose: bool = False,
-) -> Dict[str, np.ndarray]:
-    """Run every arm across n_trials paired trials.
+def build_contrasts(hopfield_arms_to_run: List[str]) -> List[Tuple[str, str]]:
+    """Build the planned-contrast list from the selected Hopfield arms.
 
-    Each trial uses one seed for both the data factory (same K-shot subsample
-    and noise realization across arms) and the model RNG key (same init key
-    across arms — different structures still produce different weights, but
-    the source of randomness is paired). The chosen ``metric`` is collected
-    per arm per trial.
+    The hypothesis decomposes into two ordered adjacent increments::
 
-    This replaces ``ABExperiment`` because we now have more than two arms
-    (MLP + 1hopfield + 2hopfield) and want one shared MLP training per trial,
-    not one MLP training per Hopfield comparison.
+        substitution 1:   1hopfield - MLP
+        substitution 2:   2hopfield - 1hopfield
 
-    Returns a dict mapping ``arm.name -> np.ndarray`` of per-trial metric
-    values (length n_trials).
+    Special case: ``--networks 2hopfield`` alone (without 1hopfield) cannot
+    test the second increment; in that case we fall back to the total-effect
+    contrast ``2hopfield - MLP``, which is reported and starred. main()
+    prints a caveat distinguishing this case from the increment test.
     """
-    per_arm_metrics: Dict[str, List[float]] = {arm.name: [] for arm in arms}
+    contrasts: List[Tuple[str, str]] = []
+    has_1hop = "1hopfield" in hopfield_arms_to_run
+    has_2hop = "2hopfield" in hopfield_arms_to_run
+    if has_1hop:
+        contrasts.append(("1hopfield", "MLP"))
+    if has_2hop:
+        if has_1hop:
+            contrasts.append(("2hopfield", "1hopfield"))
+        else:
+            contrasts.append(("2hopfield", "MLP"))
+    return contrasts
 
-    for trial_idx in range(n_trials):
-        trial_seed = seed_offset + trial_idx * 1000
-        print(f"--- Trial {trial_idx + 1}/{n_trials} (seed={trial_seed}) ---")
 
-        train_loader, test_loader = data_factory(trial_seed)
+# ---------------------------------------------------------------------------
+# Pretty-printing helpers
+# ---------------------------------------------------------------------------
 
-        for arm in arms:
-            master_key = jax.random.PRNGKey(trial_seed)
-            graph_key, train_key, eval_key = jax.random.split(master_key, 3)
 
-            params, structure = arm.model_factory(graph_key)
+def _pct(x: float) -> str:
+    return f"{x * 100:+.2f}"
 
-            t0 = time.time()
-            trained_params, _, _ = arm.train_fn(
-                params,
-                structure,
-                train_loader,
-                arm.optimizer,
-                arm.train_config,
-                train_key,
-                verbose=verbose,
-            )
-            train_time = time.time() - t0
 
-            metrics = arm.eval_fn(
-                trained_params,
-                structure,
-                test_loader,
-                arm.train_config,
-                eval_key,
-            )
+def print_per_arm_table(arm_names: List[str], grid: List[Dict]):
+    print()
+    print("Per-arm accuracy (mean +/- SE, %):")
+    cols = [f"{'K':>5}", f"{'Noise':>6}"]
+    for name in arm_names:
+        cols.append(f"{name:>14}")
+    header = "  ".join(cols)
+    print(header)
+    print("-" * len(header))
+    for r in grid:
+        parts = [f"{r['k']:>5}", f"{r['noise']:>6.1f}"]
+        for name in arm_names:
+            cell = f"{r[f'{name}_mean'] * 100:6.2f}+/-" f"{r[f'{name}_se'] * 100:.2f}"
+            parts.append(f"{cell:>14}")
+        print("  ".join(parts))
 
-            if metric not in metrics:
-                available = ", ".join(sorted(metrics.keys()))
-                raise KeyError(
-                    f"Metric '{metric}' not found in eval results for arm "
-                    f"'{arm.name}'. Available: {available}"
-                )
-            value = float(metrics[metric])
-            per_arm_metrics[arm.name].append(value)
-            print(
-                f"  {arm.name:<10}: {metric}={value:.4f}  "
-                f"(train: {train_time:.1f}s)"
-            )
 
-    return {name: np.asarray(vals) for name, vals in per_arm_metrics.items()}
+def print_contrasts_table(
+    contrasts: List[Tuple[str, str]], grid: List[Dict], n_trials: int
+):
+    if not contrasts:
+        return
+    print()
+    print("Planned contrasts (paired two-sided t-test on per-trial differences):")
+    cols = [f"{'K':>5}", f"{'Noise':>6}"]
+    for a, b in contrasts:
+        label = f"{a}-{b}"
+        cols.append(f"{label + ' D%':>16}")
+        cols.append(f"{'p':>8}")
+        cols.append(f"{'sig':>4}")
+        cols.append(f"{'d':>7}")
+    header = "  ".join(cols)
+    print(header)
+    print("-" * len(header))
+    for r in grid:
+        parts = [f"{r['k']:>5}", f"{r['noise']:>6.1f}"]
+        for a, b in contrasts:
+            key = f"{a}-{b}"
+            delta_str = _pct(r[f"{key}_delta"])
+            parts.append(f"{delta_str:>16}")
+            p = r[f"{key}_pval"]
+            parts.append(f"{p:8.4f}" if not np.isnan(p) else f"{'n/a':>8}")
+            parts.append(f"{'*' if r[f'{key}_sig'] else '':>4}")
+            d = r[f"{key}_d"]
+            parts.append(f"{d:7.3f}" if not np.isnan(d) else f"{'n/a':>7}")
+        print("  ".join(parts))
+    print()
+    print(_legend_text(n_trials, len(grid), contrasts))
+
+
+def print_descriptive_total_delta(grid: List[Dict]):
+    """Print the descriptive 2hopfield - MLP total-effect delta when it is
+    NOT a planned contrast (i.e. when both 1hopfield and 2hopfield are run,
+    so the planned contrasts are the two increments and the total effect is
+    reported only)."""
+    if not grid or "2hopfield-MLP_delta_descriptive" not in grid[0]:
+        return
+    print()
+    print("Reported-only (descriptive, NOT a planned contrast):")
+    print(f"{'K':>5}  {'Noise':>6}  {'2hopfield-MLP D%':>18}  {'SE':>8}")
+    print("-" * 44)
+    for r in grid:
+        d = r["2hopfield-MLP_delta_descriptive"]
+        se = r["2hopfield-MLP_se_descriptive"]
+        print(f"{r['k']:>5}  {r['noise']:>6.1f}  " f"{_pct(d):>18}  {se * 100:>7.2f}")
+
+
+def _legend_text(n_trials: int, n_cells: int, contrasts: List[Tuple[str, str]]) -> str:
+    n_contrasts = len(contrasts)
+    total_tests = n_cells * n_contrasts
+    cumulative_rule = ""
+    if contrasts == [("1hopfield", "MLP"), ("2hopfield", "1hopfield")]:
+        cumulative_rule = (
+            "  Per-cell criterion for 'cumulative gain': BOTH planned contrasts\n"
+            "  starred with positive deltas (intersection-union test of the\n"
+            "  conjunction, valid at level alpha under arbitrary dependence).\n"
+        )
+    return (
+        f"Legend:\n"
+        f"  * = two-sided paired t-test p<0.05 on the per-trial difference\n"
+        f"      vector, uncorrected across {n_cells} cells x {n_contrasts} "
+        f"contrasts = {total_tests} tests.\n"
+        f"      Per-cell stars are exploratory across the grid.\n"
+        f"{cumulative_rule}"
+        f"  n_trials = {n_trials}; Cohen's d is the paired d on the same vector."
+    )
+
+
+def print_heatmaps(
+    contrasts: List[Tuple[str, str]],
+    k_values: List[int],
+    noise_levels: List[float],
+    grid: List[Dict],
+):
+    if len(k_values) <= 1 or len(noise_levels) <= 1:
+        return
+    for a, b in contrasts:
+        print()
+        print(f"Delta Accuracy Heatmap ({a} - {b}, percentage points):")
+        print()
+        noise_header = f"{'K':>6}" + "".join(f"  n={n:.1f}" for n in noise_levels)
+        print(noise_header)
+        print("-" * len(noise_header))
+        for k in k_values:
+            row_str = f"{k:>6}"
+            for noise_std in noise_levels:
+                match = [r for r in grid if r["k"] == k and r["noise"] == noise_std]
+                if match:
+                    key = f"{a}-{b}"
+                    d = match[0][f"{key}_delta"] * 100
+                    sig = "*" if match[0][f"{key}_sig"] else " "
+                    row_str += f" {d:+5.1f}{sig}"
+                else:
+                    row_str += "    n/a"
+            print(row_str)
+    print()
+    print("  * = significant at p<0.05 (two-sided paired t-test, uncorrected)")
 
 
 # ---------------------------------------------------------------------------
@@ -426,7 +570,8 @@ def main():
         "learnable" if hopfield_strength is None else f"{hopfield_strength}"
     )
 
-    # MLP is always the baseline. argparse de-duplication: keep input order.
+    # MLP is always the baseline. argparse choices restricts to known names;
+    # de-duplicate while preserving input order.
     seen = set()
     hopfield_arms_to_run: List[str] = []
     for name in args.networks:
@@ -448,9 +593,10 @@ def main():
         )
 
     arms = [build_arm(name) for name in arm_names_in_run]
+    contrasts = build_contrasts(hopfield_arms_to_run)
 
     print("=" * 78)
-    print("StorkeyHopfield depth comparison: composable graph element on Fashion-MNIST")
+    print("StorkeyHopfield depth comparison on Fashion-MNIST")
     print("=" * 78)
     print("Dataset: Fashion-MNIST")
     for name in arm_names_in_run:
@@ -460,10 +606,23 @@ def main():
     print(f"Trials per condition: {args.n_trials}")
     print(f"K values (number of examples per class): {k_values}")
     print(f"Noise levels (std dev): {noise_levels}")
+    print(f"Planned contrasts: {contrasts}")
+    if "2hopfield" in hopfield_arms_to_run and "1hopfield" not in hopfield_arms_to_run:
+        print()
+        print(
+            "NOTE: --networks 2hopfield without 1hopfield falls back to the\n"
+            "total-effect contrast (2hopfield - MLP), not the per-substitution\n"
+            "increment. Pass '--networks 1hopfield 2hopfield' to test the two\n"
+            "ordered increments (1hopfield-MLP, 2hopfield-1hopfield) separately."
+        )
     print()
 
-    # Collect results across the K x noise grid.
+    # ---- run the K x noise grid -----------------------------------------------
+
     grid_results: List[Dict] = []
+    report_descriptive_total = (
+        "1hopfield" in hopfield_arms_to_run and "2hopfield" in hopfield_arms_to_run
+    )
 
     for k in k_values:
         for noise_std in noise_levels:
@@ -473,124 +632,75 @@ def main():
 
             data_factory = make_data_factory(k, noise_std, BATCH_SIZE)
 
-            metrics_by_arm = run_multi_arm_trials(
+            runner = PlannedMultiContrastExperiment(
                 arms=arms,
-                data_factory=data_factory,
-                n_trials=args.n_trials,
+                contrasts=contrasts,
                 metric="accuracy",
+                data_loader_factory=data_factory,
+                n_trials=args.n_trials,
+                seed_offset=0,
                 verbose=args.verbose,
             )
+            results = runner.run()
 
             row: Dict = {"k": k, "noise": noise_std}
-            mlp_acc = metrics_by_arm["MLP"]
-            row["MLP_mean"] = float(np.mean(mlp_acc))
-            row["MLP_se"] = (
-                float(np.std(mlp_acc, ddof=1) / np.sqrt(len(mlp_acc)))
-                if len(mlp_acc) > 1
-                else 0.0
-            )
-
-            for arm_name in hopfield_arms_to_run:
-                arm_acc = metrics_by_arm[arm_name]
-                delta = arm_acc - mlp_acc
-                row[f"{arm_name}_mean"] = float(np.mean(arm_acc))
-                row[f"{arm_name}_se"] = (
-                    float(np.std(arm_acc, ddof=1) / np.sqrt(len(arm_acc)))
-                    if len(arm_acc) > 1
+            for name in arm_names_in_run:
+                acc = results.per_arm_metrics(name)
+                row[f"{name}_mean"] = float(np.mean(acc))
+                row[f"{name}_se"] = (
+                    float(np.std(acc, ddof=1) / np.sqrt(len(acc)))
+                    if len(acc) > 1
                     else 0.0
                 )
-                row[f"{arm_name}_delta"] = float(np.mean(delta))
-                if args.n_trials >= 2:
-                    ttest = paired_ttest(arm_acc, mlp_acc)
-                    effect = cohens_d(arm_acc, mlp_acc)
-                    row[f"{arm_name}_pval"] = ttest.p_value
-                    row[f"{arm_name}_sig"] = ttest.significant_at_05
-                    row[f"{arm_name}_d"] = effect.d
-                else:
-                    row[f"{arm_name}_pval"] = float("nan")
-                    row[f"{arm_name}_sig"] = False
-                    row[f"{arm_name}_d"] = float("nan")
+
+            # One entry per declared contrast (these get stars).
+            for c in results.contrast_results():
+                key = f"{c.arm_a}-{c.arm_b}"
+                row[f"{key}_delta"] = c.mean_diff
+                row[f"{key}_se"] = c.se_diff
+                row[f"{key}_pval"] = c.p_value if args.n_trials >= 2 else float("nan")
+                row[f"{key}_sig"] = c.significant_at_05 if args.n_trials >= 2 else False
+                row[f"{key}_d"] = c.cohens_d if args.n_trials >= 2 else float("nan")
+
+            # Reported-only descriptive total effect (only when BOTH hopfield
+            # variants run AND the second increment is the planned contrast).
+            if report_descriptive_total:
+                d = results.delta("2hopfield", "MLP")
+                row["2hopfield-MLP_delta_descriptive"] = d.mean
+                row["2hopfield-MLP_se_descriptive"] = d.se
 
             grid_results.append(row)
 
+            # Per-cell summary line.
             print("  Cell summary:")
-            print(f"    MLP       : {row['MLP_mean']*100:.2f}%")
-            for arm_name in hopfield_arms_to_run:
-                p = row[f"{arm_name}_pval"]
+            for name in arm_names_in_run:
+                print(f"    {name:<10}: {row[f'{name}_mean'] * 100:.2f}%")
+            for a, b in contrasts:
+                key = f"{a}-{b}"
+                p = row[f"{key}_pval"]
                 p_str = "p=n/a" if np.isnan(p) else f"p={p:.4f}"
+                star = "*" if row[f"{key}_sig"] else ""
                 print(
-                    f"    {arm_name:<10}: {row[f'{arm_name}_mean']*100:.2f}%  "
-                    f"Delta={row[f'{arm_name}_delta']*100:+.2f}%  {p_str}"
+                    f"    {key:<22} delta={row[f'{key}_delta'] * 100:+.2f}%  "
+                    f"{p_str} {star}"
                 )
 
-    # -----------------------------------------------------------------------
-    # Summary Tables
-    # -----------------------------------------------------------------------
+    # ---- summary tables -------------------------------------------------------
 
     print("\n\n")
     print("=" * 78)
-    print("RESULTS SUMMARY")
+    print(
+        "RESULTS SUMMARY  "
+        f"(strength={strength_label}, n_trials={args.n_trials}, "
+        f"epochs={args.num_epochs})"
+    )
     print("=" * 78)
-    print(f"  Hopfield strength: {strength_label}")
-    print(f"  Trials: {args.n_trials}, Epochs: {args.num_epochs}")
-    print()
 
-    # Per-condition table: MLP and each Hopfield arm side by side.
-    cols = [f"{'K':>5}", f"{'Noise':>6}", f"{'MLP%':>13}"]
-    for arm_name in hopfield_arms_to_run:
-        cols.append(f"{arm_name + '%':>14}")
-        cols.append(f"{'Delta':>7}")
-        cols.append(f"{'p':>8}")
-        cols.append(f"{'sig':>4}")
-        cols.append(f"{'d':>7}")
-    header = " ".join(cols)
-    print(header)
-    print("-" * len(header))
-    for r in grid_results:
-        parts = [
-            f"{r['k']:>5}",
-            f"{r['noise']:>6.1f}",
-            f"{r['MLP_mean']*100:6.2f}+/-{r['MLP_se']*100:.2f}",
-        ]
-        for arm_name in hopfield_arms_to_run:
-            parts.append(
-                f"{r[f'{arm_name}_mean']*100:6.2f}+/-{r[f'{arm_name}_se']*100:.2f}"
-            )
-            parts.append(f"{r[f'{arm_name}_delta']*100:+6.2f}")
-            p = r[f"{arm_name}_pval"]
-            parts.append(f"{p:8.4f}" if not np.isnan(p) else f"{'n/a':>8}")
-            parts.append(f"{'*' if r[f'{arm_name}_sig'] else '':>4}")
-            d = r[f"{arm_name}_d"]
-            parts.append(f"{d:7.3f}" if not np.isnan(d) else f"{'n/a':>7}")
-        print(" ".join(parts))
-    print("-" * len(header))
-
-    # Delta heatmap (K x noise), one block per Hopfield arm.
-    if len(k_values) > 1 and len(noise_levels) > 1:
-        for arm_name in hopfield_arms_to_run:
-            print()
-            print(f"Delta Accuracy Heatmap ({arm_name} - MLP, percentage points):")
-            print()
-            noise_header = f"{'K':>6}" + "".join(f"  n={n:.1f}" for n in noise_levels)
-            print(noise_header)
-            print("-" * len(noise_header))
-            for k in k_values:
-                row_str = f"{k:>6}"
-                for noise_std in noise_levels:
-                    match = [
-                        r
-                        for r in grid_results
-                        if r["k"] == k and r["noise"] == noise_std
-                    ]
-                    if match:
-                        d = match[0][f"{arm_name}_delta"] * 100
-                        sig = "*" if match[0][f"{arm_name}_sig"] else " "
-                        row_str += f" {d:+5.1f}{sig}"
-                    else:
-                        row_str += "    n/a"
-                print(row_str)
-            print()
-        print("  * = significant at p<0.05")
+    print_per_arm_table(arm_names_in_run, grid_results)
+    print_contrasts_table(contrasts, grid_results, args.n_trials)
+    if report_descriptive_total:
+        print_descriptive_total_delta(grid_results)
+    print_heatmaps(contrasts, k_values, noise_levels, grid_results)
 
     print()
     print("=" * 78)

--- a/examples/storkey_hopfield_demo.py
+++ b/examples/storkey_hopfield_demo.py
@@ -133,6 +133,13 @@ the remaining Linear layers. Even there the second increment stays
 positive -- adding the late Hopfield on top of the early one helps,
 although the late position alone underperforms. The descriptive total
 effect (2hopfield - MLP) peaks at +13.0 pp at K=500, n=2.0.
+
+Quick run results (default args, RTX3090, cuda13, jax 0.10.2)
+  Cell summary:
+    MLP       : 58.32%
+    1hopfield : 62.86%
+    1hopfield-late: 61.68%
+    2hopfield : 64.26%
 """
 
 from jax_setup import set_jax_flags_before_importing_jax

--- a/examples/storkey_hopfield_demo.py
+++ b/examples/storkey_hopfield_demo.py
@@ -10,9 +10,10 @@ has enough samples for the attractors to form usable class prototypes.
 
 Architecture (same depth-4 graph across all arms, hidden width = 64)::
 
-    "MLP"        pixels(784) -> 64(Linear) -> 64(Linear)          -> 64(Linear)          -> 10(softmax+CE)
-    "1hopfield"  pixels(784) -> 64(Linear) -> 64(StorkeyHopfield) -> 64(Linear)          -> 10(softmax+CE)
-    "2hopfield"  pixels(784) -> 64(Linear) -> 64(StorkeyHopfield) -> 64(StorkeyHopfield) -> 10(softmax+CE)
+    "MLP"             pixels(784) -> 64(Linear) -> 64(Linear)          -> 64(Linear)          -> 10(softmax+CE)
+    "1hopfield"       pixels(784) -> 64(Linear) -> 64(StorkeyHopfield) -> 64(Linear)          -> 10(softmax+CE)
+    "1hopfield-late"  pixels(784) -> 64(Linear) -> 64(Linear)          -> 64(StorkeyHopfield) -> 10(softmax+CE)
+    "2hopfield"       pixels(784) -> 64(Linear) -> 64(StorkeyHopfield) -> 64(StorkeyHopfield) -> 10(softmax+CE)
 
 Position 0 is always Linear (the 784 -> 64 feature-extraction projection;
 StorkeyHopfield is width-preserving and cannot reduce dimension). The
@@ -21,22 +22,26 @@ classifier head is always Linear with Softmax + CrossEntropy energy.
 Hypothesis
 ----------
 Accuracy gains are cumulative in the number of Linear -> StorkeyHopfield
-substitutions in the hidden stack. Concretely, two adjacent paired
-contrasts on the per-trial accuracy differences:
+substitutions in the hidden stack, and driven by the substitution count
+rather than the substituted position. Three planned paired contrasts on the
+per-trial accuracy differences:
 
-    substitution 1:   acc(1hopfield) - acc(MLP)       > 0
-    substitution 2:   acc(2hopfield) - acc(1hopfield) > 0
+    substitution 1:   acc(1hopfield) - acc(MLP)            > 0
+    substitution 2:   acc(2hopfield) - acc(1hopfield)      > 0
+    position:         acc(1hopfield-late) - acc(1hopfield) ~ 0
 
-are each predicted to be positive on average, and the per-cell cumulative
-claim ("substituting more layers helps further") is the conjunction: both
-contrasts positive AND each starred (two-sided paired t-test p<0.05). The
-K x noise grid is a *sensitivity analysis* of where the per-substitution
-gain is positive: it grows with input noise, requires K large enough for
-the attractors to form class prototypes (deltas grow with K and are
-typically negative at K=10 with low noise), and scarcity alone is not
-sufficient to produce a Hopfield advantage. The reported 2hopfield - MLP
-delta is the *total* effect (both substitutions combined), which is
-informative descriptively but not tested as a planned contrast.
+The 1hopfield-late arm is the position control: without it, substitution 2
+would conflate adding a second Hopfield layer with occupying position 2 for
+the first time (only the 2hopfield arm places a Hopfield layer there). The
+per-cell cumulative claim ("substituting more layers helps further") is the
+conjunction: both increment contrasts positive AND each starred (two-sided
+paired t-test p<0.05). The K x noise grid is a *sensitivity analysis* of
+where the per-substitution gain is positive: it grows with input noise,
+requires K large enough for the attractors to form class prototypes, and
+data scarcity alone is not sufficient to produce a Hopfield advantage. The
+reported 2hopfield - MLP delta is the *total* effect (both substitutions
+combined), which is informative descriptively but not tested as a planned
+contrast.
 
 Experiment grid: K (shots per class) x noise_std
     - K controls data scarcity: how many samples each arm trains on.
@@ -55,67 +60,79 @@ JAX.)
 
 Usage::
 
-    # Full default sweep: K in {500}, noise in {2.0}, n_trials=5, epochs=1.
-    # Bare invocation is intentionally fast so that JIT compilation, the
-    # tfds download, and the printed pipeline are visible in well under a
-    # minute on a GPU. The documented Results block below was produced with
-    # --n_trials 10 --num_epochs 20 on the full grid (see the explicit
-    # commands beneath it).
+    # Default sweep: all four arms, K in {500}, noise in {2.0}, n_trials=5,
+    # epochs=1. Bare invocation is intentionally fast so that JIT
+    # compilation, the tfds download, and the printed pipeline are visible
+    # in well under a minute on a GPU. The documented Results block below
+    # was produced with --n_trials 10 --num_epochs 20 on the full grid (see
+    # the explicit command beneath it).
     python examples/storkey_hopfield_demo.py
 
-    # All three arms, both planned contrasts; K x noise grid; long run:
-    python examples/storkey_hopfield_demo.py --networks 1hopfield 2hopfield \\
+    # All four arms, all three planned contrasts; K x noise grid; long run:
+    python examples/storkey_hopfield_demo.py \\
+        --networks 1hopfield 1hopfield-late 2hopfield \\
         --k_values 10,50,100,500 --noise_levels 0.0,0.5,1.0,2.0 \\
         --n_trials 10 --num_epochs 20
 
-    # 2hopfield only (total-effect contrast against MLP, no second-increment
-    # test):
+    # 2hopfield only (total-effect contrast against MLP, no increment or
+    # position tests):
     python examples/storkey_hopfield_demo.py --networks 2hopfield \\
         --k_values 50,500 --noise_levels 0.0,2.0
 
-Results (Fashion-MNIST, paired runner; --strength 2.0, n_trials=10,
-num_epochs=20). Numbers below are from the paired-runner re-run on the
-GPU server. Each trial's seed flows through all three arms and the
-train loader is reset() between arms, so the per-trial difference vector
-is a clean within-trial paired contrast. Stars are two-sided paired
-t-tests at p<0.05, uncorrected. Both heatmaps below are the *planned*
-contrasts; the total effect (2hopfield - MLP), which equals the sum of
-the two heatmap cells, is reported descriptively in the demo output but
-is not a planned contrast.
+Results (Fashion-MNIST; --strength 2.0, n_trials=10, num_epochs=20, the
+full-grid command above). Each trial's seed flows through all four arms
+and the runner rebuilds the loaders per arm from that seed, so the
+per-trial difference vector is a clean within-trial paired contrast.
+Stars are two-sided paired t-tests at p<0.05, uncorrected across
+16 cells x 3 contrasts. The heatmaps are the three *planned* contrasts;
+the total effect (2hopfield - MLP) is reported descriptively in the demo
+output but is not tested.
 
     Delta Accuracy Heatmap (1hopfield - MLP, percentage points):
 
          K  n=0.0  n=0.5  n=1.0  n=2.0
     ----------------------------------
-        10  -1.8*  -1.0   +0.4   +2.6*
-        50  -0.1   +0.8*  +3.1*  +7.6*
-       100  +0.1   +1.1*  +3.5*  +8.3*
-       500  +0.3   +1.5*  +3.6*  +7.4*
+        10  -0.9*  -0.5   +1.2*  +4.1*
+        50  -0.1   +0.8*  +3.3*  +8.1*
+       100  -0.3   +0.9*  +3.3*  +8.5*
+       500  +0.3   +1.3*  +3.3*  +7.0*
 
     Delta Accuracy Heatmap (2hopfield - 1hopfield, percentage points):
 
          K  n=0.0  n=0.5  n=1.0  n=2.0
     ----------------------------------
-        10  -2.9*  -2.7*  -1.5*  +0.7
-        50  -0.3   -0.1   +0.8*  +2.9*
-       100  +0.2   +0.5   +1.3*  +3.2*
-       500  +0.3*  +0.8*  +2.4*  +5.9*
+        10  -0.8   -0.3   +0.3   +1.9*
+        50  +0.1   +0.2   +1.1*  +2.9*
+       100  +0.3   +0.6   +1.4*  +3.1*
+       500  +0.4*  +0.8*  +2.5*  +6.0*
+
+    Delta Accuracy Heatmap (1hopfield-late - 1hopfield, percentage points):
+
+         K  n=0.0  n=0.5  n=1.0  n=2.0
+    ----------------------------------
+        10  +0.7   +0.8*  +0.2   -0.9
+        50  +0.3   -0.1   -0.8*  -3.1*
+       100  +0.2   -0.2   -1.2*  -3.0*
+       500  +0.1   -0.0   -0.2   +0.4
 
       * = significant at p<0.05 (two-sided paired t-test, uncorrected)
 
-Cumulative gain (BOTH planned contrasts starred-positive in the same
-cell) is attained in 7 of 16 cells: every cell of K in {50, 100, 500}
-crossed with n in {1.0, 2.0}, plus K=500 at n=0.5. The K=10 row is the
-clear inverse zone -- with so few examples per class the Storkey
-attractors do not form usable class prototypes and Hopfield
-substitutions cost accuracy at low noise. At clean inputs (n=0.0) both
-contrasts are near zero across the rest of the grid -- when there is
-no noise to denoise, the attractor does not pay rent.
-
-Caveat on K=10: ``FewShotLoader`` drops the remainder batch, so K=10
-trains on 64 of 100 samples per epoch (one 64-sample batch); the K=10
-row is confounded with that truncation and should be read with that
-in mind. Use a smaller batch size at low K to remove this confound.
+Cumulative gain (BOTH increment contrasts starred-positive in the same
+cell) is attained in 8 of 16 cells: K in {50, 100, 500} crossed with
+n in {1.0, 2.0}, plus K=500 at n=0.5 and K=10 at n=2.0. Both increments
+grow with noise at every K, and at clean inputs (n=0.0) both are near
+zero: with no noise to denoise, the attractor dynamics contribute
+nothing, and at K=10 the first substitution significantly costs accuracy
+(-0.9 pp). The position contrast supports count-over-position where the
+increments are largest: at K=500 and at clean inputs the single
+substitution is position-insensitive (deltas within +/-0.4 pp). At
+K in {50, 100} under noise the late placement is significantly worse
+(-0.8 to -3.1 pp): an early attractor denoises the representation
+directly after the 784 -> 64 projection, before it propagates through
+the remaining Linear layers. Even there the second increment stays
+positive -- adding the late Hopfield on top of the early one helps,
+although the late position alone underperforms. The descriptive total
+effect (2hopfield - MLP) peaks at +13.0 pp at K=500, n=2.0.
 """
 
 from jax_setup import set_jax_flags_before_importing_jax
@@ -162,6 +179,7 @@ HIDDEN_WIDTH = 64
 ARCH_CONFIGS: Dict[str, List[str]] = {
     "MLP": ["Linear", "Linear", "Linear"],
     "1hopfield": ["Linear", "StorkeyHopfield", "Linear"],
+    "1hopfield-late": ["Linear", "Linear", "StorkeyHopfield"],
     "2hopfield": ["Linear", "StorkeyHopfield", "StorkeyHopfield"],
 }
 
@@ -215,11 +233,13 @@ def parse_args():
         "--networks",
         nargs="+",
         type=str,
-        default=["1hopfield", "2hopfield"],
-        choices=["1hopfield", "2hopfield"],
+        default=["1hopfield", "1hopfield-late", "2hopfield"],
+        choices=["1hopfield", "1hopfield-late", "2hopfield"],
         help=(
             "Which Hopfield-substituted variants to run alongside the MLP "
-            "baseline. MLP is always included implicitly. Default: both."
+            "baseline. MLP is always included implicitly. Default: all three "
+            "(1hopfield-late is the position control for the second "
+            "increment)."
         ),
     )
     parser.add_argument(
@@ -345,8 +365,9 @@ def make_data_factory(k_per_class, noise_std, batch_size):
     noise levels draw independent realizations rather than rescaled copies
     of one shared noise stream.
 
-    Pairing of the *minibatch order* across arms within a trial is handled
-    by the runner via the loaders' ``reset()`` method, not here.
+    Pairing of the *minibatch order* across arms within a trial holds
+    because the runner calls this factory once per arm with the same trial
+    seed and the loaders are deterministic in their seeds.
     """
     # Stable integer fingerprint of noise_std used as RNG entropy.
     noise_level_id = int(round(noise_std * 1_000_000))
@@ -396,26 +417,41 @@ def make_data_factory(k_per_class, noise_std, batch_size):
 def build_contrasts(hopfield_arms_to_run: List[str]) -> List[Tuple[str, str]]:
     """Build the planned-contrast list from the selected Hopfield arms.
 
-    The hypothesis decomposes into two ordered adjacent increments::
+    The full hypothesis decomposes into two ordered adjacent increments plus
+    one position control::
 
         substitution 1:   1hopfield - MLP
         substitution 2:   2hopfield - 1hopfield
+        position:         1hopfield-late - 1hopfield
 
-    Special case: ``--networks 2hopfield`` alone (without 1hopfield) cannot
-    test the second increment; in that case we fall back to the total-effect
-    contrast ``2hopfield - MLP``, which is reported and starred. main()
-    prints a caveat distinguishing this case from the increment test.
+    Partial ``--networks`` selections keep each contrast adjacent in
+    substitution count where possible:
+
+    - Without 1hopfield, 1hopfield-late takes over as the single-substitution
+      arm: its contrast is against MLP, and 2hopfield contrasts against it
+      (the second increment along the position-2 path).
+    - ``--networks 2hopfield`` alone can test neither increment; it falls
+      back to the total-effect contrast ``2hopfield - MLP``, which is
+      reported and starred. main() prints a caveat distinguishing this case
+      from the increment test.
     """
-    contrasts: List[Tuple[str, str]] = []
     has_1hop = "1hopfield" in hopfield_arms_to_run
+    has_late = "1hopfield-late" in hopfield_arms_to_run
     has_2hop = "2hopfield" in hopfield_arms_to_run
+
+    contrasts: List[Tuple[str, str]] = []
     if has_1hop:
         contrasts.append(("1hopfield", "MLP"))
-    if has_2hop:
-        if has_1hop:
+        if has_2hop:
             contrasts.append(("2hopfield", "1hopfield"))
-        else:
-            contrasts.append(("2hopfield", "MLP"))
+        if has_late:
+            contrasts.append(("1hopfield-late", "1hopfield"))
+    elif has_late:
+        contrasts.append(("1hopfield-late", "MLP"))
+        if has_2hop:
+            contrasts.append(("2hopfield", "1hopfield-late"))
+    elif has_2hop:
+        contrasts.append(("2hopfield", "MLP"))
     return contrasts
 
 
@@ -452,10 +488,13 @@ def print_contrasts_table(
         return
     print()
     print("Planned contrasts (paired two-sided t-test on per-trial differences):")
+    # Delta-column width per contrast: long labels (e.g.
+    # "1hopfield-late-1hopfield D%") widen their own column only.
+    delta_widths = [max(len(f"{a}-{b} D%"), 16) for a, b in contrasts]
     cols = [f"{'K':>5}", f"{'Noise':>6}"]
-    for a, b in contrasts:
+    for (a, b), w in zip(contrasts, delta_widths):
         label = f"{a}-{b}"
-        cols.append(f"{label + ' D%':>16}")
+        cols.append(f"{label + ' D%':>{w}}")
         cols.append(f"{'p':>8}")
         cols.append(f"{'sig':>4}")
         cols.append(f"{'d':>7}")
@@ -464,10 +503,10 @@ def print_contrasts_table(
     print("-" * len(header))
     for r in grid:
         parts = [f"{r['k']:>5}", f"{r['noise']:>6.1f}"]
-        for a, b in contrasts:
+        for (a, b), w in zip(contrasts, delta_widths):
             key = f"{a}-{b}"
             delta_str = _pct(r[f"{key}_delta"])
-            parts.append(f"{delta_str:>16}")
+            parts.append(f"{delta_str:>{w}}")
             p = r[f"{key}_pval"]
             parts.append(f"{p:8.4f}" if not np.isnan(p) else f"{'n/a':>8}")
             parts.append(f"{'*' if r[f'{key}_sig'] else '':>4}")
@@ -480,9 +519,9 @@ def print_contrasts_table(
 
 def print_descriptive_total_delta(grid: List[Dict]):
     """Print the descriptive 2hopfield - MLP total-effect delta when it is
-    NOT a planned contrast (i.e. when both 1hopfield and 2hopfield are run,
-    so the planned contrasts are the two increments and the total effect is
-    reported only)."""
+    NOT a planned contrast (i.e. when 2hopfield runs alongside a
+    single-substitution arm, so 2hopfield's planned contrast is an increment
+    and the total effect is reported only)."""
     if not grid or "2hopfield-MLP_delta_descriptive" not in grid[0]:
         return
     print()
@@ -499,11 +538,12 @@ def _legend_text(n_trials: int, n_cells: int, contrasts: List[Tuple[str, str]]) 
     n_contrasts = len(contrasts)
     total_tests = n_cells * n_contrasts
     cumulative_rule = ""
-    if contrasts == [("1hopfield", "MLP"), ("2hopfield", "1hopfield")]:
+    if ("1hopfield", "MLP") in contrasts and ("2hopfield", "1hopfield") in contrasts:
         cumulative_rule = (
-            "  Per-cell criterion for 'cumulative gain': BOTH planned contrasts\n"
-            "  starred with positive deltas (intersection-union test of the\n"
-            "  conjunction, valid at level alpha under arbitrary dependence).\n"
+            "  Per-cell criterion for 'cumulative gain': BOTH increment contrasts\n"
+            "  (1hopfield-MLP and 2hopfield-1hopfield) starred with positive\n"
+            "  deltas (intersection-union test of the conjunction, valid at\n"
+            "  level alpha under arbitrary dependence).\n"
         )
     return (
         f"Legend:\n"
@@ -607,21 +647,24 @@ def main():
     print(f"K values (number of examples per class): {k_values}")
     print(f"Noise levels (std dev): {noise_levels}")
     print(f"Planned contrasts: {contrasts}")
-    if "2hopfield" in hopfield_arms_to_run and "1hopfield" not in hopfield_arms_to_run:
+    if ("2hopfield", "MLP") in contrasts:
         print()
         print(
-            "NOTE: --networks 2hopfield without 1hopfield falls back to the\n"
-            "total-effect contrast (2hopfield - MLP), not the per-substitution\n"
-            "increment. Pass '--networks 1hopfield 2hopfield' to test the two\n"
-            "ordered increments (1hopfield-MLP, 2hopfield-1hopfield) separately."
+            "NOTE: --networks 2hopfield without a single-substitution arm\n"
+            "falls back to the total-effect contrast (2hopfield - MLP), not\n"
+            "the per-substitution increment. Pass '--networks 1hopfield\n"
+            "2hopfield' (or add 1hopfield-late) to test the ordered\n"
+            "increments separately."
         )
     print()
 
     # ---- run the K x noise grid -----------------------------------------------
 
     grid_results: List[Dict] = []
+    # The 2hopfield-MLP total effect is reported descriptively whenever
+    # 2hopfield's planned contrast is an increment (i.e. not itself vs MLP).
     report_descriptive_total = (
-        "1hopfield" in hopfield_arms_to_run and "2hopfield" in hopfield_arms_to_run
+        "2hopfield" in hopfield_arms_to_run and ("2hopfield", "MLP") not in contrasts
     )
 
     for k in k_values:
@@ -653,17 +696,19 @@ def main():
                     else 0.0
                 )
 
-            # One entry per declared contrast (these get stars).
+            # One entry per declared contrast (these get stars). With a
+            # single trial the runner reports NaN test statistics, which the
+            # print helpers render as n/a.
             for c in results.contrast_results():
                 key = f"{c.arm_a}-{c.arm_b}"
                 row[f"{key}_delta"] = c.mean_diff
                 row[f"{key}_se"] = c.se_diff
-                row[f"{key}_pval"] = c.p_value if args.n_trials >= 2 else float("nan")
-                row[f"{key}_sig"] = c.significant_at_05 if args.n_trials >= 2 else False
-                row[f"{key}_d"] = c.cohens_d if args.n_trials >= 2 else float("nan")
+                row[f"{key}_pval"] = c.p_value
+                row[f"{key}_sig"] = c.significant_at_05
+                row[f"{key}_d"] = c.cohens_d
 
-            # Reported-only descriptive total effect (only when BOTH hopfield
-            # variants run AND the second increment is the planned contrast).
+            # Reported-only descriptive total effect (only when 2hopfield's
+            # planned contrast is an increment rather than vs MLP).
             if report_descriptive_total:
                 d = results.delta("2hopfield", "MLP")
                 row["2hopfield-MLP_delta_descriptive"] = d.mean

--- a/examples/storkey_hopfield_demo.py
+++ b/examples/storkey_hopfield_demo.py
@@ -1,52 +1,75 @@
 """
-StorkeyHopfield vs MLP — Few-Shot Noise Robustness Demo
-========================================================
+StorkeyHopfield vs MLP — Depth, Few-Shot, and Noise-Robustness Demo
+====================================================================
 
-Demonstrates that the StorkeyHopfield attractor dynamics provide a
-statistically significant advantage over a vanilla MLP under data scarcity
-and input noise — conditions where memorized class prototypes and attractor
-denoising should help.
+Demonstrates that StorkeyHopfield behaves as a composable graph element in
+FabricPC: substituting one or more Linear hidden layers with StorkeyHopfield
+should produce cumulative accuracy gains under data scarcity and input noise,
+where memorized class prototypes and attractor denoising help.
 
-Architecture (same 4-node graph for both arms)::
+Architecture (same depth-4 graph across all arms, hidden width = 64)::
 
-    Hopfield: pixels(784) ──→ hidden(128,tanh) ──→ hopfield(128,tanh) ──→ output(10,softmax+CE)
-    MLP:      pixels(784) ──→ hidden(128,tanh) ──→ linear(128,tanh)   ──→ output(10,softmax+CE)
+    "MLP"        pixels(784) -> 64(Linear) -> 64(Linear)          -> 64(Linear)          -> 10(softmax+CE)
+    "1hopfield"  pixels(784) -> 64(Linear) -> 64(StorkeyHopfield) -> 64(Linear)          -> 10(softmax+CE)
+    "2hopfield"  pixels(784) -> 64(Linear) -> 64(StorkeyHopfield) -> 64(StorkeyHopfield) -> 10(softmax+CE)
+
+The first hidden layer is always Linear (the 784->64 feature-extraction
+projection — StorkeyHopfield is width-preserving and cannot reduce dimension).
+The classifier head is always Linear with Softmax + CrossEntropy energy.
+
+Hypothesis: a higher fraction of hidden layers converted from Linear to
+StorkeyHopfield produces cumulative accuracy gains under scarcity + noise.
+The MLP arm is the baseline; deltas are computed per (K, noise) cell against
+MLP.
 
 Experiment grid: K (shots per class) x noise_std
-    - K controls data scarcity: fewer examples -> more reliance on attractor memory
-    - noise_std controls input corruption: more noise -> more reliance on denoising
+    - K controls data scarcity: fewer examples -> more reliance on memory
+    - noise_std controls input corruption: more noise -> more reliance on
+      attractor denoising
 
-Hypothesis: Hopfield advantage (Delta accuracy) increases as K decreases
-and noise_std increases.
+Setup (one-time):
+    pip install tensorflow_datasets tensorflow-cpu
+    (`tensorflow-cpu` keeps TF off the GPU so it does not contend with JAX
+    for device memory; `tensorflow_datasets` is the dataset backend used by
+    `FashionMnistLoader` / `FewShotLoader`. Neither is currently declared
+    in pyproject.toml — should be added there in a follow-up.)
 
 Usage:
     python examples/storkey_hopfield_demo.py
-    python examples/storkey_hopfield_demo.py --k_values 10,50 --noise_levels 0.0,1.0 --n_trials 5
+    python examples/storkey_hopfield_demo.py --networks 1hopfield 2hopfield
+    python examples/storkey_hopfield_demo.py --networks 2hopfield --k_values 50,500 --noise_levels 0.0,2.0
     python examples/storkey_hopfield_demo.py --k_values 50 --noise_levels 0.0 --n_trials 2 --num_epochs 1
 
-Results:
-python examples/storkey_hopfield_demo.py --k_values 500 --noise_levels 2.0 --strength 2.0 --n_trials 5 --num_epochs 5
-     K    Noise    Hopfield Accuracy %         MLP Accuracy %     Delta%    p-value   Sig        d
----------------------------------------------------------------------------------------------------
-   500      2.0          64.80+/-0.28            59.70+/-0.27      +5.11      0.0000     *    13.434
----------------------------------------------------------------------------------------------------
+Results (Fashion-MNIST, --strength 2.0, --n_trials 10, --num_epochs 20)::
 
-python examples/storkey_hopfield_demo.py --k_values 5,10,20,50,100,500 --noise_levels 0.0,0.5,1.0,1.5,2.0 --strength 1.0 --n_trials 10 --num_epochs 5
-RESULTS SUMMARY (sweep K examples per class, Gaussian noise with std n):
-  Hopfield strength: 1.0
-  Trials: 10, Epochs: 5
-Delta Accuracy Heatmap (Hopfield - MLP, percentage points):
+    Delta Accuracy Heatmap (1hopfield - MLP, percentage points):
 
-     K  n=0.0  n=0.5  n=1.0  n=1.5  n=2.0
------------------------------------------
-     5  -1.2   -1.0   -0.7   -0.5   -0.4
-    10  -2.3   -1.9   -0.8   +0.1   +0.2
-    20  -0.5   -0.4   +0.5*  +1.3*  +2.1*
-    50  -0.4   -0.2   +0.7*  +1.8*  +2.5*
-   100  -0.4*  -0.2   +0.8*  +2.0*  +2.8*
-   500  +0.3   +0.7*  +1.7*  +3.1*  +4.3*
+         K  n=0.0  n=0.5  n=1.0  n=2.0
+    ----------------------------------
+        10  -1.7*  -0.9   +0.5   +2.8*
+        50  -0.2   +0.6   +3.0*  +7.6*
+       100  +0.1   +1.0*  +3.3*  +8.5*
+       500  -0.3   +0.8*  +3.2*  +7.2*
 
-  * = significant at p<0.05
+    Delta Accuracy Heatmap (2hopfield - MLP, percentage points):
+
+         K  n=0.0  n=0.5  n=1.0  n=2.0
+    ----------------------------------
+        10  -4.6*  -3.5*  -1.0   +3.4*
+        50  -0.4   +0.7*  +4.0* +10.5*
+       100  +0.3   +1.5*  +4.8* +11.6*
+       500  +0.8*  +2.4*  +5.9* +13.1*
+
+      * = significant at p<0.05
+
+The results support the hypothesis: more `Linear -> StorkeyHopfield`
+substitutions produce cumulative accuracy gains under data-abundance combined
+with input noise. The 2hopfield arm consistently beats the 1hopfield arm at
+K >= 50 and any nonzero noise, and the gap widens as noise grows (e.g.
+K=500, n=2.0: 1hopfield delta = +7.2 pp, 2hopfield delta = +13.1 pp — nearly
+double). At K=10 / no noise both Hopfield arms underperform MLP, as expected:
+with almost no data and no corruption, attractor memory has nothing to
+retrieve or denoise, so the extra Hopfield constraints only slow learning.
 """
 
 from jax_setup import set_jax_flags_before_importing_jax
@@ -54,11 +77,14 @@ from jax_setup import set_jax_flags_before_importing_jax
 set_jax_flags_before_importing_jax()
 
 import argparse
+import time
+from typing import Dict, List, Sequence
+
 import numpy as np
 import jax
 import optax
 
-from fabricpc.nodes import Linear, IdentityNode, StorkeyHopfield
+from fabricpc.nodes import Linear, IdentityNode, NodeBase, StorkeyHopfield
 from fabricpc.core.topology import Edge
 from fabricpc.graph_assembly import TaskMap, graph
 from fabricpc.graph_initialization import initialize_params
@@ -68,7 +94,7 @@ from fabricpc.core.energy import CrossEntropyEnergy
 from fabricpc.core.inference import InferenceSGD
 from fabricpc.core.initializers import XavierInitializer
 from fabricpc.training import train_pcn, evaluate_pcn
-from fabricpc.experiments import ExperimentArm, ABExperiment
+from fabricpc.experiments import ExperimentArm
 from fabricpc.experiments.statistics import paired_ttest, cohens_d
 from fabricpc.utils.data.dataloader import (
     FashionMnistLoader,
@@ -80,13 +106,30 @@ jax.config.update("jax_default_prng_impl", "threefry2x32")
 
 
 # ---------------------------------------------------------------------------
+# Architecture
+# ---------------------------------------------------------------------------
+
+BATCH_SIZE = 64
+HIDDEN_WIDTH = 64
+
+# Each entry lists the hidden-layer types between the input and the Linear
+# softmax readout. Position 0 must be Linear (784->HIDDEN_WIDTH projection);
+# StorkeyHopfield is width-preserving and cannot reduce dimension.
+ARCH_CONFIGS: Dict[str, List[str]] = {
+    "MLP": ["Linear", "Linear", "Linear"],
+    "1hopfield": ["Linear", "StorkeyHopfield", "Linear"],
+    "2hopfield": ["Linear", "StorkeyHopfield", "StorkeyHopfield"],
+}
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Few-Shot + Noise: Storkey Hopfield vs MLP on Fashion-MNIST"
+        description="Depth + Few-Shot + Noise: StorkeyHopfield as a composable graph element on Fashion-MNIST"
     )
     parser.add_argument(
         "--k_values",
@@ -104,7 +147,7 @@ def parse_args():
         "--n_trials",
         type=int,
         default=5,
-        help="Number of paired trials per condition (default: 10)",
+        help="Number of paired trials per condition (default: 5)",
     )
     parser.add_argument(
         "--num_epochs",
@@ -119,15 +162,15 @@ def parse_args():
         help="Hopfield strength: float >=0 or 'None' for learnable (default: 2.0)",
     )
     parser.add_argument(
-        "--all_hopfield",
-        action="store_true",
-        default=False,
+        "--networks",
+        nargs="+",
+        type=str,
+        default=["1hopfield", "2hopfield"],
+        choices=["1hopfield", "2hopfield"],
         help=(
-            "Fully-Hopfield MLP: run a Hopfield hidden layer at input width (784) "
-            "with no entry projection (only the Linear softmax head remains), "
-            "compared vs a vanilla MLP of the same shape. Default (off) reproduces "
-            "the original single-Hopfield-node architecture (784->128(Linear)->"
-            "128(StorkeyHopfield)->10)."
+            "Which Hopfield-substituted variants to compare against the MLP "
+            "baseline. MLP is always included implicitly. "
+            "Default: 1hopfield 2hopfield."
         ),
     )
     parser.add_argument(
@@ -140,67 +183,61 @@ def parse_args():
 
 
 # ---------------------------------------------------------------------------
-# Model Factories
+# Model Factory
 # ---------------------------------------------------------------------------
 
-BATCH_SIZE = 64
 
+def make_model_factory(
+    layer_types: Sequence[str],
+    hopfield_strength,
+    width: int = HIDDEN_WIDTH,
+):
+    """Return a model_factory(rng_key) for a classifier with a heterogeneous
+    hidden stack defined by ``layer_types``.
 
-def make_model_factory(hidden_type, width, depth, hopfield_strength):
-    """Return a model_factory(rng_key) for a classifier whose hidden stack is
-    either all StorkeyHopfield ('hopfield') or all Linear ('linear') nodes.
+    Architecture (depth-3 hidden + readout):
+        pixels(784) -> hidden0(width) -> hidden1(width) -> hidden2(width) -> class(10)
 
-    StorkeyHopfield is width-preserving (square W), so a Linear entry projection
-    (784 -> width) is inserted only when width != 784. The output is always a
-    Linear softmax + CrossEntropy head -- the classifier readout (an output node,
-    not a hidden node), so "all hidden nodes Hopfield" still holds when
-    hidden_type == 'hopfield'.
+    Each hidden layer is either Linear(tanh) or StorkeyHopfield, per the
+    corresponding entry of layer_types. Position 0 must be Linear because
+    StorkeyHopfield is width-preserving (square W, in_dim == out_dim) and
+    cannot perform the 784->width projection.
 
-    Reproduces the original demo arms when (width=128, depth=1):
-        'hopfield' -> pixels(784) -> entry(128,Linear) -> hidden0(128,SH) -> class(10)
-        'linear'   -> pixels(784) -> entry(128,Linear) -> hidden0(128,Linear) -> class(10)
-    Fully-Hopfield arm when (width=784, depth=1):
-        'hopfield' -> pixels(784) -> hidden0(784,SH) -> class(10)   (no entry projection)
+    The classifier head is always Linear with Softmax + CrossEntropy energy.
     """
 
     def create_model(rng_key):
         pixels = IdentityNode(shape=(784,), name="pixels")
-        nodes = [pixels]
-        edges = []
-        prev = pixels
+        # Annotate as List[NodeBase] so Pylance allows appending Linear /
+        # StorkeyHopfield / etc. without inferring the narrower IdentityNode
+        # type from the initial single-element list.
+        nodes: List[NodeBase] = [pixels]
+        edges: List[Edge] = []
+        prev: NodeBase = pixels
 
-        # Entry projection only needed to change width into the hidden stack.
-        if width != 784:
-            entry = Linear(
-                shape=(width,),
-                activation=TanhActivation(),
-                name="entry",
-                weight_init=XavierInitializer(),
-            )
-            nodes.append(entry)
-            edges.append(Edge(source=prev, target=entry.slot("in")))
-            prev = entry
-
-        # Hidden stack: all StorkeyHopfield or all Linear, at constant width.
-        for i in range(depth):
-            if hidden_type == "hopfield":
-                hidden = StorkeyHopfield(
+        for i, ltype in enumerate(layer_types):
+            if ltype == "StorkeyHopfield":
+                layer = StorkeyHopfield(
                     shape=(width,),
                     name=f"hidden{i}",
                     hopfield_strength=hopfield_strength,
                 )
-            else:
-                hidden = Linear(
+            elif ltype == "Linear":
+                layer = Linear(
                     shape=(width,),
                     activation=TanhActivation(),
                     name=f"hidden{i}",
                     weight_init=XavierInitializer(),
                 )
-            nodes.append(hidden)
-            edges.append(Edge(source=prev, target=hidden.slot("in")))
-            prev = hidden
+            else:
+                raise ValueError(
+                    f"Unknown layer type {ltype!r} at position {i}; "
+                    "expected 'Linear' or 'StorkeyHopfield'."
+                )
+            nodes.append(layer)
+            edges.append(Edge(source=prev, target=layer.slot("in")))
+            prev = layer
 
-        # Linear softmax classifier head (output node, not a hidden node).
         output = Linear(
             shape=(10,),
             activation=SoftmaxActivation(),
@@ -223,13 +260,11 @@ def make_model_factory(hidden_type, width, depth, hopfield_strength):
     return create_model
 
 
-def arch_str(hidden_type, width, depth):
+def arch_str(layer_types: Sequence[str], width: int = HIDDEN_WIDTH) -> str:
     """Human-readable architecture string for the header print."""
     parts = ["784"]
-    if width != 784:
-        parts.append(f"{width}(Linear, tanh)")
-    node = "StorkeyHopfield" if hidden_type == "hopfield" else "Linear"
-    for _ in range(depth):
+    for ltype in layer_types:
+        node = "StorkeyHopfield" if ltype == "StorkeyHopfield" else "Linear"
         parts.append(f"{width}({node}, tanh)")
     parts.append("10(softmax, CE)")
     return " -> ".join(parts)
@@ -241,16 +276,13 @@ def arch_str(hidden_type, width, depth):
 
 
 def make_data_factory(k_per_class, noise_std, batch_size):
-    """Return a data_loader_factory(seed) for ABExperiment.
+    """Return a data_loader_factory(seed) for the multi-arm trial loop.
 
-    Both arms receive identical training data (same K-shot subsample)
-    and identical test noise within a trial.
-
-    Seeds are domain-separated: the K-shot subsample is a function of
-    the trial seed only (so the same training data is reused across
-    noise_levels for a clean isolation of the noise effect), while the
-    test-noise seed mixes (trial, noise_std) so different noise levels
-    draw independent realizations rather than rescaled copies of one
+    Each trial seed produces a deterministic K-shot subsample (function of
+    trial seed only) and an independent test-noise realization (function of
+    trial seed and noise_std). Identical training data is reused across noise
+    levels for a clean isolation of the noise effect, while different noise
+    levels draw independent realizations rather than rescaled copies of one
     shared noise stream.
     """
     # Stable integer fingerprint of noise_std used as RNG entropy.
@@ -294,6 +326,84 @@ def make_data_factory(k_per_class, noise_std, batch_size):
 
 
 # ---------------------------------------------------------------------------
+# Multi-Arm Trial Runner
+# ---------------------------------------------------------------------------
+
+
+def run_multi_arm_trials(
+    arms: List[ExperimentArm],
+    data_factory,
+    n_trials: int,
+    metric: str = "accuracy",
+    seed_offset: int = 0,
+    verbose: bool = False,
+) -> Dict[str, np.ndarray]:
+    """Run every arm across n_trials paired trials.
+
+    Each trial uses one seed for both the data factory (same K-shot subsample
+    and noise realization across arms) and the model RNG key (same init key
+    across arms — different structures still produce different weights, but
+    the source of randomness is paired). The chosen ``metric`` is collected
+    per arm per trial.
+
+    This replaces ``ABExperiment`` because we now have more than two arms
+    (MLP + 1hopfield + 2hopfield) and want one shared MLP training per trial,
+    not one MLP training per Hopfield comparison.
+
+    Returns a dict mapping ``arm.name -> np.ndarray`` of per-trial metric
+    values (length n_trials).
+    """
+    per_arm_metrics: Dict[str, List[float]] = {arm.name: [] for arm in arms}
+
+    for trial_idx in range(n_trials):
+        trial_seed = seed_offset + trial_idx * 1000
+        print(f"--- Trial {trial_idx + 1}/{n_trials} (seed={trial_seed}) ---")
+
+        train_loader, test_loader = data_factory(trial_seed)
+
+        for arm in arms:
+            master_key = jax.random.PRNGKey(trial_seed)
+            graph_key, train_key, eval_key = jax.random.split(master_key, 3)
+
+            params, structure = arm.model_factory(graph_key)
+
+            t0 = time.time()
+            trained_params, _, _ = arm.train_fn(
+                params,
+                structure,
+                train_loader,
+                arm.optimizer,
+                arm.train_config,
+                train_key,
+                verbose=verbose,
+            )
+            train_time = time.time() - t0
+
+            metrics = arm.eval_fn(
+                trained_params,
+                structure,
+                test_loader,
+                arm.train_config,
+                eval_key,
+            )
+
+            if metric not in metrics:
+                available = ", ".join(sorted(metrics.keys()))
+                raise KeyError(
+                    f"Metric '{metric}' not found in eval results for arm "
+                    f"'{arm.name}'. Available: {available}"
+                )
+            value = float(metrics[metric])
+            per_arm_metrics[arm.name].append(value)
+            print(
+                f"  {arm.name:<10}: {metric}={value:.4f}  "
+                f"(train: {train_time:.1f}s)"
+            )
+
+    return {name: np.asarray(vals) for name, vals in per_arm_metrics.items()}
+
+
+# ---------------------------------------------------------------------------
 # Main Experiment
 # ---------------------------------------------------------------------------
 
@@ -316,175 +426,174 @@ def main():
         "learnable" if hopfield_strength is None else f"{hopfield_strength}"
     )
 
-    # Architecture: --all_hopfield runs the Hopfield layer at input width (784)
-    # with no entry projection (fully-Hopfield MLP); default keeps the original
-    # 128-width single-Hopfield-node architecture.
-    hidden_width = 784 if args.all_hopfield else 128
-    hidden_depth = 1
+    # MLP is always the baseline. argparse de-duplication: keep input order.
+    seen = set()
+    hopfield_arms_to_run: List[str] = []
+    for name in args.networks:
+        if name not in seen:
+            seen.add(name)
+            hopfield_arms_to_run.append(name)
+    arm_names_in_run: List[str] = ["MLP"] + hopfield_arms_to_run
 
-    title = (
-        "Fully-Hopfield MLP vs vanilla MLP"
-        if args.all_hopfield
-        else "Few-Shot + Noise Robustness: StorkeyHopfield vs MLP"
-    )
+    def build_arm(arm_name: str) -> ExperimentArm:
+        return ExperimentArm(
+            name=arm_name,
+            model_factory=make_model_factory(
+                ARCH_CONFIGS[arm_name], hopfield_strength, HIDDEN_WIDTH
+            ),
+            train_fn=train_pcn,
+            eval_fn=evaluate_pcn,
+            optimizer=optimizer,
+            train_config=train_config,
+        )
 
-    print("=" * 70)
-    print(title)
-    print("=" * 70)
+    arms = [build_arm(name) for name in arm_names_in_run]
+
+    print("=" * 78)
+    print("StorkeyHopfield depth comparison: composable graph element on Fashion-MNIST")
+    print("=" * 78)
     print("Dataset: Fashion-MNIST")
-    print(f"Hopfield: {arch_str('hopfield', hidden_width, hidden_depth)}")
-    print(f"MLP:      {arch_str('linear', hidden_width, hidden_depth)}")
+    for name in arm_names_in_run:
+        print(f"  {name:<10}: {arch_str(ARCH_CONFIGS[name], HIDDEN_WIDTH)}")
     print(f"Hopfield strength: {strength_label}")
     print(f"Epochs per trial: {args.num_epochs}")
     print(f"Trials per condition: {args.n_trials}")
-    print(f"K values (numer of examples per class): {k_values}")
+    print(f"K values (number of examples per class): {k_values}")
     print(f"Noise levels (std dev): {noise_levels}")
     print()
 
-    arm_hop = ExperimentArm(
-        name="Hopfield",
-        model_factory=make_model_factory(
-            "hopfield", hidden_width, hidden_depth, hopfield_strength
-        ),
-        train_fn=train_pcn,
-        eval_fn=evaluate_pcn,
-        optimizer=optimizer,
-        train_config=train_config,
-    )
-
-    arm_mlp = ExperimentArm(
-        name="MLP",
-        model_factory=make_model_factory(
-            "linear", hidden_width, hidden_depth, hopfield_strength
-        ),
-        train_fn=train_pcn,
-        eval_fn=evaluate_pcn,
-        optimizer=optimizer,
-        train_config=train_config,
-    )
-
-    # Collect results across the K x noise grid
-    grid_results = []
+    # Collect results across the K x noise grid.
+    grid_results: List[Dict] = []
 
     for k in k_values:
         for noise_std in noise_levels:
-            print(f"\n{'='*70}")
+            print(f"\n{'='*78}")
             print(f"  K={k} shots/class, noise_std={noise_std}")
-            print(f"{'='*70}")
+            print(f"{'='*78}")
 
             data_factory = make_data_factory(k, noise_std, BATCH_SIZE)
 
-            experiment = ABExperiment(
-                arm_a=arm_hop,
-                arm_b=arm_mlp,
-                metric="accuracy",
-                data_loader_factory=data_factory,
+            metrics_by_arm = run_multi_arm_trials(
+                arms=arms,
+                data_factory=data_factory,
                 n_trials=args.n_trials,
+                metric="accuracy",
                 verbose=args.verbose,
             )
 
-            result = experiment.run()
+            row: Dict = {"k": k, "noise": noise_std}
+            mlp_acc = metrics_by_arm["MLP"]
+            row["MLP_mean"] = float(np.mean(mlp_acc))
+            row["MLP_se"] = (
+                float(np.std(mlp_acc, ddof=1) / np.sqrt(len(mlp_acc)))
+                if len(mlp_acc) > 1
+                else 0.0
+            )
 
-            hop_acc = result.arm_a_metrics
-            mlp_acc = result.arm_b_metrics
-            delta = hop_acc - mlp_acc
-
-            row = {
-                "k": k,
-                "noise": noise_std,
-                "hop_mean": float(np.mean(hop_acc)),
-                "hop_se": (
-                    float(np.std(hop_acc, ddof=1) / np.sqrt(len(hop_acc)))
-                    if len(hop_acc) > 1
+            for arm_name in hopfield_arms_to_run:
+                arm_acc = metrics_by_arm[arm_name]
+                delta = arm_acc - mlp_acc
+                row[f"{arm_name}_mean"] = float(np.mean(arm_acc))
+                row[f"{arm_name}_se"] = (
+                    float(np.std(arm_acc, ddof=1) / np.sqrt(len(arm_acc)))
+                    if len(arm_acc) > 1
                     else 0.0
-                ),
-                "mlp_mean": float(np.mean(mlp_acc)),
-                "mlp_se": (
-                    float(np.std(mlp_acc, ddof=1) / np.sqrt(len(mlp_acc)))
-                    if len(mlp_acc) > 1
-                    else 0.0
-                ),
-                "delta_mean": float(np.mean(delta)),
-            }
-
-            if args.n_trials >= 2:
-                ttest = paired_ttest(hop_acc, mlp_acc)
-                effect = cohens_d(hop_acc, mlp_acc)
-                row["p_value"] = ttest.p_value
-                row["significant"] = ttest.significant_at_05
-                row["cohens_d"] = effect.d
-            else:
-                row["p_value"] = float("nan")
-                row["significant"] = False
-                row["cohens_d"] = float("nan")
+                )
+                row[f"{arm_name}_delta"] = float(np.mean(delta))
+                if args.n_trials >= 2:
+                    ttest = paired_ttest(arm_acc, mlp_acc)
+                    effect = cohens_d(arm_acc, mlp_acc)
+                    row[f"{arm_name}_pval"] = ttest.p_value
+                    row[f"{arm_name}_sig"] = ttest.significant_at_05
+                    row[f"{arm_name}_d"] = effect.d
+                else:
+                    row[f"{arm_name}_pval"] = float("nan")
+                    row[f"{arm_name}_sig"] = False
+                    row[f"{arm_name}_d"] = float("nan")
 
             grid_results.append(row)
 
-            print(
-                f"  -> Hopfield: {row['hop_mean']*100:.2f}%  "
-                f"MLP: {row['mlp_mean']*100:.2f}%  "
-                f"Delta: {row['delta_mean']*100:+.2f}%  "
-                f"p={row['p_value']:.4f}"
-            )
+            print("  Cell summary:")
+            print(f"    MLP       : {row['MLP_mean']*100:.2f}%")
+            for arm_name in hopfield_arms_to_run:
+                p = row[f"{arm_name}_pval"]
+                p_str = "p=n/a" if np.isnan(p) else f"p={p:.4f}"
+                print(
+                    f"    {arm_name:<10}: {row[f'{arm_name}_mean']*100:.2f}%  "
+                    f"Delta={row[f'{arm_name}_delta']*100:+.2f}%  {p_str}"
+                )
 
-    # ---------------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Summary Tables
-    # ---------------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     print("\n\n")
-    print("=" * 70)
+    print("=" * 78)
     print("RESULTS SUMMARY")
-    print("=" * 70)
+    print("=" * 78)
     print(f"  Hopfield strength: {strength_label}")
     print(f"  Trials: {args.n_trials}, Epochs: {args.num_epochs}")
     print()
 
-    # Per-condition table
-    header = f"{'K':>6} {'Noise':>8} {'Hopfield%':>12} {'MLP%':>12} {'Delta%':>10} {'p-value':>10} {'Sig':>5} {'d':>8}"
+    # Per-condition table: MLP and each Hopfield arm side by side.
+    cols = [f"{'K':>5}", f"{'Noise':>6}", f"{'MLP%':>13}"]
+    for arm_name in hopfield_arms_to_run:
+        cols.append(f"{arm_name + '%':>14}")
+        cols.append(f"{'Delta':>7}")
+        cols.append(f"{'p':>8}")
+        cols.append(f"{'sig':>4}")
+        cols.append(f"{'d':>7}")
+    header = " ".join(cols)
     print(header)
     print("-" * len(header))
     for r in grid_results:
-        hop_str = f"{r['hop_mean']*100:.2f}+/-{r['hop_se']*100:.2f}"
-        mlp_str = f"{r['mlp_mean']*100:.2f}+/-{r['mlp_se']*100:.2f}"
-        delta_str = f"{r['delta_mean']*100:+.2f}"
-        p_str = f"{r['p_value']:.4f}" if not np.isnan(r["p_value"]) else "n/a"
-        sig_str = "*" if r["significant"] else ""
-        d_str = f"{r['cohens_d']:.3f}" if not np.isnan(r["cohens_d"]) else "n/a"
-        print(
-            f"{r['k']:>6} {r['noise']:>8.1f} {hop_str:>12} {mlp_str:>12} "
-            f"{delta_str:>10} {p_str:>10} {sig_str:>5} {d_str:>8}"
-        )
+        parts = [
+            f"{r['k']:>5}",
+            f"{r['noise']:>6.1f}",
+            f"{r['MLP_mean']*100:6.2f}+/-{r['MLP_se']*100:.2f}",
+        ]
+        for arm_name in hopfield_arms_to_run:
+            parts.append(
+                f"{r[f'{arm_name}_mean']*100:6.2f}+/-{r[f'{arm_name}_se']*100:.2f}"
+            )
+            parts.append(f"{r[f'{arm_name}_delta']*100:+6.2f}")
+            p = r[f"{arm_name}_pval"]
+            parts.append(f"{p:8.4f}" if not np.isnan(p) else f"{'n/a':>8}")
+            parts.append(f"{'*' if r[f'{arm_name}_sig'] else '':>4}")
+            d = r[f"{arm_name}_d"]
+            parts.append(f"{d:7.3f}" if not np.isnan(d) else f"{'n/a':>7}")
+        print(" ".join(parts))
     print("-" * len(header))
 
-    # Delta heatmap (K x noise)
+    # Delta heatmap (K x noise), one block per Hopfield arm.
     if len(k_values) > 1 and len(noise_levels) > 1:
-        print()
-        print("Delta Accuracy Heatmap (Hopfield - MLP, percentage points):")
-        print()
-
-        # Header row: noise levels
-        noise_header = f"{'K':>6}" + "".join(f"  n={n:.1f}" for n in noise_levels)
-        print(noise_header)
-        print("-" * len(noise_header))
-
-        for k in k_values:
-            row_str = f"{k:>6}"
-            for noise_std in noise_levels:
-                match = [
-                    r for r in grid_results if r["k"] == k and r["noise"] == noise_std
-                ]
-                if match:
-                    d = match[0]["delta_mean"] * 100
-                    sig = "*" if match[0]["significant"] else " "
-                    row_str += f" {d:+5.1f}{sig}"
-                else:
-                    row_str += "    n/a"
-            print(row_str)
-        print()
+        for arm_name in hopfield_arms_to_run:
+            print()
+            print(f"Delta Accuracy Heatmap ({arm_name} - MLP, percentage points):")
+            print()
+            noise_header = f"{'K':>6}" + "".join(f"  n={n:.1f}" for n in noise_levels)
+            print(noise_header)
+            print("-" * len(noise_header))
+            for k in k_values:
+                row_str = f"{k:>6}"
+                for noise_std in noise_levels:
+                    match = [
+                        r
+                        for r in grid_results
+                        if r["k"] == k and r["noise"] == noise_std
+                    ]
+                    if match:
+                        d = match[0][f"{arm_name}_delta"] * 100
+                        sig = "*" if match[0][f"{arm_name}_sig"] else " "
+                        row_str += f" {d:+5.1f}{sig}"
+                    else:
+                        row_str += "    n/a"
+                print(row_str)
+            print()
         print("  * = significant at p<0.05")
 
     print()
-    print("=" * 70)
+    print("=" * 78)
 
 
 if __name__ == "__main__":

--- a/fabricpc/experiments/__init__.py
+++ b/fabricpc/experiments/__init__.py
@@ -1,6 +1,15 @@
 """Reusable experiment harnesses for comparing training methods and architectures."""
 
-from fabricpc.experiments.ab_experiment import ExperimentArm, ABExperiment, ABResults
+from fabricpc.experiments.ab_experiment import (
+    ExperimentArm,
+    TrialResult,
+    ABExperiment,
+    ABResults,
+    PlannedMultiContrastExperiment,
+    PlannedMultiContrastResults,
+    ContrastResult,
+    DescriptiveDelta,
+)
 from fabricpc.experiments.statistics import (
     paired_ttest,
     cohens_d,
@@ -10,8 +19,13 @@ from fabricpc.experiments.statistics import (
 
 __all__ = [
     "ExperimentArm",
+    "TrialResult",
     "ABExperiment",
     "ABResults",
+    "PlannedMultiContrastExperiment",
+    "PlannedMultiContrastResults",
+    "ContrastResult",
+    "DescriptiveDelta",
     "paired_ttest",
     "cohens_d",
     "estimate_required_n",

--- a/fabricpc/experiments/ab_experiment.py
+++ b/fabricpc/experiments/ab_experiment.py
@@ -1,36 +1,48 @@
 """A/B experiment harness for comparing training methods and architectures.
 
-Provides a reusable framework for running paired statistical comparisons
-between two training configurations (different architectures, different
+Provides reusable framework for running paired statistical comparisons
+across two or more training configurations (different architectures, different
 training algorithms, or both).
 
-Example::
+Two public runners are provided:
+
+- :class:`PlannedMultiContrastExperiment` — N arms with constructor-declared
+  planned contrasts. The single source of truth for the per-trial training
+  loop. Each trial builds loaders once via the user-supplied factory and
+  calls ``reset()`` on them before every arm, so every arm sees the same
+  minibatch stream — paired in both data subsample/noise AND in batch order.
+- :class:`ABExperiment` — a thin 2-arm wrapper that delegates entirely to
+  ``PlannedMultiContrastExperiment``. Preserves the historical
+  ``arm_a``/``arm_b`` / ``ABResults`` API so existing callers (the four
+  example files in ``examples/``) keep working unchanged.
+
+Example (multi-arm, planned-contrast)::
+
+    from fabricpc.experiments import (
+        ExperimentArm, PlannedMultiContrastExperiment,
+    )
+
+    runner = PlannedMultiContrastExperiment(
+        arms=[arm_mlp, arm_1hopfield, arm_2hopfield],
+        contrasts=[("1hopfield", "MLP"), ("2hopfield", "1hopfield")],
+        metric="accuracy",
+        data_loader_factory=make_loaders,
+        n_trials=10,
+    )
+    results = runner.run()
+    for c in results.contrast_results():
+        print(c.arm_a, c.arm_b, c.mean_diff, c.p_value, c.cohens_d)
+    # Reported-only delta (descriptive, not in the contrast family):
+    total = results.delta("2hopfield", "MLP")
+    print(total.mean, total.se)
+
+Example (2-arm, legacy ABExperiment, unchanged from before)::
 
     from fabricpc.experiments import ExperimentArm, ABExperiment
-    import optax
-
-    optimizer = optax.adam(1e-3)
-
-    arm_a = ExperimentArm(
-        name="Lateral",
-        model_factory=create_lateral_model,
-        train_fn=train_pcn,
-        eval_fn=evaluate_pcn,
-        optimizer=optimizer,
-        train_config=pc_config,
-    )
-    arm_b = ExperimentArm(
-        name="MLP",
-        model_factory=create_mlp_model,
-        train_fn=train_pcn,
-        eval_fn=evaluate_pcn,
-        optimizer=optimizer,
-        train_config=pc_config,
-    )
 
     experiment = ABExperiment(
-        arm_a=arm_a,
-        arm_b=arm_b,
+        arm_a=arm_lateral,
+        arm_b=arm_mlp,
         metric="accuracy",
         data_loader_factory=make_loaders,
         n_trials=10,
@@ -65,10 +77,11 @@ DataLoaderFactory = Callable[
 
 @dataclass(frozen=True)
 class ExperimentArm:
-    """One arm (condition) of an A/B experiment.
+    """One arm (condition) of an experiment.
 
     Args:
-        name: Human-readable name for this arm (e.g., "PC-sigmoid").
+        name: Human-readable name for this arm (e.g., "PC-sigmoid"). Must be
+            unique within a single experiment's arms list.
         model_factory: Callable taking a JAX rng_key and returning
             (GraphParams, GraphStructure). Called fresh each trial.
         train_fn: Training function with signature matching train_pcn.
@@ -94,12 +107,325 @@ class TrialResult:
     all_metrics: Dict[str, float]
 
 
+# ---------------------------------------------------------------------------
+# Multi-arm, planned-contrast runner (single source of truth)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ContrastResult:
+    """Statistics for one declared planned contrast (``arm_a - arm_b``).
+
+    The mean and SE are computed on the per-trial difference vector (paired
+    design), so the SE is the SE of the paired difference (not the SE of an
+    unpaired delta-of-means). The t-test and Cohen's d are likewise paired.
+    """
+
+    arm_a: str
+    arm_b: str
+    mean_diff: float
+    se_diff: float
+    t_statistic: float
+    p_value: float
+    significant_at_05: bool
+    cohens_d: float
+    n: int
+
+
+@dataclass
+class DescriptiveDelta:
+    """Descriptive statistics for a reported-only paired delta.
+
+    Returned by :meth:`PlannedMultiContrastResults.delta` for arm pairs that
+    are NOT in the declared contrast family. Carries no test (no p-value, no
+    significance flag, no Cohen's d) so it cannot be confused with a planned
+    contrast at read sites.
+    """
+
+    arm_a: str
+    arm_b: str
+    mean: float
+    std: float
+    se: float
+    n: int
+
+
+@dataclass
+class PlannedMultiContrastResults:
+    """Results from a completed :class:`PlannedMultiContrastExperiment`.
+
+    Carries per-arm per-trial metric values plus one :class:`ContrastResult`
+    for each contrast declared at construction. Reported-only deltas (any arm
+    pair NOT in the declared contrast family) are available via
+    :meth:`delta`, which returns descriptive statistics with no test attached.
+    """
+
+    arm_names: List[str]
+    contrasts: List[Tuple[str, str]]
+    metric: str
+    n_trials: int
+    per_arm_trials: Dict[str, List[TrialResult]]
+    seeds: List[int]
+    total_time: float
+    num_epochs: int
+
+    def per_arm_metrics(self, arm_name: str) -> np.ndarray:
+        """Per-trial metric values for one arm (length n_trials)."""
+        if arm_name not in self.per_arm_trials:
+            raise KeyError(
+                f"Unknown arm name {arm_name!r}; "
+                f"available: {sorted(self.per_arm_trials.keys())}"
+            )
+        return np.array([t.metric_value for t in self.per_arm_trials[arm_name]])
+
+    def per_arm_times(self, arm_name: str) -> np.ndarray:
+        if arm_name not in self.per_arm_trials:
+            raise KeyError(
+                f"Unknown arm name {arm_name!r}; "
+                f"available: {sorted(self.per_arm_trials.keys())}"
+            )
+        return np.array([t.train_time for t in self.per_arm_trials[arm_name]])
+
+    def contrast_results(self) -> List[ContrastResult]:
+        """One :class:`ContrastResult` per declared contrast, in declaration
+        order. Each contrast is a two-sided paired t-test on the per-trial
+        difference vector, plus paired Cohen's d."""
+        out: List[ContrastResult] = []
+        for a, b in self.contrasts:
+            a_vals = self.per_arm_metrics(a)
+            b_vals = self.per_arm_metrics(b)
+            diff = a_vals - b_vals
+            ttest = paired_ttest(a_vals, b_vals)
+            effect = cohens_d(a_vals, b_vals)
+            mean_diff = float(np.mean(diff))
+            se_diff = (
+                float(np.std(diff, ddof=1) / np.sqrt(len(diff)))
+                if len(diff) > 1
+                else 0.0
+            )
+            out.append(
+                ContrastResult(
+                    arm_a=a,
+                    arm_b=b,
+                    mean_diff=mean_diff,
+                    se_diff=se_diff,
+                    t_statistic=ttest.t_statistic,
+                    p_value=ttest.p_value,
+                    significant_at_05=ttest.significant_at_05,
+                    cohens_d=effect.d,
+                    n=len(diff),
+                )
+            )
+        return out
+
+    def delta(self, arm_a: str, arm_b: str) -> DescriptiveDelta:
+        """Descriptive statistics for ``arm_a - arm_b`` over per-trial
+        differences. No t-test, no Cohen's d — use this for reported-only
+        deltas that are NOT in the declared planned-contrast family. The
+        deliberately narrower return type makes it impossible to misread a
+        reported-only delta as a tested contrast."""
+        a_vals = self.per_arm_metrics(arm_a)
+        b_vals = self.per_arm_metrics(arm_b)
+        diff = a_vals - b_vals
+        n = len(diff)
+        mean = float(np.mean(diff))
+        std = float(np.std(diff, ddof=1)) if n > 1 else 0.0
+        se = std / np.sqrt(n) if n > 1 else 0.0
+        return DescriptiveDelta(
+            arm_a=arm_a, arm_b=arm_b, mean=mean, std=std, se=se, n=n
+        )
+
+
+def _reset_loader_if_supported(loader: Any) -> None:
+    """Call ``loader.reset()`` if it exists, no-op otherwise.
+
+    Loaders in ``fabricpc.utils.data.dataloader`` implement ``reset()`` so
+    that multi-arm experiments can replay the identical batch stream across
+    arms. User-supplied loaders without a ``reset()`` are silently tolerated
+    so that legacy callers keep working (with the caveat that an arm-order
+    dependence will leak in if their iteration is stateful).
+    """
+    if hasattr(loader, "reset"):
+        loader.reset()
+
+
+class PlannedMultiContrastExperiment:
+    """Runner for paired N-arm experiments with constructor-declared contrasts.
+
+    Each trial:
+      1. Builds train/test loaders once via ``data_loader_factory(trial_seed)``.
+      2. For each arm in ``arms``: calls ``reset()`` on both loaders (so every
+         arm replays the identical batch stream), trains a fresh model, and
+         evaluates it.
+
+    The shared per-trial seed is also used as the model RNG seed for every
+    arm, so the source of model-init randomness is paired across arms (the
+    architectures differ, so the resulting weights differ; only the seed is
+    shared).
+
+    Args:
+        arms: Arms to run, each evaluated once per trial.
+        contrasts: List of ``(arm_a_name, arm_b_name)`` pairs declaring the
+            planned-contrast family. Each contrast is a two-sided paired
+            t-test on the per-trial difference vector. Every name must
+            reference an arm in ``arms``.
+        metric: Key in each arm's eval-result dict to compare
+            (e.g. ``"accuracy"``, ``"perplexity"``).
+        data_loader_factory: Callable ``seed -> (train_loader, test_loader)``.
+            The returned loaders should expose ``reset()`` for proper pairing;
+            loaders without it are tolerated but lose the cross-arm
+            batch-stream guarantee.
+        n_trials: Number of independent paired trials.
+        seed_offset: Base seed offset. Trial i uses
+            ``seed = seed_offset + i * 1000``.
+        verbose: If True, forward verbose=True to each arm's train_fn.
+    """
+
+    def __init__(
+        self,
+        arms: List[ExperimentArm],
+        contrasts: List[Tuple[str, str]],
+        metric: str,
+        data_loader_factory: DataLoaderFactory,
+        n_trials: int = 10,
+        seed_offset: int = 0,
+        verbose: bool = False,
+    ):
+        if len(arms) < 1:
+            raise ValueError("arms must contain at least one ExperimentArm.")
+
+        arm_names = [a.name for a in arms]
+        if len(set(arm_names)) != len(arm_names):
+            duplicates = sorted({n for n in arm_names if arm_names.count(n) > 1})
+            raise ValueError(
+                f"Arm names must be unique within an experiment. Duplicates: {duplicates}"
+            )
+
+        name_set = set(arm_names)
+        for a, b in contrasts:
+            if a not in name_set:
+                raise ValueError(
+                    f"Contrast references unknown arm {a!r}; "
+                    f"available arms: {sorted(name_set)}"
+                )
+            if b not in name_set:
+                raise ValueError(
+                    f"Contrast references unknown arm {b!r}; "
+                    f"available arms: {sorted(name_set)}"
+                )
+
+        self.arms = list(arms)
+        self.contrasts = list(contrasts)
+        self.metric = metric
+        self.data_loader_factory = data_loader_factory
+        self.n_trials = n_trials
+        self.seed_offset = seed_offset
+        self.verbose = verbose
+
+    def _run_arm_trial(
+        self,
+        arm: ExperimentArm,
+        trial_seed: int,
+        train_loader: Any,
+        test_loader: Any,
+    ) -> TrialResult:
+        """Run a single trial for one arm. The caller is responsible for
+        having reset the loaders, so this method does not reset them itself."""
+        master_key = jax.random.PRNGKey(trial_seed)
+        graph_key, train_key, eval_key = jax.random.split(master_key, 3)
+
+        params, structure = arm.model_factory(graph_key)
+
+        t0 = time.time()
+        trained_params, _, _ = arm.train_fn(
+            params,
+            structure,
+            train_loader,
+            arm.optimizer,
+            arm.train_config,
+            train_key,
+            verbose=self.verbose,
+        )
+        train_time = time.time() - t0
+
+        metrics = arm.eval_fn(
+            trained_params,
+            structure,
+            test_loader,
+            arm.train_config,
+            eval_key,
+        )
+
+        if self.metric not in metrics:
+            available = ", ".join(sorted(metrics.keys()))
+            raise KeyError(
+                f"Metric '{self.metric}' not found in eval results for arm "
+                f"'{arm.name}'. Available: {available}"
+            )
+
+        return TrialResult(
+            metric_value=float(metrics[self.metric]),
+            train_time=train_time,
+            all_metrics={k: float(v) for k, v in metrics.items()},
+        )
+
+    def run(self) -> PlannedMultiContrastResults:
+        """Execute all trials for all arms. Returns
+        :class:`PlannedMultiContrastResults`."""
+        per_arm_trials: Dict[str, List[TrialResult]] = {a.name: [] for a in self.arms}
+        seeds: List[int] = []
+
+        num_epochs = self.arms[0].train_config.get("num_epochs", 1)
+        total_start = time.time()
+
+        for trial_idx in range(self.n_trials):
+            trial_seed = self.seed_offset + trial_idx * 1000
+            seeds.append(trial_seed)
+
+            print(f"--- Trial {trial_idx + 1}/{self.n_trials} (seed={trial_seed}) ---")
+
+            # Build loaders ONCE per trial; reset() per arm replays the
+            # identical batch stream so per-arm results are independent of arm
+            # order and of arm-subset selection.
+            train_loader, test_loader = self.data_loader_factory(trial_seed)
+
+            for arm in self.arms:
+                _reset_loader_if_supported(train_loader)
+                _reset_loader_if_supported(test_loader)
+                result = self._run_arm_trial(arm, trial_seed, train_loader, test_loader)
+                per_arm_trials[arm.name].append(result)
+                print(
+                    f"  {arm.name}: {self.metric}={result.metric_value:.4f}  "
+                    f"(train: {result.train_time:.1f}s)"
+                )
+
+        total_time = time.time() - total_start
+
+        return PlannedMultiContrastResults(
+            arm_names=[a.name for a in self.arms],
+            contrasts=list(self.contrasts),
+            metric=self.metric,
+            n_trials=self.n_trials,
+            per_arm_trials=per_arm_trials,
+            seeds=seeds,
+            total_time=total_time,
+            num_epochs=num_epochs,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2-arm legacy wrapper
+# ---------------------------------------------------------------------------
+
+
 @dataclass
 class ABResults:
-    """Results from a completed A/B experiment.
+    """Results from a completed 2-arm A/B experiment.
 
     Holds per-trial data for both arms and provides analysis and reporting
-    via :meth:`print_summary`.
+    via :meth:`print_summary`. Built by :meth:`ABExperiment.run` (which
+    delegates to :class:`PlannedMultiContrastExperiment` internally — this
+    class is the legacy view onto the same data).
     """
 
     arm_a_name: str
@@ -248,23 +574,26 @@ class ABResults:
 
 
 class ABExperiment:
-    """Runner for paired A/B experiments.
+    """Paired 2-arm experiment runner — thin wrapper around
+    :class:`PlannedMultiContrastExperiment`.
 
-    Runs N independent trials where each trial initializes fresh models
-    for both arms using the same RNG seed (paired design), trains both,
-    evaluates both, and records the specified metric.
+    Preserved for backward compatibility: existing callers
+    (PC_backprop_compare, mnist_lateral_connections, mnist_cyclic_graph,
+    storkey_hopfield_diagnostic) keep working unchanged. The single
+    declared contrast is ``(arm_a.name, arm_b.name)`` and the trial loop
+    is the multi-arm runner's. ``ABResults`` is reconstructed from the
+    multi-arm results so the legacy API surface is identical.
 
     Args:
         arm_a: First experimental condition.
         arm_b: Second experimental condition.
-        metric: Key in eval_fn's return dict to compare
-            (e.g., "accuracy", "perplexity").
+        metric: Key in eval_fn's return dict to compare.
         data_loader_factory: Callable taking an int seed and returning
             (train_loader, test_loader).
         n_trials: Number of independent paired trials.
         seed_offset: Base seed offset. Trial i uses
-            seed = seed_offset + i * 1000.
-        verbose: If True, print per-epoch training output.
+            ``seed = seed_offset + i * 1000``.
+        verbose: If True, forward verbose=True to each arm's train_fn.
     """
 
     def __init__(
@@ -285,111 +614,29 @@ class ABExperiment:
         self.seed_offset = seed_offset
         self.verbose = verbose
 
-    def _run_arm_trial(
-        self,
-        arm: ExperimentArm,
-        trial_seed: int,
-        train_loader: Any,
-        test_loader: Any,
-    ) -> TrialResult:
-        """Run a single trial for one arm."""
-        master_key = jax.random.PRNGKey(trial_seed)
-        graph_key, train_key, eval_key = jax.random.split(master_key, 3)
-
-        params, structure = arm.model_factory(graph_key)
-
-        t0 = time.time()
-        trained_params, _, _ = arm.train_fn(
-            params,
-            structure,
-            train_loader,
-            arm.optimizer,
-            arm.train_config,
-            train_key,
+    def run(self) -> ABResults:
+        """Run the experiment and return :class:`ABResults`. Internally
+        delegates to :class:`PlannedMultiContrastExperiment` so there is one
+        trial-loop implementation across both runners."""
+        runner = PlannedMultiContrastExperiment(
+            arms=[self.arm_a, self.arm_b],
+            contrasts=[(self.arm_a.name, self.arm_b.name)],
+            metric=self.metric,
+            data_loader_factory=self.data_loader_factory,
+            n_trials=self.n_trials,
+            seed_offset=self.seed_offset,
             verbose=self.verbose,
         )
-        train_time = time.time() - t0
-
-        metrics = arm.eval_fn(
-            trained_params,
-            structure,
-            test_loader,
-            arm.train_config,
-            eval_key,
-        )
-
-        if self.metric not in metrics:
-            available = ", ".join(sorted(metrics.keys()))
-            raise KeyError(
-                f"Metric '{self.metric}' not found in eval results for arm "
-                f"'{arm.name}'. Available: {available}"
-            )
-
-        return TrialResult(
-            metric_value=float(metrics[self.metric]),
-            train_time=train_time,
-            all_metrics={k: float(v) for k, v in metrics.items()},
-        )
-
-    def run(self) -> ABResults:
-        """Execute the full experiment: all trials for both arms.
-
-        Returns:
-            ABResults containing per-trial data and analysis methods.
-        """
-        arm_a_trials: List[TrialResult] = []
-        arm_b_trials: List[TrialResult] = []
-        seeds: List[int] = []
-
-        num_epochs = self.arm_a.train_config.get(
-            "num_epochs",
-            self.arm_b.train_config.get("num_epochs", 1),
-        )
-
-        total_start = time.time()
-
-        for trial_idx in range(self.n_trials):
-            trial_seed = self.seed_offset + trial_idx * 1000
-            seeds.append(trial_seed)
-
-            print(
-                f"--- Trial {trial_idx + 1}/{self.n_trials} " f"(seed={trial_seed}) ---"
-            )
-
-            # Arm A
-            train_loader, test_loader = self.data_loader_factory(trial_seed)
-            result_a = self._run_arm_trial(
-                self.arm_a, trial_seed, train_loader, test_loader
-            )
-            arm_a_trials.append(result_a)
-            print(
-                f"  {self.arm_a.name}: {self.metric}="
-                f"{result_a.metric_value:.4f}  "
-                f"(train: {result_a.train_time:.1f}s)"
-            )
-
-            # Arm B (recreate loaders for isolation)
-            train_loader, test_loader = self.data_loader_factory(trial_seed)
-            result_b = self._run_arm_trial(
-                self.arm_b, trial_seed, train_loader, test_loader
-            )
-            arm_b_trials.append(result_b)
-            print(
-                f"  {self.arm_b.name}: {self.metric}="
-                f"{result_b.metric_value:.4f}  "
-                f"(train: {result_b.train_time:.1f}s)"
-            )
-
-        total_time = time.time() - total_start
+        multi = runner.run()
 
         return ABResults(
             arm_a_name=self.arm_a.name,
             arm_b_name=self.arm_b.name,
             metric=self.metric,
             n_trials=self.n_trials,
-            arm_a_trials=arm_a_trials,
-            arm_b_trials=arm_b_trials,
-            seeds=seeds,
-            total_time=total_time,
-            num_epochs=num_epochs,
+            arm_a_trials=multi.per_arm_trials[self.arm_a.name],
+            arm_b_trials=multi.per_arm_trials[self.arm_b.name],
+            seeds=multi.seeds,
+            total_time=multi.total_time,
+            num_epochs=multi.num_epochs,
         )

--- a/fabricpc/experiments/ab_experiment.py
+++ b/fabricpc/experiments/ab_experiment.py
@@ -8,13 +8,13 @@ Two public runners are provided:
 
 - :class:`PlannedMultiContrastExperiment` — N arms with constructor-declared
   planned contrasts. The single source of truth for the per-trial training
-  loop. Each trial builds loaders once via the user-supplied factory and
-  calls ``reset()`` on them before every arm, so every arm sees the same
-  minibatch stream — paired in both data subsample/noise AND in batch order.
+  loop. Within each trial, every arm gets freshly constructed loaders from
+  ``data_loader_factory(trial_seed)``, so every arm sees the same minibatch
+  stream — paired in data subsample/noise AND in batch order — provided the
+  factory is deterministic in its seed argument.
 - :class:`ABExperiment` — a thin 2-arm wrapper that delegates entirely to
   ``PlannedMultiContrastExperiment``. Preserves the historical
-  ``arm_a``/``arm_b`` / ``ABResults`` API so existing callers (the four
-  example files in ``examples/``) keep working unchanged.
+  ``arm_a``/``arm_b`` / ``ABResults`` API.
 
 Example (multi-arm, planned-contrast)::
 
@@ -189,31 +189,42 @@ class PlannedMultiContrastResults:
     def contrast_results(self) -> List[ContrastResult]:
         """One :class:`ContrastResult` per declared contrast, in declaration
         order. Each contrast is a two-sided paired t-test on the per-trial
-        difference vector, plus paired Cohen's d."""
+        difference vector, plus paired Cohen's d. With fewer than 2 trials the
+        test statistics are NaN and ``significant_at_05`` is False (a paired
+        test needs at least 2 differences), so this method is total in
+        ``n_trials``."""
         out: List[ContrastResult] = []
         for a, b in self.contrasts:
             a_vals = self.per_arm_metrics(a)
             b_vals = self.per_arm_metrics(b)
             diff = a_vals - b_vals
-            ttest = paired_ttest(a_vals, b_vals)
-            effect = cohens_d(a_vals, b_vals)
+            n = len(diff)
             mean_diff = float(np.mean(diff))
-            se_diff = (
-                float(np.std(diff, ddof=1) / np.sqrt(len(diff)))
-                if len(diff) > 1
-                else 0.0
-            )
+            if n > 1:
+                ttest = paired_ttest(a_vals, b_vals)
+                effect = cohens_d(a_vals, b_vals)
+                se_diff = float(np.std(diff, ddof=1) / np.sqrt(n))
+                t_statistic = ttest.t_statistic
+                p_value = ttest.p_value
+                significant = ttest.significant_at_05
+                d = effect.d
+            else:
+                se_diff = 0.0
+                t_statistic = float("nan")
+                p_value = float("nan")
+                significant = False
+                d = float("nan")
             out.append(
                 ContrastResult(
                     arm_a=a,
                     arm_b=b,
                     mean_diff=mean_diff,
                     se_diff=se_diff,
-                    t_statistic=ttest.t_statistic,
-                    p_value=ttest.p_value,
-                    significant_at_05=ttest.significant_at_05,
-                    cohens_d=effect.d,
-                    n=len(diff),
+                    t_statistic=t_statistic,
+                    p_value=p_value,
+                    significant_at_05=significant,
+                    cohens_d=d,
+                    n=n,
                 )
             )
         return out
@@ -236,27 +247,15 @@ class PlannedMultiContrastResults:
         )
 
 
-def _reset_loader_if_supported(loader: Any) -> None:
-    """Call ``loader.reset()`` if it exists, no-op otherwise.
-
-    Loaders in ``fabricpc.utils.data.dataloader`` implement ``reset()`` so
-    that multi-arm experiments can replay the identical batch stream across
-    arms. User-supplied loaders without a ``reset()`` are silently tolerated
-    so that legacy callers keep working (with the caveat that an arm-order
-    dependence will leak in if their iteration is stateful).
-    """
-    if hasattr(loader, "reset"):
-        loader.reset()
-
-
 class PlannedMultiContrastExperiment:
     """Runner for paired N-arm experiments with constructor-declared contrasts.
 
-    Each trial:
-      1. Builds train/test loaders once via ``data_loader_factory(trial_seed)``.
-      2. For each arm in ``arms``: calls ``reset()`` on both loaders (so every
-         arm replays the identical batch stream), trains a fresh model, and
-         evaluates it.
+    Within each trial, every arm gets freshly constructed loaders from
+    ``data_loader_factory(trial_seed)``, trains a fresh model, and is
+    evaluated. Because the factory receives the same seed for every arm of a
+    trial, all arms see identical data and identical batch order whenever the
+    factory is deterministic in its seed — the pairing holds by construction,
+    with no requirements on the loader objects themselves.
 
     The shared per-trial seed is also used as the model RNG seed for every
     arm, so the source of model-init randomness is paired across arms (the
@@ -272,10 +271,13 @@ class PlannedMultiContrastExperiment:
         metric: Key in each arm's eval-result dict to compare
             (e.g. ``"accuracy"``, ``"perplexity"``).
         data_loader_factory: Callable ``seed -> (train_loader, test_loader)``.
-            The returned loaders should expose ``reset()`` for proper pairing;
-            loaders without it are tolerated but lose the cross-arm
-            batch-stream guarantee.
-        n_trials: Number of independent paired trials.
+            Called once per arm within each trial, always with the trial's
+            seed. Must be deterministic in its seed argument: two calls with
+            the same seed must yield loaders producing identical batch
+            streams, otherwise the arms are not paired.
+        n_trials: Number of independent paired trials. Must be >= 1; the
+            paired test statistics require >= 2 (a single trial yields per-arm
+            metrics and NaN test statistics).
         seed_offset: Base seed offset. Trial i uses
             ``seed = seed_offset + i * 1000``.
         verbose: If True, forward verbose=True to each arm's train_fn.
@@ -293,6 +295,9 @@ class PlannedMultiContrastExperiment:
     ):
         if len(arms) < 1:
             raise ValueError("arms must contain at least one ExperimentArm.")
+
+        if n_trials < 1:
+            raise ValueError(f"n_trials must be >= 1; got {n_trials}.")
 
         arm_names = [a.name for a in arms]
         if len(set(arm_names)) != len(arm_names):
@@ -329,8 +334,7 @@ class PlannedMultiContrastExperiment:
         train_loader: Any,
         test_loader: Any,
     ) -> TrialResult:
-        """Run a single trial for one arm. The caller is responsible for
-        having reset the loaders, so this method does not reset them itself."""
+        """Run a single trial for one arm on the given loaders."""
         master_key = jax.random.PRNGKey(trial_seed)
         graph_key, train_key, eval_key = jax.random.split(master_key, 3)
 
@@ -375,7 +379,14 @@ class PlannedMultiContrastExperiment:
         per_arm_trials: Dict[str, List[TrialResult]] = {a.name: [] for a in self.arms}
         seeds: List[int] = []
 
-        num_epochs = self.arms[0].train_config.get("num_epochs", 1)
+        num_epochs = next(
+            (
+                arm.train_config["num_epochs"]
+                for arm in self.arms
+                if "num_epochs" in arm.train_config
+            ),
+            1,
+        )
         total_start = time.time()
 
         for trial_idx in range(self.n_trials):
@@ -384,14 +395,11 @@ class PlannedMultiContrastExperiment:
 
             print(f"--- Trial {trial_idx + 1}/{self.n_trials} (seed={trial_seed}) ---")
 
-            # Build loaders ONCE per trial; reset() per arm replays the
-            # identical batch stream so per-arm results are independent of arm
-            # order and of arm-subset selection.
-            train_loader, test_loader = self.data_loader_factory(trial_seed)
-
             for arm in self.arms:
-                _reset_loader_if_supported(train_loader)
-                _reset_loader_if_supported(test_loader)
+                # Fresh loaders per arm from the same trial seed: every arm
+                # sees the identical batch stream, so per-arm results are
+                # independent of arm order and of arm-subset selection.
+                train_loader, test_loader = self.data_loader_factory(trial_seed)
                 result = self._run_arm_trial(arm, trial_seed, train_loader, test_loader)
                 per_arm_trials[arm.name].append(result)
                 print(
@@ -577,12 +585,10 @@ class ABExperiment:
     """Paired 2-arm experiment runner — thin wrapper around
     :class:`PlannedMultiContrastExperiment`.
 
-    Preserved for backward compatibility: existing callers
-    (PC_backprop_compare, mnist_lateral_connections, mnist_cyclic_graph,
-    storkey_hopfield_diagnostic) keep working unchanged. The single
-    declared contrast is ``(arm_a.name, arm_b.name)`` and the trial loop
-    is the multi-arm runner's. ``ABResults`` is reconstructed from the
-    multi-arm results so the legacy API surface is identical.
+    Preserved for backward compatibility. The single declared contrast is
+    ``(arm_a.name, arm_b.name)`` and the trial loop is the multi-arm
+    runner's. ``ABResults`` is reconstructed from the multi-arm results so
+    the legacy API surface is identical.
 
     Args:
         arm_a: First experimental condition.

--- a/fabricpc/utils/data/dataloader.py
+++ b/fabricpc/utils/data/dataloader.py
@@ -80,15 +80,32 @@ class MnistLoader:
         self.num_examples = info.splits[split].num_examples
         self._num_batches = (self.num_examples + batch_size - 1) // batch_size
 
-        # Build pipeline
-        if shuffle:
-            ds = ds.shuffle(
-                buffer_size=self.num_examples, seed=buffer_seed
-            )  # mnist fits in memory (~60MB) so the buffer is the full dataset
-        ds = ds.batch(batch_size, drop_remainder=False)
-        ds = ds.prefetch(tf.data.AUTOTUNE)
+        # Cache the unshuffled/unbatched dataset and the shuffle seed so
+        # reset() can replay the identical epoch-shuffle stream without paying
+        # for another tfds.load.
+        self._raw_ds = ds
+        self._buffer_seed = buffer_seed
+        self._build_pipeline()
 
+    def _build_pipeline(self):
+        """(Re)build the shuffle/batch/prefetch pipeline on top of the cached
+        raw dataset. Called from __init__ and from reset()."""
+        import tensorflow as tf
+
+        ds = self._raw_ds
+        if self.shuffle:
+            ds = ds.shuffle(
+                buffer_size=self.num_examples, seed=self._buffer_seed
+            )  # mnist fits in memory (~60MB) so the buffer is the full dataset
+        ds = ds.batch(self.batch_size, drop_remainder=False)
+        ds = ds.prefetch(tf.data.AUTOTUNE)
         self.ds = ds
+
+    def reset(self):
+        """Reset the iteration state so subsequent iteration replays the
+        identical batch stream from epoch 0. Required for paired multi-arm
+        experiments where every arm must see the same minibatch order."""
+        self._build_pipeline()
 
     def __iter__(self):
         for images, labels in self.ds:
@@ -165,12 +182,29 @@ class Cifar100Loader:
         self.num_examples = info.splits[split].num_examples
         self._num_batches = (self.num_examples + batch_size - 1) // batch_size
 
-        if shuffle:
-            ds = ds.shuffle(buffer_size=self.num_examples, seed=buffer_seed)
-        ds = ds.batch(batch_size, drop_remainder=False)
-        ds = ds.prefetch(tf.data.AUTOTUNE)
+        # Cache the raw dataset + shuffle seed so reset() can replay the
+        # identical batch stream from epoch 0 without re-loading from disk.
+        self._raw_ds = ds
+        self._buffer_seed = buffer_seed
+        self._build_pipeline()
 
+    def _build_pipeline(self):
+        """(Re)build the shuffle/batch/prefetch pipeline on top of the cached
+        raw dataset. Called from __init__ and from reset()."""
+        import tensorflow as tf
+
+        ds = self._raw_ds
+        if self.shuffle:
+            ds = ds.shuffle(buffer_size=self.num_examples, seed=self._buffer_seed)
+        ds = ds.batch(self.batch_size, drop_remainder=False)
+        ds = ds.prefetch(tf.data.AUTOTUNE)
         self.ds = ds
+
+    def reset(self):
+        """Reset iteration state so subsequent iteration replays the identical
+        batch stream from epoch 0. Required for paired multi-arm experiments
+        where every arm must see the same minibatch order."""
+        self._build_pipeline()
 
     def __iter__(self):
         for images, labels in self.ds:
@@ -245,12 +279,29 @@ class Cifar10Loader:
         self.num_examples = info.splits[split].num_examples
         self._num_batches = (self.num_examples + batch_size - 1) // batch_size
 
-        if shuffle:
-            ds = ds.shuffle(buffer_size=self.num_examples, seed=buffer_seed)
-        ds = ds.batch(batch_size, drop_remainder=False)
-        ds = ds.prefetch(tf.data.AUTOTUNE)
+        # Cache the raw dataset + shuffle seed so reset() can replay the
+        # identical batch stream from epoch 0 without re-loading from disk.
+        self._raw_ds = ds
+        self._buffer_seed = buffer_seed
+        self._build_pipeline()
 
+    def _build_pipeline(self):
+        """(Re)build the shuffle/batch/prefetch pipeline on top of the cached
+        raw dataset. Called from __init__ and from reset()."""
+        import tensorflow as tf
+
+        ds = self._raw_ds
+        if self.shuffle:
+            ds = ds.shuffle(buffer_size=self.num_examples, seed=self._buffer_seed)
+        ds = ds.batch(self.batch_size, drop_remainder=False)
+        ds = ds.prefetch(tf.data.AUTOTUNE)
         self.ds = ds
+
+    def reset(self):
+        """Reset iteration state so subsequent iteration replays the identical
+        batch stream from epoch 0. Required for paired multi-arm experiments
+        where every arm must see the same minibatch order."""
+        self._build_pipeline()
 
     def __iter__(self):
         for images, labels in self.ds:
@@ -574,12 +625,29 @@ class FashionMnistLoader:
         self.num_examples = info.splits[split].num_examples
         self._num_batches = (self.num_examples + batch_size - 1) // batch_size
 
-        if shuffle:
-            ds = ds.shuffle(buffer_size=self.num_examples, seed=buffer_seed)
-        ds = ds.batch(batch_size, drop_remainder=False)
-        ds = ds.prefetch(tf.data.AUTOTUNE)
+        # Cache the raw dataset + shuffle seed so reset() can replay the
+        # identical batch stream from scratch without a fresh tfds.load.
+        self._raw_ds = ds
+        self._buffer_seed = buffer_seed
+        self._build_pipeline()
 
+    def _build_pipeline(self):
+        """(Re)build the shuffle/batch/prefetch pipeline. Called from __init__
+        and from reset()."""
+        import tensorflow as tf
+
+        ds = self._raw_ds
+        if self.shuffle:
+            ds = ds.shuffle(buffer_size=self.num_examples, seed=self._buffer_seed)
+        ds = ds.batch(self.batch_size, drop_remainder=False)
+        ds = ds.prefetch(tf.data.AUTOTUNE)
         self.ds = ds
+
+    def reset(self):
+        """Reset iteration state so subsequent iteration replays the identical
+        batch stream from epoch 0. Required for paired multi-arm experiments
+        where every arm must see the same minibatch order."""
+        self._build_pipeline()
 
     def __iter__(self):
         for images, labels in self.ds:
@@ -674,6 +742,13 @@ class FewShotLoader:
         self.num_samples = len(selected_indices)
         self._num_batches = self.num_samples // batch_size
 
+    def reset(self):
+        """Reset the epoch counter so subsequent iteration replays the
+        identical epoch-shuffle stream from epoch 0. Required for paired
+        multi-arm experiments: each arm must see the same minibatch order,
+        otherwise the per-arm accuracies depend on arm position in the list."""
+        self._epoch = 0
+
     def __iter__(self):
         indices = np.arange(self.num_samples)
         if self.shuffle:
@@ -714,6 +789,14 @@ class NoisyTestLoader:
         self.base_loader = base_loader
         self.noise_std = noise_std
         self.seed = seed
+
+    def reset(self):
+        """No-op for this wrapper (noise RNG is reseeded inside __iter__ from
+        self.seed each pass, so it is already idempotent). Forwards to the
+        wrapped base loader's reset() if it has one, so multi-arm runners can
+        call reset() uniformly across train and test loaders."""
+        if hasattr(self.base_loader, "reset"):
+            self.base_loader.reset()
 
     def __iter__(self):
         rng = np.random.default_rng(self.seed)

--- a/fabricpc/utils/data/dataloader.py
+++ b/fabricpc/utils/data/dataloader.py
@@ -17,12 +17,23 @@ _TOKENIZERS_INSTALL_HINT = (
 )
 
 
-class MnistLoader:
-    """JAX-compatible data loader using TensorFlow Datasets.
+class _TfdsImageLoader:
+    """Shared base for TFDS image-classification loaders.
 
-    Provides the same interface as PyTorch DataLoader but uses tfds
-    data parallelism based on C++ that bypasses GIL and does not inherit GPU state.
-    Avoids os.fork warnings with JAX.
+    Loads a tfds split, builds a shuffle/batch/prefetch tf.data pipeline, and
+    yields (normalized float32 images, one-hot labels) numpy batches. Uses
+    tfds data parallelism based on C++ that bypasses GIL and does not inherit
+    GPU state; avoids os.fork warnings with JAX.
+
+    Subclasses set two class attributes:
+        _DATASET_NAME: tfds dataset name (version-pinned where needed).
+        _NUM_CLASSES: number of classes for one-hot labels.
+
+    Iteration statefulness: with ``shuffle=True`` the tf.data pipeline
+    reshuffles on every pass, so the batch order advances with each epoch of
+    one training run. Construct a fresh instance per logical training run;
+    paired experiment runners obtain per-arm instances by calling their
+    ``data_loader_factory`` once per arm.
 
     Args:
         split: Dataset split to load. Use 'train' for training data or
@@ -32,9 +43,13 @@ class MnistLoader:
         shuffle: Whether to shuffle the data each epoch.
         seed: Random seed for reproducibility. When set, ensures deterministic
               shuffling across runs and machines. If None, shuffling is random.
-        normalize_mean: Mean for normalization (default: MNIST mean).
-        normalize_std: Std for normalization (default: MNIST std).
+        tensor_format: 'NHWC' for image tensors or 'flat' for flattened rows.
+        normalize_mean: Mean for normalization (scalar or per-channel tuple).
+        normalize_std: Std for normalization (scalar or per-channel tuple).
     """
+
+    _DATASET_NAME: str
+    _NUM_CLASSES: int
 
     def __init__(
         self,
@@ -42,9 +57,9 @@ class MnistLoader:
         batch_size: int,
         shuffle: bool = True,
         seed: int = None,
-        tensor_format: str = "NHWC",  # image tensor 'flat' or 'NHWC' batch-height-width-channels
-        normalize_mean: float = 0.1307,
-        normalize_std: float = 0.3081,
+        tensor_format: str = "NHWC",
+        normalize_mean=0.0,
+        normalize_std=1.0,
     ):
         import tensorflow_datasets as tfds
         import tensorflow as tf
@@ -56,8 +71,8 @@ class MnistLoader:
         self.shuffle = shuffle
         self.seed = seed
         self.tensor_format = tensor_format
-        self.normalize_mean = normalize_mean
-        self.normalize_std = normalize_std
+        self.normalize_mean = np.asarray(normalize_mean, dtype=np.float32)
+        self.normalize_std = np.asarray(normalize_std, dtype=np.float32)
 
         # Split seed into two independent seeds for file and buffer shuffling
         file_seed, buffer_seed = split_np_seed(seed, n=2)
@@ -68,9 +83,8 @@ class MnistLoader:
             interleave_cycle_length=1,  # Sequential reading for determinism
         )
 
-        # Load dataset with pinned version for cross-machine reproducibility
         ds, info = tfds.load(
-            "mnist:3.0.1",
+            self._DATASET_NAME,
             split=split,
             with_info=True,
             as_supervised=True,
@@ -80,45 +94,23 @@ class MnistLoader:
         self.num_examples = info.splits[split].num_examples
         self._num_batches = (self.num_examples + batch_size - 1) // batch_size
 
-        # Cache the unshuffled/unbatched dataset and the shuffle seed so
-        # reset() can replay the identical epoch-shuffle stream without paying
-        # for another tfds.load.
-        self._raw_ds = ds
-        self._buffer_seed = buffer_seed
-        self._build_pipeline()
-
-    def _build_pipeline(self):
-        """(Re)build the shuffle/batch/prefetch pipeline on top of the cached
-        raw dataset. Called from __init__ and from reset()."""
-        import tensorflow as tf
-
-        ds = self._raw_ds
-        if self.shuffle:
-            ds = ds.shuffle(
-                buffer_size=self.num_examples, seed=self._buffer_seed
-            )  # mnist fits in memory (~60MB) so the buffer is the full dataset
-        ds = ds.batch(self.batch_size, drop_remainder=False)
+        if shuffle:
+            # These datasets fit in memory, so the shuffle buffer is the
+            # full split.
+            ds = ds.shuffle(buffer_size=self.num_examples, seed=buffer_seed)
+        ds = ds.batch(batch_size, drop_remainder=False)
         ds = ds.prefetch(tf.data.AUTOTUNE)
         self.ds = ds
 
-    def reset(self):
-        """Reset the iteration state so subsequent iteration replays the
-        identical batch stream from epoch 0. Required for paired multi-arm
-        experiments where every arm must see the same minibatch order."""
-        self._build_pipeline()
-
     def __iter__(self):
         for images, labels in self.ds:
-            # Convert to numpy, normalize, and flatten
             images = images.numpy().astype(np.float32) / 255.0
             images = (images - self.normalize_mean) / self.normalize_std
 
-            # images shape is (Batch, 28, 28, 1)
             if self.tensor_format == "flat":
-                images = images.reshape(images.shape[0], -1)  # Flatten to (Batch, 784)
+                images = images.reshape(images.shape[0], -1)
 
-            # One-hot encode labels
-            labels = one_hot(labels.numpy(), num_classes=10)
+            labels = one_hot(labels.numpy(), num_classes=self._NUM_CLASSES)
 
             yield images, labels
 
@@ -126,21 +118,50 @@ class MnistLoader:
         return self._num_batches
 
 
-class Cifar100Loader:
-    """JAX-compatible CIFAR-100 data loader using TensorFlow Datasets.
+class MnistLoader(_TfdsImageLoader):
+    """MNIST loader (28x28 grayscale, 10 digit classes).
 
-    Loads the CIFAR-100 dataset (32x32 RGB images, 100 fine-grained classes)
-    and yields batches of (images, one_hot_labels).
-
-    Args:
-        split: Dataset split to load ('train' or 'test').
-        batch_size: Number of samples per batch.
-        shuffle: Whether to shuffle the data each epoch.
-        seed: Random seed for reproducibility.
-        tensor_format: 'NHWC' for (batch, 32, 32, 3) or 'flat' for (batch, 3072).
-        normalize_mean: Per-channel mean for normalization (default: CIFAR-100 mean).
-        normalize_std: Per-channel std for normalization (default: CIFAR-100 std).
+    Yields (batch, 28, 28, 1) images ('NHWC') or (batch, 784) rows ('flat').
+    Defaults normalize with the MNIST per-pixel mean/std. Dataset version is
+    pinned for cross-machine reproducibility. See :class:`_TfdsImageLoader`
+    for the shared constructor arguments and iteration contract.
     """
+
+    _DATASET_NAME = "mnist:3.0.1"
+    _NUM_CLASSES = 10
+
+    def __init__(
+        self,
+        split: str,
+        batch_size: int,
+        shuffle: bool = True,
+        seed: int = None,
+        tensor_format: str = "NHWC",
+        normalize_mean: float = 0.1307,
+        normalize_std: float = 0.3081,
+    ):
+        super().__init__(
+            split=split,
+            batch_size=batch_size,
+            shuffle=shuffle,
+            seed=seed,
+            tensor_format=tensor_format,
+            normalize_mean=normalize_mean,
+            normalize_std=normalize_std,
+        )
+
+
+class Cifar100Loader(_TfdsImageLoader):
+    """CIFAR-100 loader (32x32 RGB, 100 fine-grained classes).
+
+    Yields (batch, 32, 32, 3) images ('NHWC') or (batch, 3072) rows ('flat').
+    Defaults normalize per channel with the CIFAR-100 mean/std. See
+    :class:`_TfdsImageLoader` for the shared constructor arguments and
+    iteration contract.
+    """
+
+    _DATASET_NAME = "cifar100"
+    _NUM_CLASSES = 100
 
     def __init__(
         self,
@@ -152,92 +173,28 @@ class Cifar100Loader:
         normalize_mean: tuple = (0.5071, 0.4867, 0.4408),
         normalize_std: tuple = (0.2675, 0.2565, 0.2761),
     ):
-        import tensorflow_datasets as tfds
-        import tensorflow as tf
-
-        tf.config.set_visible_devices([], "GPU")
-
-        self.batch_size = batch_size
-        self.shuffle = shuffle
-        self.seed = seed
-        self.tensor_format = tensor_format
-        self.normalize_mean = np.array(normalize_mean, dtype=np.float32)
-        self.normalize_std = np.array(normalize_std, dtype=np.float32)
-
-        file_seed, buffer_seed = split_np_seed(seed, n=2)
-
-        read_config = tfds.ReadConfig(
-            shuffle_seed=file_seed,
-            interleave_cycle_length=1,
-        )
-
-        ds, info = tfds.load(
-            "cifar100",
+        super().__init__(
             split=split,
-            with_info=True,
-            as_supervised=True,
-            read_config=read_config,
-            shuffle_files=shuffle and seed is not None,
+            batch_size=batch_size,
+            shuffle=shuffle,
+            seed=seed,
+            tensor_format=tensor_format,
+            normalize_mean=normalize_mean,
+            normalize_std=normalize_std,
         )
-        self.num_examples = info.splits[split].num_examples
-        self._num_batches = (self.num_examples + batch_size - 1) // batch_size
-
-        # Cache the raw dataset + shuffle seed so reset() can replay the
-        # identical batch stream from epoch 0 without re-loading from disk.
-        self._raw_ds = ds
-        self._buffer_seed = buffer_seed
-        self._build_pipeline()
-
-    def _build_pipeline(self):
-        """(Re)build the shuffle/batch/prefetch pipeline on top of the cached
-        raw dataset. Called from __init__ and from reset()."""
-        import tensorflow as tf
-
-        ds = self._raw_ds
-        if self.shuffle:
-            ds = ds.shuffle(buffer_size=self.num_examples, seed=self._buffer_seed)
-        ds = ds.batch(self.batch_size, drop_remainder=False)
-        ds = ds.prefetch(tf.data.AUTOTUNE)
-        self.ds = ds
-
-    def reset(self):
-        """Reset iteration state so subsequent iteration replays the identical
-        batch stream from epoch 0. Required for paired multi-arm experiments
-        where every arm must see the same minibatch order."""
-        self._build_pipeline()
-
-    def __iter__(self):
-        for images, labels in self.ds:
-            images = images.numpy().astype(np.float32) / 255.0
-            # Per-channel normalization: (H, W, C) broadcast
-            images = (images - self.normalize_mean) / self.normalize_std
-
-            if self.tensor_format == "flat":
-                images = images.reshape(images.shape[0], -1)
-
-            labels = one_hot(labels.numpy(), num_classes=100)
-
-            yield images, labels
-
-    def __len__(self):
-        return self._num_batches
 
 
-class Cifar10Loader:
-    """JAX-compatible CIFAR-10 data loader using TensorFlow Datasets.
+class Cifar10Loader(_TfdsImageLoader):
+    """CIFAR-10 loader (32x32 RGB, 10 classes).
 
-    Loads the CIFAR-10 dataset (32x32 RGB images, 10 classes)
-    and yields batches of (images, one_hot_labels).
-
-    Args:
-        split: Dataset split to load ('train' or 'test').
-        batch_size: Number of samples per batch.
-        shuffle: Whether to shuffle the data each epoch.
-        seed: Random seed for reproducibility.
-        tensor_format: 'NHWC' for (batch, 32, 32, 3) or 'flat' for (batch, 3072).
-        normalize_mean: Per-channel mean for normalization (default: CIFAR-10 mean).
-        normalize_std: Per-channel std for normalization (default: CIFAR-10 std).
+    Yields (batch, 32, 32, 3) images ('NHWC') or (batch, 3072) rows ('flat').
+    Defaults normalize per channel with the CIFAR-10 mean/std. See
+    :class:`_TfdsImageLoader` for the shared constructor arguments and
+    iteration contract.
     """
+
+    _DATASET_NAME = "cifar10"
+    _NUM_CLASSES = 10
 
     def __init__(
         self,
@@ -249,75 +206,15 @@ class Cifar10Loader:
         normalize_mean: tuple = (0.4914, 0.4822, 0.4465),
         normalize_std: tuple = (0.2470, 0.2435, 0.2616),
     ):
-        import tensorflow_datasets as tfds
-        import tensorflow as tf
-
-        tf.config.set_visible_devices([], "GPU")
-
-        self.batch_size = batch_size
-        self.shuffle = shuffle
-        self.seed = seed
-        self.tensor_format = tensor_format
-        self.normalize_mean = np.array(normalize_mean, dtype=np.float32)
-        self.normalize_std = np.array(normalize_std, dtype=np.float32)
-
-        file_seed, buffer_seed = split_np_seed(seed, n=2)
-
-        read_config = tfds.ReadConfig(
-            shuffle_seed=file_seed,
-            interleave_cycle_length=1,
-        )
-
-        ds, info = tfds.load(
-            "cifar10",
+        super().__init__(
             split=split,
-            with_info=True,
-            as_supervised=True,
-            read_config=read_config,
-            shuffle_files=shuffle and seed is not None,
+            batch_size=batch_size,
+            shuffle=shuffle,
+            seed=seed,
+            tensor_format=tensor_format,
+            normalize_mean=normalize_mean,
+            normalize_std=normalize_std,
         )
-        self.num_examples = info.splits[split].num_examples
-        self._num_batches = (self.num_examples + batch_size - 1) // batch_size
-
-        # Cache the raw dataset + shuffle seed so reset() can replay the
-        # identical batch stream from epoch 0 without re-loading from disk.
-        self._raw_ds = ds
-        self._buffer_seed = buffer_seed
-        self._build_pipeline()
-
-    def _build_pipeline(self):
-        """(Re)build the shuffle/batch/prefetch pipeline on top of the cached
-        raw dataset. Called from __init__ and from reset()."""
-        import tensorflow as tf
-
-        ds = self._raw_ds
-        if self.shuffle:
-            ds = ds.shuffle(buffer_size=self.num_examples, seed=self._buffer_seed)
-        ds = ds.batch(self.batch_size, drop_remainder=False)
-        ds = ds.prefetch(tf.data.AUTOTUNE)
-        self.ds = ds
-
-    def reset(self):
-        """Reset iteration state so subsequent iteration replays the identical
-        batch stream from epoch 0. Required for paired multi-arm experiments
-        where every arm must see the same minibatch order."""
-        self._build_pipeline()
-
-    def __iter__(self):
-        for images, labels in self.ds:
-            images = images.numpy().astype(np.float32) / 255.0
-            # Per-channel normalization: (H, W, C) broadcast
-            images = (images - self.normalize_mean) / self.normalize_std
-
-            if self.tensor_format == "flat":
-                images = images.reshape(images.shape[0], -1)
-
-            labels = one_hot(labels.numpy(), num_classes=10)
-
-            yield images, labels
-
-    def __len__(self):
-        return self._num_batches
 
 
 class _TokenSequenceLoader:
@@ -569,21 +466,17 @@ class BpeDataLoader(_TokenSequenceLoader):
         return self._tok.decode([int(i) for i in indices], skip_special_tokens=True)
 
 
-class FashionMnistLoader:
-    """JAX-compatible Fashion-MNIST data loader using TensorFlow Datasets.
+class FashionMnistLoader(_TfdsImageLoader):
+    """Fashion-MNIST loader (28x28 grayscale, 10 clothing categories).
 
-    Drop-in replacement for MnistLoader with the Fashion-MNIST dataset
-    (28x28 grayscale, 10 clothing categories).
-
-    Args:
-        split: Dataset split ('train' or 'test').
-        batch_size: Number of samples per batch.
-        shuffle: Whether to shuffle the data each epoch.
-        seed: Random seed for reproducibility.
-        tensor_format: 'NHWC' for (batch, 28, 28, 1) or 'flat' for (batch, 784).
-        normalize_mean: Mean for normalization (default: Fashion-MNIST mean).
-        normalize_std: Std for normalization (default: Fashion-MNIST std).
+    Drop-in replacement for MnistLoader. Yields (batch, 28, 28, 1) images
+    ('NHWC') or (batch, 784) rows ('flat'). Defaults normalize with the
+    Fashion-MNIST per-pixel mean/std. See :class:`_TfdsImageLoader` for the
+    shared constructor arguments and iteration contract.
     """
+
+    _DATASET_NAME = "fashion_mnist"
+    _NUM_CLASSES = 10
 
     def __init__(
         self,
@@ -595,83 +488,33 @@ class FashionMnistLoader:
         normalize_mean: float = 0.2860,
         normalize_std: float = 0.3530,
     ):
-        import tensorflow_datasets as tfds
-        import tensorflow as tf
-
-        tf.config.set_visible_devices([], "GPU")
-
-        self.batch_size = batch_size
-        self.shuffle = shuffle
-        self.seed = seed
-        self.tensor_format = tensor_format
-        self.normalize_mean = normalize_mean
-        self.normalize_std = normalize_std
-
-        file_seed, buffer_seed = split_np_seed(seed, n=2)
-
-        read_config = tfds.ReadConfig(
-            shuffle_seed=file_seed,
-            interleave_cycle_length=1,
-        )
-
-        ds, info = tfds.load(
-            "fashion_mnist",
+        super().__init__(
             split=split,
-            with_info=True,
-            as_supervised=True,
-            read_config=read_config,
-            shuffle_files=shuffle and seed is not None,
+            batch_size=batch_size,
+            shuffle=shuffle,
+            seed=seed,
+            tensor_format=tensor_format,
+            normalize_mean=normalize_mean,
+            normalize_std=normalize_std,
         )
-        self.num_examples = info.splits[split].num_examples
-        self._num_batches = (self.num_examples + batch_size - 1) // batch_size
-
-        # Cache the raw dataset + shuffle seed so reset() can replay the
-        # identical batch stream from scratch without a fresh tfds.load.
-        self._raw_ds = ds
-        self._buffer_seed = buffer_seed
-        self._build_pipeline()
-
-    def _build_pipeline(self):
-        """(Re)build the shuffle/batch/prefetch pipeline. Called from __init__
-        and from reset()."""
-        import tensorflow as tf
-
-        ds = self._raw_ds
-        if self.shuffle:
-            ds = ds.shuffle(buffer_size=self.num_examples, seed=self._buffer_seed)
-        ds = ds.batch(self.batch_size, drop_remainder=False)
-        ds = ds.prefetch(tf.data.AUTOTUNE)
-        self.ds = ds
-
-    def reset(self):
-        """Reset iteration state so subsequent iteration replays the identical
-        batch stream from epoch 0. Required for paired multi-arm experiments
-        where every arm must see the same minibatch order."""
-        self._build_pipeline()
-
-    def __iter__(self):
-        for images, labels in self.ds:
-            images = images.numpy().astype(np.float32) / 255.0
-            images = (images - self.normalize_mean) / self.normalize_std
-
-            if self.tensor_format == "flat":
-                images = images.reshape(images.shape[0], -1)
-
-            labels = one_hot(labels.numpy(), num_classes=10)
-
-            yield images, labels
-
-    def __len__(self):
-        return self._num_batches
 
 
 class FewShotLoader:
     """Class-balanced K-shot data loader using TensorFlow Datasets.
 
-    Loads a full dataset, subsamples exactly K examples per class
-    (deterministically via seed), and yields shuffled minibatches.
-    Both arms in an A/B experiment receive identical training data
-    when given the same seed.
+    Subsamples exactly K examples per class (deterministically via seed) and
+    yields shuffled minibatches, including a final partial batch when the
+    sample count is not a multiple of batch_size. Both arms in a paired
+    experiment receive identical training data when given the same seed.
+
+    The full split is loaded once per process and memoized in a class-level
+    cache keyed on (dataset_name, split); constructions after the first
+    reuse the cached raw arrays, so building one loader per arm per trial in
+    paired experiments costs only the K-shot subsample.
+
+    Iteration statefulness: with ``shuffle=True`` the shuffle order advances
+    with each pass (epoch). Construct a fresh instance per logical training
+    run; two same-seed instances yield identical epoch-shuffle streams.
 
     Args:
         dataset_name: TFDS dataset name (e.g., 'fashion_mnist', 'mnist:3.0.1').
@@ -686,6 +529,32 @@ class FewShotLoader:
         normalize_std: Std for normalization.
     """
 
+    # (dataset_name, split) -> (raw images, int32 labels); raw dtype as
+    # loaded (uint8 for the MNIST/CIFAR families), pre-normalization.
+    _raw_split_cache = {}
+
+    @classmethod
+    def _load_raw_split(cls, dataset_name: str, split: str):
+        key = (dataset_name, split)
+        if key not in cls._raw_split_cache:
+            import tensorflow_datasets as tfds
+            import tensorflow as tf
+
+            tf.config.set_visible_devices([], "GPU")
+
+            ds = tfds.load(dataset_name, split=split, as_supervised=True)
+            all_images = []
+            all_labels = []
+            for img, label in ds:
+                all_images.append(img.numpy())
+                all_labels.append(int(label.numpy()))
+
+            cls._raw_split_cache[key] = (
+                np.asarray(all_images),
+                np.asarray(all_labels, dtype=np.int32),
+            )
+        return cls._raw_split_cache[key]
+
     def __init__(
         self,
         dataset_name: str,
@@ -699,11 +568,6 @@ class FewShotLoader:
         normalize_mean: float = 0.2860,
         normalize_std: float = 0.3530,
     ):
-        import tensorflow_datasets as tfds
-        import tensorflow as tf
-
-        tf.config.set_visible_devices([], "GPU")
-
         self.batch_size = batch_size
         self.shuffle = shuffle
         self.seed = seed
@@ -713,23 +577,13 @@ class FewShotLoader:
         self.num_classes = num_classes
         self._epoch = 0
 
-        # Load entire dataset into memory
-        ds = tfds.load(dataset_name, split=split, as_supervised=True)
-        all_images = []
-        all_labels = []
-        for img, label in ds:
-            all_images.append(img.numpy())
-            all_labels.append(int(label.numpy()))
-
-        all_images = np.array(all_images, dtype=np.float32) / 255.0
-        all_images = (all_images - self.normalize_mean) / self.normalize_std
-        all_labels = np.array(all_labels, dtype=np.int32)
+        raw_images, raw_labels = self._load_raw_split(dataset_name, split)
 
         # Class-balanced subsampling
         rng = np.random.default_rng(seed)
         selected_indices = []
         for c in range(num_classes):
-            class_indices = np.where(all_labels == c)[0]
+            class_indices = np.where(raw_labels == c)[0]
             if len(class_indices) < k_per_class:
                 chosen = class_indices  # use all if fewer than K
             else:
@@ -737,17 +591,13 @@ class FewShotLoader:
             selected_indices.append(chosen)
         selected_indices = np.concatenate(selected_indices)
 
-        self.images = all_images[selected_indices]
-        self.labels = all_labels[selected_indices]
+        # Normalize only the selected subsample; the cached raw arrays stay
+        # untouched for other constructions.
+        images = raw_images[selected_indices].astype(np.float32) / 255.0
+        self.images = (images - self.normalize_mean) / self.normalize_std
+        self.labels = raw_labels[selected_indices]
         self.num_samples = len(selected_indices)
-        self._num_batches = self.num_samples // batch_size
-
-    def reset(self):
-        """Reset the epoch counter so subsequent iteration replays the
-        identical epoch-shuffle stream from epoch 0. Required for paired
-        multi-arm experiments: each arm must see the same minibatch order,
-        otherwise the per-arm accuracies depend on arm position in the list."""
-        self._epoch = 0
+        self._num_batches = (self.num_samples + batch_size - 1) // batch_size
 
     def __iter__(self):
         indices = np.arange(self.num_samples)
@@ -759,7 +609,7 @@ class FewShotLoader:
             rng.shuffle(indices)
         self._epoch += 1
 
-        for start in range(0, self.num_samples - self.batch_size + 1, self.batch_size):
+        for start in range(0, self.num_samples, self.batch_size):
             batch_idx = indices[start : start + self.batch_size]
             images = self.images[batch_idx]
 
@@ -789,14 +639,6 @@ class NoisyTestLoader:
         self.base_loader = base_loader
         self.noise_std = noise_std
         self.seed = seed
-
-    def reset(self):
-        """No-op for this wrapper (noise RNG is reseeded inside __iter__ from
-        self.seed each pass, so it is already idempotent). Forwards to the
-        wrapped base loader's reset() if it has one, so multi-arm runners can
-        call reset() uniformly across train and test loaders."""
-        if hasattr(self.base_loader, "reset"):
-            self.base_loader.reset()
 
     def __iter__(self):
         rng = np.random.default_rng(self.seed)

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,0 +1,371 @@
+"""Tests for the paired experiment runners in fabricpc.experiments.
+
+The pairing guarantee is the core invariant: within a trial, every arm must
+consume the identical batch stream. The runner achieves this by calling
+data_loader_factory(trial_seed) once per arm, so the tests use a
+deliberately STATEFUL stub loader (epoch-dependent shuffle, like
+FewShotLoader) — if the runner ever goes back to sharing loader instances
+across arms, these tests fail.
+
+No TFDS, no real training: train/eval are stubs that fingerprint the batch
+stream they receive. FewShotLoader tests monkeypatch tfds.load and are
+gated on the tensorflow/tensorflow_datasets imports.
+"""
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import numpy as np
+import pytest
+
+from fabricpc.experiments import (
+    ExperimentArm,
+    TrialResult,
+    ABExperiment,
+    PlannedMultiContrastExperiment,
+    PlannedMultiContrastResults,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class StatefulStubLoader:
+    """Loader whose batch order depends on how often it has been iterated.
+
+    Mimics the epoch statefulness of FewShotLoader: each pass shuffles with
+    a seed derived from (seed, epoch counter) and advances the counter. Two
+    fresh instances with the same seed yield identical streams; one shared
+    instance yields a different stream on every pass.
+    """
+
+    def __init__(self, seed: int, n_batches: int = 6):
+        self.seed = seed
+        self.n_batches = n_batches
+        self._epoch = 0
+
+    def __iter__(self):
+        rng = np.random.default_rng(self.seed + self._epoch)
+        self._epoch += 1
+        order = rng.permutation(self.n_batches)
+        for i in order:
+            x = np.full((2, 3), float(i), dtype=np.float32)
+            y = np.zeros((2, 10), dtype=np.float32)
+            y[:, int(i) % 10] = 1.0
+            yield x, y
+
+    def __len__(self):
+        return self.n_batches
+
+
+def stub_factory(seed):
+    return StatefulStubLoader(seed), StatefulStubLoader(seed + 1)
+
+
+def _stream_fingerprint(loader, num_epochs):
+    """Order-sensitive fingerprint of the multi-epoch batch stream."""
+    values = []
+    for _ in range(num_epochs):
+        for x, _ in loader:
+            values.append(float(x[0, 0]))
+    v = np.asarray(values)
+    return float(np.dot(v, np.arange(1, len(v) + 1)))
+
+
+def stub_train(params, structure, train_loader, optimizer, config, key, verbose=False):
+    fp = _stream_fingerprint(train_loader, config.get("num_epochs", 1))
+    return {"train_fingerprint": fp}, None, None
+
+
+def stub_eval(trained_params, structure, test_loader, config, key):
+    test_fp = _stream_fingerprint(test_loader, 1)
+    # Depends on both the training stream and the test stream, so any
+    # cross-arm stream divergence shows up in the metric.
+    return {"accuracy": trained_params["train_fingerprint"] + test_fp}
+
+
+def make_arm(name, num_epochs=2, eval_fn=stub_eval):
+    return ExperimentArm(
+        name=name,
+        model_factory=lambda rng_key: ({}, None),
+        train_fn=stub_train,
+        eval_fn=eval_fn,
+        optimizer=None,
+        train_config={"num_epochs": num_epochs},
+    )
+
+
+def run_experiment(arm_names, n_trials=3, contrasts=None):
+    runner = PlannedMultiContrastExperiment(
+        arms=[make_arm(n) for n in arm_names],
+        contrasts=contrasts or [],
+        metric="accuracy",
+        data_loader_factory=stub_factory,
+        n_trials=n_trials,
+    )
+    return runner.run()
+
+
+# ---------------------------------------------------------------------------
+# Pairing invariant
+# ---------------------------------------------------------------------------
+
+
+def test_arms_see_identical_batch_stream():
+    """All arms of a trial consume the identical multi-epoch stream, even
+    though the loaders are stateful across passes."""
+    results = run_experiment(["A", "B", "C"])
+    a = results.per_arm_metrics("A")
+    b = results.per_arm_metrics("B")
+    c = results.per_arm_metrics("C")
+    np.testing.assert_array_equal(a, b)
+    np.testing.assert_array_equal(a, c)
+
+
+def test_trials_differ():
+    """Different trials use different seeds, so the streams (and metrics)
+    differ across trials — the pairing is within-trial, not global."""
+    a = run_experiment(["A", "B"]).per_arm_metrics("A")
+    assert len(set(a.tolist())) == len(a)
+
+
+def test_arm_order_and_subset_independence():
+    """An arm's per-trial metrics do not depend on its position in the arms
+    list or on which other arms run (regression test for the shared-loader
+    pairing bug)."""
+    b_first = run_experiment(["B", "A"]).per_arm_metrics("B")
+    b_second = run_experiment(["A", "B"]).per_arm_metrics("B")
+    b_alone = run_experiment(["B"]).per_arm_metrics("B")
+    np.testing.assert_array_equal(b_first, b_second)
+    np.testing.assert_array_equal(b_first, b_alone)
+
+
+# ---------------------------------------------------------------------------
+# Contrast statistics
+# ---------------------------------------------------------------------------
+
+
+def _results_from_metrics(per_arm_values, contrasts):
+    """Build a results object directly from per-arm metric vectors."""
+    per_arm_trials = {
+        name: [
+            TrialResult(metric_value=v, train_time=0.0, all_metrics={"accuracy": v})
+            for v in values
+        ]
+        for name, values in per_arm_values.items()
+    }
+    n_trials = len(next(iter(per_arm_values.values())))
+    return PlannedMultiContrastResults(
+        arm_names=list(per_arm_values.keys()),
+        contrasts=contrasts,
+        metric="accuracy",
+        n_trials=n_trials,
+        per_arm_trials=per_arm_trials,
+        seeds=list(range(n_trials)),
+        total_time=0.0,
+        num_epochs=1,
+    )
+
+
+def test_contrast_results_math():
+    a = [0.8, 0.9, 0.7, 0.85]
+    b = [0.7, 0.75, 0.72, 0.74]
+    results = _results_from_metrics({"A": a, "B": b}, contrasts=[("A", "B")])
+    (c,) = results.contrast_results()
+
+    diff = np.array(a) - np.array(b)
+    assert c.n == 4
+    assert c.mean_diff == pytest.approx(float(np.mean(diff)))
+    assert c.se_diff == pytest.approx(float(np.std(diff, ddof=1) / np.sqrt(4)))
+    assert c.cohens_d == pytest.approx(float(np.mean(diff) / np.std(diff, ddof=1)))
+    from scipy import stats
+
+    t_ref, p_ref = stats.ttest_rel(a, b)
+    assert c.t_statistic == pytest.approx(float(t_ref))
+    assert c.p_value == pytest.approx(float(p_ref))
+    assert c.significant_at_05 == (p_ref < 0.05)
+
+
+def test_descriptive_delta_carries_no_test():
+    a = [0.8, 0.9]
+    b = [0.7, 0.75]
+    results = _results_from_metrics({"A": a, "B": b}, contrasts=[])
+    d = results.delta("A", "B")
+    diff = np.array(a) - np.array(b)
+    assert d.mean == pytest.approx(float(np.mean(diff)))
+    assert d.std == pytest.approx(float(np.std(diff, ddof=1)))
+    assert d.se == pytest.approx(float(np.std(diff, ddof=1) / np.sqrt(2)))
+    assert not hasattr(d, "p_value")
+    assert not hasattr(d, "significant_at_05")
+    assert not hasattr(d, "cohens_d")
+
+
+def test_single_trial_yields_nan_statistics():
+    """contrast_results() is total in n_trials: one trial gives NaN test
+    statistics instead of raising after the training compute is spent."""
+    results = _results_from_metrics({"A": [0.8], "B": [0.7]}, contrasts=[("A", "B")])
+    (c,) = results.contrast_results()
+    assert c.n == 1
+    assert c.mean_diff == pytest.approx(0.1)
+    assert np.isnan(c.t_statistic)
+    assert np.isnan(c.p_value)
+    assert np.isnan(c.cohens_d)
+    assert c.significant_at_05 is False
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_arm_names_rejected():
+    with pytest.raises(ValueError, match="unique"):
+        PlannedMultiContrastExperiment(
+            arms=[make_arm("A"), make_arm("A")],
+            contrasts=[],
+            metric="accuracy",
+            data_loader_factory=stub_factory,
+        )
+
+
+def test_unknown_contrast_arm_rejected():
+    with pytest.raises(ValueError, match="unknown arm"):
+        PlannedMultiContrastExperiment(
+            arms=[make_arm("A"), make_arm("B")],
+            contrasts=[("A", "C")],
+            metric="accuracy",
+            data_loader_factory=stub_factory,
+        )
+
+
+def test_nonpositive_n_trials_rejected():
+    with pytest.raises(ValueError, match="n_trials"):
+        PlannedMultiContrastExperiment(
+            arms=[make_arm("A")],
+            contrasts=[],
+            metric="accuracy",
+            data_loader_factory=stub_factory,
+            n_trials=0,
+        )
+
+
+def test_missing_metric_raises_keyerror():
+    def bad_eval(trained_params, structure, test_loader, config, key):
+        return {"perplexity": 1.0}
+
+    runner = PlannedMultiContrastExperiment(
+        arms=[make_arm("A", eval_fn=bad_eval)],
+        contrasts=[],
+        metric="accuracy",
+        data_loader_factory=stub_factory,
+        n_trials=2,
+    )
+    with pytest.raises(KeyError, match="perplexity"):
+        runner.run()
+
+
+# ---------------------------------------------------------------------------
+# ABExperiment delegation
+# ---------------------------------------------------------------------------
+
+
+def test_ab_experiment_matches_multi_contrast_runner():
+    ab = ABExperiment(
+        arm_a=make_arm("A"),
+        arm_b=make_arm("B"),
+        metric="accuracy",
+        data_loader_factory=stub_factory,
+        n_trials=3,
+    )
+    ab_results = ab.run()
+    multi = run_experiment(["A", "B"], n_trials=3, contrasts=[("A", "B")])
+
+    np.testing.assert_array_equal(ab_results.arm_a_metrics, multi.per_arm_metrics("A"))
+    np.testing.assert_array_equal(ab_results.arm_b_metrics, multi.per_arm_metrics("B"))
+    assert ab_results.seeds == multi.seeds
+    assert ab_results.num_epochs == multi.num_epochs
+
+
+# ---------------------------------------------------------------------------
+# FewShotLoader: cache, remainder batch, seed determinism (tfds-gated,
+# offline via monkeypatched tfds.load)
+# ---------------------------------------------------------------------------
+
+
+class _FakeTensor:
+    def __init__(self, value):
+        self._value = value
+
+    def numpy(self):
+        return self._value
+
+
+@pytest.fixture
+def fewshot_env(monkeypatch):
+    pytest.importorskip("tensorflow")
+    tfds = pytest.importorskip("tensorflow_datasets")
+    from fabricpc.utils.data.dataloader import FewShotLoader
+
+    rng = np.random.default_rng(0)
+    n_per_class, num_classes = 20, 3
+    records = []
+    for c in range(num_classes):
+        for _ in range(n_per_class):
+            img = rng.integers(0, 256, size=(4, 4, 1), dtype=np.uint8)
+            records.append((_FakeTensor(img), _FakeTensor(np.int64(c))))
+
+    load_calls = []
+
+    def fake_load(name, split, as_supervised):
+        load_calls.append((name, split))
+        return records
+
+    monkeypatch.setattr(tfds, "load", fake_load)
+    monkeypatch.setattr(FewShotLoader, "_raw_split_cache", {})  # isolate cache per test
+    return FewShotLoader, load_calls, num_classes
+
+
+def _make_fewshot(cls, num_classes, k=5, batch_size=4, seed=123):
+    return cls(
+        dataset_name="fake_ds",
+        split="train",
+        k_per_class=k,
+        batch_size=batch_size,
+        num_classes=num_classes,
+        shuffle=True,
+        seed=seed,
+        tensor_format="flat",
+    )
+
+
+def test_fewshot_raw_split_loaded_once(fewshot_env):
+    cls, load_calls, num_classes = fewshot_env
+    first = _make_fewshot(cls, num_classes, seed=1)
+    second = _make_fewshot(cls, num_classes, seed=1)
+    assert load_calls == [("fake_ds", "train")]
+    np.testing.assert_array_equal(first.images, second.images)
+    np.testing.assert_array_equal(first.labels, second.labels)
+
+
+def test_fewshot_yields_remainder_batch(fewshot_env):
+    cls, _, num_classes = fewshot_env
+    # 3 classes x 5 shots = 15 samples; batch 4 -> 3 full batches + one of 3.
+    loader = _make_fewshot(cls, num_classes, k=5, batch_size=4)
+    sizes = [x.shape[0] for x, _ in loader]
+    assert sizes == [4, 4, 4, 3]
+    assert len(loader) == 4
+    assert sum(sizes) == loader.num_samples
+
+
+def test_fewshot_same_seed_instances_pair(fewshot_env):
+    """Two fresh same-seed instances yield identical multi-epoch streams —
+    the foundation of the runner's factory-per-arm pairing."""
+    cls, _, num_classes = fewshot_env
+    first = _make_fewshot(cls, num_classes)
+    second = _make_fewshot(cls, num_classes)
+    for _ in range(3):  # three epochs; shuffle advances per pass
+        for (x1, y1), (x2, y2) in zip(first, second):
+            np.testing.assert_array_equal(x1, x2)
+            np.testing.assert_array_equal(y1, y2)


### PR DESCRIPTION
The refactored version of storkey_hopfield_demo.py demonstrates the advantage opf using the hopfield nodes in case of the data scarcity + high noise input. The architecture differs by one of the hidden layers, second one with 128 entries, to be fully-hopfield network. The chosen architecture can be varied by user, e.g. instead of having the linear hidden layers in-between, we can have fully-hopfield arm with 784 neurons and then linear layer that classifies these 784 updated latent states to get probabilities for 10 classes. The two seperate methods in the factory have been replaced with one make_model_factoryThe refactored version of storkey_hopfield_demo.py demonstrates the advantage opf using the hopfield nodes in case of the data scarcity + high noise input. The architecture differs by one of the hidden layers, second one with 128 entries, to be fully-hopfield network. The chosen architecture can be varied by user, e.g. instead of having the linear hidden layers in-between, we can have fully-hopfield arm with 784 neurons and then linear layer that classifies these 784 updated latent states to get probabilities for 10 classes by enabling --all-hopfield argument. This design choice (Fully-Hopfield arm) does not perform well as we scale up the training MNIST dataset or add the noise, it creates a large gap between the MLP and Hopfield accuracy due to incorrect architecture: the Hopfield network is suitable for retrieving the patterns given the partial/corrupted input, while MLP learn the features of the images. Thus, we train the Hopfield network on something that is not suitable for, which is feature extraction and so it disables Hopfield network to perform in what it is good at -- pattern recognition. Here are the runs for the enabled --all-hopfield argument: 

  RESULTS SUMMARY
    Hopfield strength: 2.0
    Trials: 5, Epochs: 20

       K    Noise    Hopfield%         MLP%     Delta%    p-value   Sig        d
      50      0.0 77.18+/-0.28 77.95+/-0.27      -0.77     0.0113     *   -1.985
      50      1.0 71.16+/-0.30 73.20+/-0.26      -2.04     0.0056     *   -2.430
      50      2.0 58.05+/-0.57 62.96+/-0.40      -4.91     0.0001     *   -7.916
     100      0.0 78.51+/-0.43 80.39+/-0.38      -1.88     0.0035     *   -2.750
     100      1.0 70.78+/-0.50 74.15+/-0.54      -3.37     0.0002     *   -5.705
     100      2.0 55.49+/-0.78 61.09+/-0.68      -5.59     0.0002     *   -5.873
     500      0.0 80.08+/-0.89 84.13+/-0.24      -4.04     0.0064     *   -2.338
     500      1.0 71.47+/-0.44 76.06+/-0.27      -4.59     0.0008     *   -4.127
     500      2.0 53.67+/-0.39 59.22+/-0.30      -5.55     0.0010     *   -3.824

  Delta Accuracy Heatmap (Hopfield - MLP, percentage points):

       K  n=0.0  n=1.0  n=2.0
      50  -0.8*  -2.0*  -4.9*
     100  -1.9*  -3.4*  -5.6*
     500  -4.0*  -4.6*  -5.6*

    * = significant at p<0.05 
    
    While using the Hopfield network as one of the hidden states, 128 by 128 weight matrix, we find that the hidden Hopfield layer performs better as the noise in the data increases and the K (number of the samples) increases (use the code documentation as the reference).