### PR TITLE
Development clean-up for storkey_hopfield.py (removing dead code)

### DIFF
--- a/examples/storkey_hopfield_demo.py
+++ b/examples/storkey_hopfield_demo.py
@@ -28,7 +28,7 @@ Results:
 python examples/storkey_hopfield_demo.py --k_values 500 --noise_levels 2.0 --strength 2.0 --n_trials 5 --num_epochs 5
      K    Noise    Hopfield Accuracy %         MLP Accuracy %     Delta%    p-value   Sig        d
 ---------------------------------------------------------------------------------------------------
-   500      2.0          64.94+/-0.33            60.33+/-0.34      +4.61      0.0000     *    11.115
+   500      2.0          64.80+/-0.28            59.70+/-0.27      +5.11      0.0000     *    13.434
 ---------------------------------------------------------------------------------------------------
 
 python examples/storkey_hopfield_demo.py --k_values 5,10,20,50,100,500 --noise_levels 0.0,0.5,1.0,1.5,2.0 --strength 1.0 --n_trials 10 --num_epochs 5

--- a/fabricpc/nodes/storkey_hopfield.py
+++ b/fabricpc/nodes/storkey_hopfield.py
@@ -78,6 +78,7 @@ from fabricpc.core.types import NodeParams, NodeState, NodeInfo
 from fabricpc.core.activations import TanhActivation
 from fabricpc.core.energy import GaussianEnergy
 from fabricpc.core.initializers import (
+    ZerosInitializer,
     NormalInitializer,
     XavierInitializer,
     initialize,
@@ -129,6 +130,7 @@ class StorkeyHopfield(NodeBase):
         enforce_symmetry: Symmetrize W via 0.5*(W+W.T) in forward (default: True).
         zero_diagonal: Zero W diagonal in forward (default: False).
         weight_init: Initializer for weights (default: XavierInitializer()).
+        bias_init: Initializer for biases (default: ZerosInitializer()).
         latent_init: Initializer for latent states (default: NormalInitializer()).
     """
 
@@ -144,6 +146,7 @@ class StorkeyHopfield(NodeBase):
         zero_diagonal: bool = False,
         latent_init: InitializerBase = NormalInitializer(),
         weight_init: InitializerBase = XavierInitializer(),
+        bias_init: InitializerBase = ZerosInitializer(),
     ):
         super().__init__(
             shape=shape,
@@ -152,6 +155,7 @@ class StorkeyHopfield(NodeBase):
             energy=energy,
             latent_init=latent_init,
             weight_init=weight_init,
+            bias_init=bias_init,
             hopfield_strength=hopfield_strength,
             use_bias=use_bias,
             enforce_symmetry=enforce_symmetry,
@@ -210,20 +214,21 @@ class StorkeyHopfield(NodeBase):
             W  # Store W under the input edge key for gradient flow to presynaptic node.
         )
 
-        # Biases
+        # Biases — use_bias and bias_init are defaulted in __init__ and flow
+        # through node_info.node_config; no need to re-default here.
+        # ZerosInitializer ignores key_b, but we pass it so the call generalizes
+        # to any other initializer the user supplies via bias_init.
+        # Bias shape for proper broadcasting, prepending batch dim: (1, ..., 1, out_features)
         biases = {}
-        # Initialize bias (usually zeros)
-        # Bias shape for proper broadcasting, prepending batch dimension: (1, ..., 1, out_features)
-        use_bias = config.get("use_bias", True)
-        if use_bias:
+        if config["use_bias"]:
             bias_shape = (1,) * len(node_shape) + (node_shape[-1],)
-            biases["b"] = jnp.zeros(bias_shape)
+            biases["b"] = initialize(key_b, bias_shape, config["bias_init"])
 
         # Learnable hopfield_strength if not fixed.
         # Stored as an unconstrained raw parameter; jax.nn.softplus is applied
         # in forward() to guarantee effective strength >= 0. Init raw so that
         # softplus(raw) = 1.0.
-        hopfield_strength = config.get("hopfield_strength", None)
+        hopfield_strength = config["hopfield_strength"]
         if hopfield_strength is None:
             biases["hopfield_strength"] = inverse_softplus(jnp.array(1.0))
 

--- a/fabricpc/nodes/storkey_hopfield.py
+++ b/fabricpc/nodes/storkey_hopfield.py
@@ -126,7 +126,7 @@ class StorkeyHopfield(NodeBase):
         hopfield_strength: Scaling of E_hop relative to E_pc.
             If None (default), a learnable scalar initialized to 1.0.
             If a float, fixed at that value.
-        use_bias: Whether to include bias (default: True).
+        use_bias: Whether to include bias (default: False).
         enforce_symmetry: Symmetrize W via 0.5*(W+W.T) in forward (default: True).
         zero_diagonal: Zero W diagonal in forward (default: False).
         weight_init: Initializer for weights (default: XavierInitializer()).

--- a/fabricpc/nodes/storkey_hopfield.py
+++ b/fabricpc/nodes/storkey_hopfield.py
@@ -173,7 +173,7 @@ class StorkeyHopfield(NodeBase):
         node_shape: Tuple[int, ...],
         input_shapes: Dict[str, Tuple[int, ...]],
         weight_init: InitializerBase,
-        config: Optional[Dict[str, Any]] = None,
+        config: Optional[Dict[str, Any]],
     ) -> NodeParams:
         """
         Initialize Hopfield W matrix and biases.
@@ -185,8 +185,6 @@ class StorkeyHopfield(NodeBase):
             - "b": bias vector if use_bias
             - "hopfield_strength": learnable scalar if hopfield_strength is None
         """
-        if config is None:
-            config = {}
 
         # weight_init is defaulted once, in the __init__ signature, and flows
         # in via node_info.weight_init. It is not re-defaulted here — the
@@ -195,16 +193,14 @@ class StorkeyHopfield(NodeBase):
         # Weights
         weights_dict = {}
         D = node_shape[-1]
-        key_hop, key_b = jax.random.split(
-            key,
-        )
+        key_hop, key_b = jax.random.split(key)
 
         # Hopfield W: (D, D)
         W = initialize(key_hop, (D, D), weight_init)
         # Apply symmetry/diagonal constraints at init time too
         W = StorkeyHopfield._prepare_W(W, config)
 
-        # get the first dictionary key and shape (there should only be one input edge for this node)
+        # This node takes a single input edge.
         edge_key, in_shape = next(iter(input_shapes.items()))
         if in_shape[-1] != D:
             raise ValueError(
@@ -214,20 +210,15 @@ class StorkeyHopfield(NodeBase):
             W  # Store W under the input edge key for gradient flow to presynaptic node.
         )
 
-        # Biases — use_bias and bias_init are defaulted in __init__ and flow
-        # through node_info.node_config; no need to re-default here.
-        # ZerosInitializer ignores key_b, but we pass it so the call generalizes
-        # to any other initializer the user supplies via bias_init.
-        # Bias shape for proper broadcasting, prepending batch dim: (1, ..., 1, out_features)
+        # Bias shape broadcasts over the batch dim: (1, ..., 1, out_features).
         biases = {}
         if config["use_bias"]:
             bias_shape = (1,) * len(node_shape) + (node_shape[-1],)
             biases["b"] = initialize(key_b, bias_shape, config["bias_init"])
 
-        # Learnable hopfield_strength if not fixed.
-        # Stored as an unconstrained raw parameter; jax.nn.softplus is applied
-        # in forward() to guarantee effective strength >= 0. Init raw so that
-        # softplus(raw) = 1.0.
+        # Learnable hopfield_strength: stored as an unconstrained raw parameter
+        # Softplus is applied in forward() to guarantee effective strength >= 0
+        # Init raw so that softplus(raw) = 1.0
         hopfield_strength = config["hopfield_strength"]
         if hopfield_strength is None:
             biases["hopfield_strength"] = inverse_softplus(jnp.array(1.0))
@@ -303,44 +294,36 @@ class StorkeyHopfield(NodeBase):
 
         edge_key, input_probe_state = next(iter(inputs.items()))
 
-        # Prepare Hopfield W
+        # Symmetrize the weights
         W = StorkeyHopfield._prepare_W(params.weights[edge_key], config)
 
-        # Resolve hopfield_strength: learnable (softplus-constrained) or fixed.
-        # The learnable raw parameter is unconstrained; softplus ensures the
-        # effective strength is always >= 0.
+        # Learnable strength is stored raw; softplus keeps the effective value >= 0.
         if "hopfield_strength" in params.biases:
             strength = jax.nn.softplus(params.biases["hopfield_strength"])
         else:
-            strength = config.get("hopfield_strength", 1.0)
+            strength = config["hopfield_strength"]
 
         # Strength-weighted blend: probe/(1+s) + (probe @ W)*s/(1+s).
-        # Residual (probe) provides the information pathway; W specializes
-        # in attractor corrections. At strength=0 this is pure pass-through.
+        # The probe residual carries the information pathway while
+        # W specializes in attractor corrections. At s=0 it is a pure
+        # pass-through; the learned projection dominates as s grows.
         blend = 1.0 / (1.0 + strength)
         pre_activation = input_probe_state * blend + (input_probe_state @ W) * (
             1.0 - blend
         )
 
-        # Add bias
         if "b" in params.biases and params.biases["b"].size > 0:
             pre_activation = pre_activation + params.biases["b"]
 
-        # Apply activation (tanh by default)
         activation = node_info.activation
         z_mu = type(activation).forward(pre_activation, activation.config)
-
-        # Prediction error
         error = state.z_latent - z_mu
 
-        # Update state
         state = state._replace(z_mu=z_mu, error=error)
 
-        # Standard PC energy via energy_functional
+        # Standard PC energy, then add the Hopfield attractor energy on top.
         node_class = node_info.node_class
         state = node_class.energy_functional(state, node_info)
-
-        # Add Hopfield attractor energy scaled by strength
         state = StorkeyHopfield.accumulate_hopfield_energy(state, W, strength)
 
         return state


### PR DESCRIPTION
1) The duplication of setting Initializer classes for weight_init and bias_init have been removed from initialize_params (the default Initializer is being set in the signature of the __init__).

2) If the config is not passed to the initialize_params() static method, the old code silently default it to an empty dictionay and the code would eventually crash at config['use_bias'], as it would not find this key in an empty dictionary. The usual case is the initialization of parameters with the base method (fabricpc.graph_initialization.initialize_params() method), so the initialize_paraams is not called during the StorkeyHopfield initialization. I removed the initialization to the empty dictionary for the config, as we already populate config with the base initialize_params method -- fabricpc.graph_initialization.initialize_params(...).

3) Removed the double default for the use_bias, bias_init, hopfield_strength, as it is being configured in the dignature of the __init__ constructor. So, config.get(attribute, default) -> config[attribute].

4) Raise an error if inappropriate value is being passed to the weight_init, specifically, if it is set to None. The default is already XavierInitializer(). No need for None as a default argument.

5) All tests pass for StorkeyHopfield, specifically the ones where the changes have been implemented:
```
TestShapes::test_init_params_1d                              PASSED
TestShapes::test_forward_1d                                  PASSED
TestEnergy::test_energy_decreases_during_inference           PASSED
TestGradients::test_gradient_shapes_and_nonzero              PASSED
TestGradients::test_hopfield_strength_gradient               PASSED
TestSymmetryAndConfig::test_prepare_w_constraints            PASSED
TestSymmetryAndConfig::test_config_options                   PASSED
TestIntegration::test_four_node_graph                        PASSED
```