### PR TITLE
Precision weighting + NGD trainer for predictive coding (ResNet-18/CIFAR-10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,8 @@ nbproject/
 # !important-file.txt
 
 # End of file
+
+# precision_experiment.py sweep outputs
+precision_*.csv
+precision_*.md
+*.progress.csv

--- a/examples/precision_experiment.py
+++ b/examples/precision_experiment.py
@@ -1,0 +1,524 @@
+"""
+Precision-weighting ablation driver for the ResNet-18 CIFAR-10 PC demo.
+
+Runs the demo across seeds for a control arm ("regular" PC, --precision none) and
+one or more treatment arms (e.g. diag_probe), captures each run's test accuracy and
+final train energy, and builds a *paired* statistical comparison of every treatment
+against the control.
+
+Why paired: each seed fixes both the model init and the train-batch order, so the
+per-seed delta (treatment - control at the SAME seed) cancels that shared variance
+and isolates the precision effect. The summary reports mean +/- std per arm, the
+mean paired delta, and a paired t-test p-value (when scipy is available).
+
+Each cell is checkpointed to the CSV as soon as it finishes, so a crash partway
+through a long sweep loses nothing; rerun with --resume to skip completed cells.
+
+Usage (from the repo root):
+    PYTHONPATH=. python examples/precision_experiment.py \
+        --seeds 0 1 2 --num_epochs 30 --activation tanh --eval_every 5
+
+    # quick end-to-end smoke test of the harness itself (2 epochs):
+    PYTHONPATH=. python examples/precision_experiment.py --seeds 0 1 --num_epochs 2 --no_augment
+
+    # resume an interrupted sweep (skips cells already in the CSV):
+    PYTHONPATH=. python examples/precision_experiment.py --seeds 0 1 2 --num_epochs 30 --activation tanh --resume
+
+Outputs:
+    precision_results.csv  — one row per run (raw, append-only, resume source)
+    precision_results.md   — paired summary table, ready to paste into the PR / report
+"""
+
+import argparse
+import csv
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+import time
+
+# Matches the demo's periodic eval line, e.g. "  Epoch 5: accuracy=42.13%"
+_EVAL_RE = re.compile(r"Epoch\s+(\d+):\s*accuracy=([\d.]+)%")
+
+try:
+    from scipy import stats as scipy_stats
+except Exception:  # scipy optional
+    scipy_stats = None
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEMO = os.path.join(REPO_ROOT, "examples", "resnet18_cifar10_demo.py")
+
+CSV_FIELDS = [
+    "seed",
+    "precision",
+    "optimizer",
+    "momentum",
+    "activation",
+    "num_epochs",
+    "batch_size",
+    "accuracy",  # fraction in [0, 1]
+    "final_train_energy",
+    "train_time_s",
+]
+
+
+# ---------------------------------------------------------------------------
+# Running one cell (one seed x one arm) as an isolated subprocess
+# ---------------------------------------------------------------------------
+
+
+def _run_once(cmd, env):
+    """Run the demo subprocess once, streaming output live.
+
+    Returns (result|None, exit_code, evals) where `evals` is a list of
+    (epoch:int, accuracy_pct:float) parsed from the demo's periodic eval lines, so a
+    crash mid-cell still yields the accuracy trajectory captured up to the crash."""
+    proc = subprocess.Popen(
+        cmd,
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    result = None
+    evals = []
+    for line in proc.stdout:
+        sys.stdout.write(line)  # live progress (tqdm, prints)
+        sys.stdout.flush()
+        if line.startswith("[RESULT] "):
+            try:
+                result = json.loads(line[len("[RESULT] ") :])
+            except json.JSONDecodeError:
+                pass
+        else:
+            m = _EVAL_RE.search(line)
+            if m:
+                evals.append((int(m.group(1)), float(m.group(2))))
+    proc.wait()
+    if proc.stdout is not None:
+        proc.stdout.close()  # release the pipe fd promptly (this runs in a retry loop)
+    return result, proc.returncode, evals
+
+
+def append_progress(path, seed, precision, optimizer, momentum, attempt, evals):
+    """Append per-epoch eval rows to a progress CSV so the within-cell accuracy
+    trajectory survives a crash. The `attempt` column disambiguates retries (a retried
+    cell re-emits the same epochs); `optimizer`/`momentum` keep distinct sweeps' (e.g.
+    momentum 0.0 vs 0.9) trajectories separable if they share the same --out."""
+    if not evals:
+        return
+    new = not os.path.exists(path)
+    with open(path, "a", newline="") as f:
+        w = csv.writer(f)
+        if new:
+            w.writerow(
+                [
+                    "seed",
+                    "precision",
+                    "optimizer",
+                    "momentum",
+                    "attempt",
+                    "epoch",
+                    "accuracy_pct",
+                ]
+            )
+        for epoch, acc in evals:
+            w.writerow([seed, precision, optimizer, momentum, attempt, epoch, acc])
+
+
+def run_cell(seed, precision, args):
+    """Run one cell with up to `args.retries` attempts; return the parsed [RESULT] dict
+    or None if every attempt failed. Retries guard against TRANSIENT failures (e.g. the
+    intermittent cuDNN sublibrary mismatch / a momentarily busy GPU) — a systematic error
+    will still fail all attempts and be recorded as failed."""
+    cmd = [
+        sys.executable,
+        DEMO,
+        "--seed",
+        str(seed),
+        "--precision",
+        precision,
+        "--optimizer",
+        args.optimizer,
+        "--momentum",
+        str(args.momentum),
+        "--num_epochs",
+        str(args.num_epochs),
+        "--activation",
+        args.activation,
+        "--batch_size",
+        str(args.batch_size),
+        "--infer_steps",
+        str(args.infer_steps),
+        "--eta_infer",
+        str(args.eta_infer),
+        "--lr",
+        str(args.lr),
+        "--weight_decay",
+        str(args.weight_decay),
+        "--eval_every",
+        str(args.eval_every),
+    ]
+    if args.no_augment:
+        cmd.append("--no_augment")
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = "."
+    env["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
+
+    print("\n" + "=" * 70)
+    print(
+        f">>> RUN  seed={seed}  precision={precision}  "
+        f"epochs={args.num_epochs}  act={args.activation}"
+    )
+    print("=" * 70, flush=True)
+
+    progress_path = os.path.splitext(args.out)[0] + ".progress.csv"
+
+    attempts = max(1, args.retries)
+    for attempt in range(1, attempts + 1):
+        if attempt > 1:
+            print(
+                f">>> retry {attempt}/{attempts} for seed={seed} precision={precision} "
+                f"(sleeping {args.retry_sleep}s first)",
+                flush=True,
+            )
+            if args.retry_sleep > 0:
+                time.sleep(args.retry_sleep)
+        result, rc, evals = _run_once(cmd, env)
+        # Persist the per-epoch trajectory even if the cell ultimately fails, so a
+        # mid-cell crash still leaves the accuracy curve up to the crash on disk.
+        append_progress(
+            progress_path,
+            seed,
+            precision,
+            args.optimizer,
+            args.momentum,
+            attempt,
+            evals,
+        )
+        if result is not None:
+            return result
+        print(
+            f"!!! attempt {attempt}/{attempts} seed={seed} precision={precision} "
+            f"produced no [RESULT] (exit {rc})",
+            file=sys.stderr,
+        )
+
+    print(
+        f"!!! seed={seed} precision={precision} FAILED after {attempts} attempt(s) "
+        f"— recording as failed.",
+        file=sys.stderr,
+    )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# CSV checkpointing
+# ---------------------------------------------------------------------------
+
+
+def load_csv(path):
+    if not os.path.exists(path):
+        return []
+    with open(path, newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def append_csv(path, row):
+    new = not os.path.exists(path)
+    with open(path, "a", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=CSV_FIELDS)
+        if new:
+            w.writeheader()
+        w.writerow({k: row.get(k, "") for k in CSV_FIELDS})
+
+
+def already_done(rows, seed, precision, args):
+    for r in rows:
+        # Old CSVs predate the optimizer/momentum columns -> treat missing as adamw / 0.0.
+        if (
+            int(r["seed"]) == seed
+            and r["precision"] == precision
+            and r.get("optimizer", "adamw") == args.optimizer
+            and float(r.get("momentum") or 0.0) == args.momentum
+            and int(r["num_epochs"]) == args.num_epochs
+            and r["activation"] == args.activation
+            and r["accuracy"] not in ("", "nan")
+        ):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Statistics
+# ---------------------------------------------------------------------------
+
+
+def mean(xs):
+    return sum(xs) / len(xs) if xs else float("nan")
+
+
+def std(xs):
+    # sample standard deviation (ddof=1)
+    if len(xs) < 2:
+        return float("nan")
+    m = mean(xs)
+    return math.sqrt(sum((x - m) ** 2 for x in xs) / (len(xs) - 1))
+
+
+def paired_ttest(treat, ctrl):
+    """Return (mean_delta, std_delta, t_stat, p_value, n). p/t are nan without scipy."""
+    deltas = [t - c for t, c in zip(treat, ctrl)]
+    n = len(deltas)
+    md, sd = mean(deltas), std(deltas)
+    t = p = float("nan")
+    if scipy_stats is not None and n >= 2:
+        t, p = scipy_stats.ttest_rel(treat, ctrl)
+    elif n >= 2 and sd > 0:
+        t = md / (sd / math.sqrt(n))  # p left nan (no t-distribution without scipy)
+    return md, sd, float(t), float(p), n
+
+
+# ---------------------------------------------------------------------------
+# Table building
+# ---------------------------------------------------------------------------
+
+
+def build_report(rows, args):
+    """Build the paired markdown report from CSV rows matching this config."""
+    # index: (seed, precision) -> {accuracy, final_train_energy}
+    cells = {}
+    for r in rows:
+        # Filter to this sweep's config; old CSVs lack optimizer/momentum -> adamw / 0.0.
+        if (
+            int(r["num_epochs"]) != args.num_epochs
+            or r["activation"] != args.activation
+            or r.get("optimizer", "adamw") != args.optimizer
+            or float(r.get("momentum") or 0.0) != args.momentum
+        ):
+            continue
+        if r["accuracy"] in ("", "nan"):
+            continue
+        cells[(int(r["seed"]), r["precision"])] = {
+            "acc": float(r["accuracy"]) * 100.0,
+            "energy": float(r["final_train_energy"]),
+        }
+
+    control = args.control
+    treatments = [a for a in args.arms if a != control]
+    seeds = sorted({s for (s, p) in cells})
+
+    lines = []
+    lines.append(f"# Precision weighting ablation — ResNet-18 / CIFAR-10 (PC + muPC)\n")
+    opt_desc = args.optimizer + (
+        f" (momentum {args.momentum})"
+        if args.optimizer == "ngd" and args.momentum
+        else ""
+    )
+    lines.append(
+        f"- Config: **{args.num_epochs} epochs**, optimizer **{opt_desc}**, "
+        f"activation **{args.activation}**, batch {args.batch_size}, "
+        f"infer_steps {args.infer_steps}, lr {args.lr}, "
+        f"augment={'off' if args.no_augment else 'on'}"
+    )
+    lines.append(f"- Control arm: `{control}` (regular PC, isotropic precision Pi=1)")
+    lines.append(f"- Seeds: {seeds}  (paired: each seed fixes init + batch order)\n")
+
+    for treat in treatments:
+        paired_seeds = [
+            s for s in seeds if (s, control) in cells and (s, treat) in cells
+        ]
+        if not paired_seeds:
+            lines.append(f"## `{treat}` vs `{control}` — no paired seeds yet\n")
+            continue
+
+        ctrl_acc = [cells[(s, control)]["acc"] for s in paired_seeds]
+        treat_acc = [cells[(s, treat)]["acc"] for s in paired_seeds]
+        ctrl_en = [cells[(s, control)]["energy"] for s in paired_seeds]
+        treat_en = [cells[(s, treat)]["energy"] for s in paired_seeds]
+
+        lines.append(f"## `{treat}` vs `{control}`\n")
+        lines.append(
+            "| seed | acc {ctrl} (%) | acc {tr} (%) | Δacc (pts) | "
+            "energy {ctrl} | energy {tr} | Δenergy |".format(ctrl=control, tr=treat)
+        )
+        lines.append("|---|---|---|---|---|---|---|")
+        for s in paired_seeds:
+            a_c, a_t = cells[(s, control)]["acc"], cells[(s, treat)]["acc"]
+            e_c, e_t = cells[(s, control)]["energy"], cells[(s, treat)]["energy"]
+            lines.append(
+                f"| {s} | {a_c:.2f} | {a_t:.2f} | {a_t - a_c:+.2f} | "
+                f"{e_c:.4f} | {e_t:.4f} | {e_t - e_c:+.4f} |"
+            )
+
+        md_a, sd_a, t_a, p_a, n = paired_ttest(treat_acc, ctrl_acc)
+        md_e, sd_e, _, _, _ = paired_ttest(treat_en, ctrl_en)
+
+        lines.append("")
+        lines.append(
+            f"**Accuracy** — {control}: {mean(ctrl_acc):.2f} ± {std(ctrl_acc):.2f} | "
+            f"{treat}: {mean(treat_acc):.2f} ± {std(treat_acc):.2f}"
+        )
+        lines.append(
+            f"**Paired Δacc**: {md_a:+.2f} ± {sd_a:.2f} pts over n={n} seeds"
+            + (
+                f"  (paired t={t_a:.2f}, p={p_a:.4f})"
+                if not math.isnan(p_a)
+                else f"  (t={t_a:.2f}; install scipy for p-value)"
+            )
+        )
+        lines.append(
+            f"**Paired Δenergy**: {md_e:+.4f} ± {sd_e:.4f} "
+            f"(negative = lower/better energy)\n"
+        )
+
+        verdict = "FAVORS precision" if md_a > 0 else "favors control / no gain"
+        sig = (
+            ""
+            if math.isnan(p_a)
+            else (
+                " — significant at 0.05" if p_a < 0.05 else " — NOT significant at 0.05"
+            )
+        )
+        lines.append(
+            f"> Verdict: mean paired Δacc {md_a:+.2f} pts ({verdict}){sig}. "
+            f"n={n} is small — treat p-values as indicative, not definitive.\n"
+        )
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Precision-weighting paired ablation driver"
+    )
+    p.add_argument("--seeds", type=int, nargs="+", default=[0, 1, 2])
+    p.add_argument(
+        "--arms",
+        type=str,
+        nargs="+",
+        default=["none", "diag_probe"],
+        help="Arms to run; the control must be among them.",
+    )
+    p.add_argument(
+        "--control",
+        type=str,
+        default="none",
+        help="Control arm every treatment is compared against (default: none)",
+    )
+    p.add_argument(
+        "--optimizer",
+        type=str,
+        default="adamw",
+        choices=["adamw", "ngd"],
+        help="Optimizer for ALL arms in this sweep. 'ngd' = SGD so "
+        "precision acts as the per-channel adaptive LR (use with "
+        "--arms none online for the faithful NGD test). Default adamw. "
+        "Recorded per-row; the report keys on it so adamw/ngd rows in "
+        "the same CSV are never conflated.",
+    )
+    p.add_argument(
+        "--momentum",
+        type=float,
+        default=0.0,
+        help="SGD momentum passed to every cell (only affects --optimizer ngd; "
+        "0.0 = plain SGD, try 0.9). Default 0.0.",
+    )
+    p.add_argument("--num_epochs", type=int, default=30)
+    p.add_argument(
+        "--activation",
+        type=str,
+        default="tanh",
+        choices=["relu", "tanh", "gelu", "leaky_relu"],
+    )
+    p.add_argument("--batch_size", type=int, default=256)
+    p.add_argument("--infer_steps", type=int, default=80)
+    p.add_argument("--eta_infer", type=float, default=0.1)
+    p.add_argument("--lr", type=float, default=0.01)
+    p.add_argument("--weight_decay", type=float, default=0.01)
+    p.add_argument("--eval_every", type=int, default=5)
+    p.add_argument("--no_augment", action="store_true")
+    p.add_argument(
+        "--gpu", type=str, default="0", help="CUDA_VISIBLE_DEVICES for child runs"
+    )
+    p.add_argument(
+        "--retries",
+        type=int,
+        default=2,
+        help="Max attempts per cell; retries guard transient failures "
+        "(e.g. intermittent cuDNN mismatch / busy GPU). Default 2.",
+    )
+    p.add_argument(
+        "--retry_sleep",
+        type=float,
+        default=10.0,
+        help="Seconds to wait before each retry (lets a transient GPU/cuDNN "
+        "state clear). Default 10.",
+    )
+    p.add_argument("--out", type=str, default="precision_results.csv")
+    p.add_argument("--md", type=str, default="precision_results.md")
+    p.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip (seed, arm) cells already present in --out",
+    )
+    p.add_argument(
+        "--report_only",
+        action="store_true",
+        help="Skip running; just rebuild the markdown report from --out",
+    )
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    if args.control not in args.arms:
+        sys.exit(f"--control '{args.control}' must be one of --arms {args.arms}")
+
+    if not args.report_only:
+        existing = load_csv(args.out)
+        # Run control first per seed, then treatments (so partial reports are paired).
+        ordered_arms = [args.control] + [a for a in args.arms if a != args.control]
+        for seed in args.seeds:
+            for arm in ordered_arms:
+                if args.resume and already_done(existing, seed, arm, args):
+                    print(
+                        f"--resume: skipping seed={seed} precision={arm} (already done)"
+                    )
+                    continue
+                result = run_cell(seed, arm, args)
+                if result is None:
+                    result = {  # record the failure so it's visible / resumable
+                        "seed": seed,
+                        "precision": arm,
+                        "optimizer": args.optimizer,
+                        "momentum": args.momentum,
+                        "activation": args.activation,
+                        "num_epochs": args.num_epochs,
+                        "batch_size": args.batch_size,
+                        "accuracy": "nan",
+                        "final_train_energy": "nan",
+                        "train_time_s": "nan",
+                    }
+                append_csv(args.out, result)
+
+    rows = load_csv(args.out)
+    report = build_report(rows, args)
+    with open(args.md, "w") as f:
+        f.write(report)
+    print("\n" + report)
+    print(f"\nRaw results: {args.out}   Summary table: {args.md}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/resnet18_cifar10_demo.py
+++ b/examples/resnet18_cifar10_demo.py
@@ -28,17 +28,31 @@ Includes cosine LR schedule with warmup and optional data augmentation
 (random horizontal flip + random crop with padding).
 
 Usage:
-    python examples/resnet18_cifar10_demo.py --quick              # 2-epoch smoke test
-    python examples/resnet18_cifar10_demo.py --activation tanh    # with tanh instead of relu
-    python examples/resnet18_cifar10_demo.py --num_epochs 100 --activation tanh --eval_every 10
+    python examples/resnet18_cifar10_demo.py --quick                 # 2-epoch smoke test
+    python examples/resnet18_cifar10_demo.py --num_epochs 30 --activation tanh --eval_every 5
 
+    Precision (--precision): none (Pi=1, baseline) | diag_probe (frozen per-channel Pi=1/Var
+        from a one-pass residual probe) | online (Pi learned each step via EMA -- the NGD scheme).
+    Optimizer (--optimizer): adamw (default) | ngd (plain SGD, so precision acts as the
+        per-channel adaptive LR). --momentum M (ngd only; ~10x's the effective step, use lower lr).
+    --seed S (independent run, for error bars); --probe_latents (per-node latent/error/move RMS).
 
-python examples/resnet18_cifar10_demo.py --quick
-Model: 31 nodes, 38 edges
-Total parameters: 2,795,210
-Train energy: 0.1020
-Test Accuracy: 40.89%
-Training time: 623.3s (311.6s per epoch)
+    # NGD arm (precision as the adaptive LR): online precision + SGD + momentum.
+    python examples/resnet18_cifar10_demo.py --precision online --optimizer ngd \\
+        --momentum 0.9 --lr 0.02 --activation tanh --num_epochs 30
+
+Multi-seed paired sweeps + significance stats: examples/precision_experiment.py.
+
+Results (CIFAR-10, muPC, tanh; diag_probe vs none Pi=1 baseline, AdamW):
+    - Early training (2 epochs): diag_probe CONSISTENTLY beats the baseline across seeds
+      (+1.6 / +2.8 / +3.1 pts, lower train energy) -- a convergence-speed / conditioning gain.
+    - At convergence (30 epochs, 3 seeds): the gap WASHES OUT -- none 42.03 +/- 0.23% vs
+      diag_probe 42.01 +/- 1.15%; paired Delta_acc = -0.02 pts (p=0.98, not significant);
+      energy marginally lower for diag_probe. Precision speeds early convergence but does NOT
+      change the converged accuracy ceiling.
+    - NGD (online precision + plain SGD) trains far slower than AdamW and does not reach the
+      AdamW baseline in this setup.
+    Precision weighting is a conditioning/robustness lever, not a path to backprop accuracy.
 """
 
 from jax_setup import set_jax_flags_before_importing_jax
@@ -50,6 +64,7 @@ import jax.numpy as jnp
 import numpy as np
 import optax
 import argparse
+import json
 import time
 from fabricpc.nodes import ConvNode, Linear, IdentityNode, SkipConnection, AvgPool
 from fabricpc.core.topology import Edge
@@ -72,6 +87,9 @@ from fabricpc.core.initializers import (
 )
 from fabricpc.core.mupc import MuPCConfig
 from fabricpc.training import train_pcn, evaluate_pcn
+from fabricpc.training.train import _convert_batch
+from fabricpc.training.ngd_trainer import train_ngd, probe_latent_propagation
+from fabricpc.core.precision import probe_residual_precision
 from fabricpc.utils.data.dataloader import Cifar10Loader
 
 jax.config.update("jax_default_prng_impl", "threefry2x32")
@@ -147,6 +165,13 @@ class AugmentedCifar10Loader:
 # =============================================================================
 
 
+def _gauss_energy(name, precision_map):
+    """GaussianEnergy for `name`, with diagonal precision from the probe if present."""
+    if precision_map is not None and name in precision_map:
+        return GaussianEnergy(precision=precision_map[name])
+    return GaussianEnergy()
+
+
 def make_residual_block(
     prev_node,
     channels,
@@ -154,6 +179,7 @@ def make_residual_block(
     block_name,
     weight_init,
     activation=None,
+    precision_map=None,
 ):
     """
     Create one residual block: conv_a -> conv_b(act) -> skip(sum).
@@ -184,6 +210,7 @@ def make_residual_block(
         padding="SAME",
         activation=activation,
         weight_init=weight_init,
+        energy=_gauss_energy(f"{block_name}_conv_a", precision_map),
         name=f"{block_name}_conv_a",
     )
 
@@ -194,11 +221,13 @@ def make_residual_block(
         padding="SAME",
         activation=activation,
         weight_init=weight_init,
+        energy=_gauss_energy(f"{block_name}_conv_b", precision_map),
         name=f"{block_name}_conv_b",
     )
 
     skip_node = SkipConnection(
         shape=(out_h, out_w, channels),
+        energy=_gauss_energy(f"{block_name}_skip_sum", precision_map),
         name=f"{block_name}_skip_sum",
     )
 
@@ -219,6 +248,7 @@ def make_residual_block(
             padding="SAME",
             activation=IdentityActivation(),
             weight_init=weight_init,
+            energy=_gauss_energy(f"{block_name}_skip", precision_map),
             name=f"{block_name}_skip",
         )
         nodes.append(conv_skip)
@@ -235,6 +265,7 @@ def build_resnet18(
     scaling=None,
     output_weight_init=None,
     activation=None,
+    precision_map=None,
     *,
     infer_steps,
     eta_infer,
@@ -269,6 +300,7 @@ def build_resnet18(
         padding="SAME",
         activation=activation,
         weight_init=weight_init,
+        energy=_gauss_energy("stem", precision_map),
         name="stem",
     )
 
@@ -296,13 +328,19 @@ def build_resnet18(
                 block_name=block_name,
                 weight_init=weight_init,
                 activation=activation,
+                precision_map=precision_map,
             )
             all_nodes.extend(nodes)
             all_edges.extend(edges)
             prev = add_node
 
     # Global average pooling: (B, 4, 4, 256) -> (B, 256)
-    avg_pool = AvgPool(shape=(256,), name="avgpool", global_pool=True)
+    avg_pool = AvgPool(
+        shape=(256,),
+        name="avgpool",
+        global_pool=True,
+        energy=_gauss_energy("avgpool", precision_map),
+    )
     all_nodes.append(avg_pool)
     all_edges.append(Edge(source=prev, target=avg_pool.slot("in")))
 
@@ -337,17 +375,43 @@ def build_resnet18(
 # =============================================================================
 
 
-def _create_mupc_model(rng_key, *, infer_steps, eta_infer, activation=None):
-    """Create ResNet-18 with muPC parameterization."""
-    structure = build_resnet18(
+def _create_mupc_model(
+    rng_key,
+    *,
+    infer_steps,
+    eta_infer,
+    activation=None,
+    precision_mode="none",
+    probe_batch=None,
+    probe_key=None,
+):
+    """Create ResNet-18 with muPC parameterization.
+
+    precision_mode: "none" (Pi=1) | "diag_probe" (frozen per-channel Pi=1/Var from one
+    clamped inference pass) | "online" (built as none; Pi learned in the NGD trainer).
+    """
+    build = lambda precision_map=None: build_resnet18(
         weight_init=MuPCInitializer(),
         scaling=MuPCConfig(include_output=False),
         output_weight_init=XavierInitializer(),
         activation=activation,
+        precision_map=precision_map,
         infer_steps=infer_steps,
         eta_infer=eta_infer,
     )
+    structure = build()
     params = initialize_params(structure, rng_key)
+    if precision_mode == "diag_probe":
+        if probe_batch is None or probe_key is None:
+            raise ValueError("diag_probe requires probe_batch and probe_key")
+        precision_map = probe_residual_precision(
+            params, structure, probe_batch, probe_key
+        )
+        structure = build(precision_map)
+        print(
+            f"Precision probe: diagonal Pi estimated for {len(precision_map)} "
+            f"Gaussian-energy nodes (per-channel 1/Var, mean-normalized)."
+        )
     return params, structure
 
 
@@ -368,15 +432,34 @@ def run_single_mupc(args):
         f"LR: {args.lr}  |  Augment: {not args.no_augment}"
     )
 
-    master_rng_key = jax.random.PRNGKey(42)
-    graph_key, train_key, eval_key = jax.random.split(master_rng_key, 3)
+    master_rng_key = jax.random.PRNGKey(args.seed)
+    graph_key, train_key, eval_key, probe_key = jax.random.split(master_rng_key, 4)
+
+    # Data (built before the model so the precision probe can use a real batch); the
+    # train-shuffle seed is tied to --seed so each seed is a fully independent run.
+    base_train_loader = Cifar10Loader(
+        "train", batch_size=args.batch_size, shuffle=True, seed=args.seed
+    )
+    if args.no_augment:
+        train_loader = base_train_loader
+    else:
+        train_loader = AugmentedCifar10Loader(base_train_loader, seed=args.seed)
+    test_loader = Cifar10Loader("test", batch_size=args.batch_size, shuffle=False)
+
+    probe_batch = None
+    if args.precision == "diag_probe":
+        probe_batch = _convert_batch(next(iter(train_loader)))
 
     # Build model
+    print(f"Precision weighting: {args.precision}")
     params, structure = _create_mupc_model(
         graph_key,
         infer_steps=args.infer_steps,
         eta_infer=args.eta_infer,
         activation=activation,
+        precision_mode=args.precision,
+        probe_batch=probe_batch,
+        probe_key=probe_key,
     )
 
     # Print model summary
@@ -384,16 +467,6 @@ def run_single_mupc(args):
 
     total_params = sum(p.size for p in jax.tree_util.tree_leaves(params))
     print(f"Total parameters: {total_params:,}")
-
-    # Data
-    base_train_loader = Cifar10Loader(
-        "train", batch_size=args.batch_size, shuffle=True, seed=42
-    )
-    if args.no_augment:
-        train_loader = base_train_loader
-    else:
-        train_loader = AugmentedCifar10Loader(base_train_loader, seed=42)
-    test_loader = Cifar10Loader("test", batch_size=args.batch_size, shuffle=False)
 
     # Cosine LR schedule with warmup
     steps_per_epoch = len(train_loader)
@@ -407,7 +480,15 @@ def run_single_mupc(args):
         decay_steps=total_steps,
         end_value=args.lr * 0.01,
     )
-    optimizer = optax.adamw(schedule, weight_decay=args.weight_decay)
+    if args.optimizer == "ngd":
+        # plain SGD so the per-channel precision acts as the adaptive LR; momentum (0.0 ->
+        # None = plain SGD) makes the narrow stable-LR regime trainable.
+        optimizer = optax.sgd(schedule, momentum=(args.momentum or None))
+        if args.momentum:
+            print(f"  ngd: SGD with momentum={args.momentum}")
+    else:
+        optimizer = optax.adamw(schedule, weight_decay=args.weight_decay)
+    print(f"Optimizer: {args.optimizer}")
     train_config = {"num_epochs": args.num_epochs}
 
     # Periodic evaluation callback
@@ -418,7 +499,9 @@ def run_single_mupc(args):
         if eval_every > 0 and (
             epoch_num % eval_every == 0 or epoch_num == args.num_epochs
         ):
-            metrics = evaluate_pcn(params, structure, test_loader, config, eval_key)
+            metrics = evaluate_pcn(
+                params, structure, test_loader, train_config, eval_key
+            )
             print(f"  Epoch {epoch_num}: accuracy={metrics['accuracy'] * 100:.2f}%")
             return metrics
         return None
@@ -429,16 +512,30 @@ def run_single_mupc(args):
     )
     start_time = time.time()
 
-    trained_params, energy_history, _ = train_pcn(
-        params=params,
-        structure=structure,
-        train_loader=train_loader,
-        optimizer=optimizer,
-        config=train_config,
-        rng_key=train_key,
-        verbose=False,
-        epoch_callback=epoch_callback,
-    )
+    learned_precision = None
+    if args.precision == "online":
+        trained_params, learned_precision, energy_history = train_ngd(
+            params=params,
+            structure=structure,
+            train_loader=train_loader,
+            optimizer=optimizer,
+            num_epochs=args.num_epochs,
+            rng_key=train_key,
+            lam=args.precision_lam,
+            epoch_callback=epoch_callback,
+            verbose=False,
+        )
+    else:
+        trained_params, energy_history, _ = train_pcn(
+            params=params,
+            structure=structure,
+            train_loader=train_loader,
+            optimizer=optimizer,
+            config=train_config,
+            rng_key=train_key,
+            verbose=False,
+            epoch_callback=epoch_callback,
+        )
 
     elapsed = time.time() - start_time
     print(
@@ -451,6 +548,44 @@ def run_single_mupc(args):
         trained_params, structure, test_loader, train_config, eval_key
     )
     print(f"Test Accuracy: {metrics['accuracy'] * 100:.2f}%")
+
+    if args.probe_latents:
+        probe_b = _convert_batch(next(iter(test_loader)))
+        report = probe_latent_propagation(
+            trained_params,
+            structure,
+            probe_b,
+            eval_key,
+            precision_map=learned_precision,
+        )
+        print("\nLatent propagation (per node, topological order):")
+        print(
+            f"  {'node':<18}{'in_deg':>7}{'z_rms':>10}{'err_rms':>10}{'move_rms':>10}"
+        )
+        for name, m in report.items():
+            print(
+                f"  {name:<18}{m['in_degree']:>7}{m['z_rms']:>10.4f}"
+                f"{m['err_rms']:>10.4f}{m['move_rms']:>10.4f}"
+            )
+
+    final_energy = float("nan")
+    if energy_history and energy_history[-1]:
+        last_epoch = energy_history[-1]
+        final_energy = float(sum(last_epoch) / len(last_epoch))
+    result = {
+        "seed": args.seed,
+        "precision": args.precision,
+        "optimizer": args.optimizer,
+        "momentum": args.momentum,
+        "activation": args.activation,
+        "num_epochs": args.num_epochs,
+        "batch_size": args.batch_size,
+        "accuracy": float(metrics["accuracy"]),
+        "final_train_energy": final_energy,
+        "train_time_s": float(elapsed),
+    }
+    print("[RESULT] " + json.dumps(result))
+    return result
 
 
 # =============================================================================
@@ -475,7 +610,7 @@ def parse_args():
         "--eta_infer", type=float, default=0.1, help="Inference rate (default: 0.1)"
     )
     parser.add_argument(
-        "--lr", type=float, default=0.01, help="Learning rate (default: 0.001)"
+        "--lr", type=float, default=0.01, help="Learning rate (default: 0.01)"
     )
     parser.add_argument(
         "--weight_decay", type=float, default=0.01, help="Weight decay (default: 0.01)"
@@ -486,6 +621,44 @@ def parse_args():
         default="relu",
         choices=["relu", "tanh", "gelu", "leaky_relu"],
         help="Activation function for hidden layers (default: relu)",
+    )
+    parser.add_argument(
+        "--precision",
+        type=str,
+        default="none",
+        choices=["none", "diag_probe", "online"],
+        help="Precision weighting: none (Pi=1) | diag_probe (frozen per-channel 1/Var) | "
+        "online (per-step EMA, the NGD scheme). Default none",
+    )
+    parser.add_argument(
+        "--optimizer",
+        type=str,
+        default="adamw",
+        choices=["adamw", "ngd"],
+        help="adamw (default) | ngd (plain SGD; precision acts as the adaptive LR)",
+    )
+    parser.add_argument(
+        "--momentum",
+        type=float,
+        default=0.0,
+        help="SGD momentum for --optimizer ngd (0.0=plain SGD; try 0.9). Ignored for adamw.",
+    )
+    parser.add_argument(
+        "--precision_lam",
+        type=float,
+        default=0.05,
+        help="EMA rate for online precision (only with --precision online; default 0.05)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Master seed for model init AND train-shuffle order (default: 42)",
+    )
+    parser.add_argument(
+        "--probe_latents",
+        action="store_true",
+        help="After training, print a per-node latent-propagation table.",
     )
     parser.add_argument(
         "--no_augment",
@@ -509,6 +682,8 @@ def parse_args():
 
 def main():
     args = parse_args()
+    if not (0.0 <= args.momentum < 1.0):
+        raise SystemExit(f"--momentum must be in [0.0, 1.0); got {args.momentum}")
     if args.quick:
         args.num_epochs = 2
         args.no_augment = True

--- a/fabricpc/core/__init__.py
+++ b/fabricpc/core/__init__.py
@@ -38,6 +38,7 @@ from fabricpc.core.energy import (
     compute_energy_gradient,
     get_energy_and_gradient,
 )
+from fabricpc.core.precision import probe_residual_precision
 
 # Inference functions and classes
 from fabricpc.core.inference import (
@@ -92,6 +93,7 @@ __all__ = [
     "compute_energy",
     "compute_energy_gradient",
     "get_energy_and_gradient",
+    "probe_residual_precision",
     # Inference
     "InferenceBase",
     "InferenceSGD",

--- a/fabricpc/core/energy.py
+++ b/fabricpc/core/energy.py
@@ -148,8 +148,10 @@ class GaussianEnergy(EnergyFunctional):
         precision: 1/sigma^2 (default: 1.0). Higher values = sharper distributions.
     """
 
-    def __init__(self, precision=1.0):
-        super().__init__(precision=precision)
+    def __init__(self, precision=1.0, include_log_precision=False):
+        super().__init__(
+            precision=precision, include_log_precision=include_log_precision
+        )
 
     @staticmethod
     def energy(
@@ -160,11 +162,19 @@ class GaussianEnergy(EnergyFunctional):
 
         Sums over all non-batch dimensions.
         """
-        precision = config.get("precision", 1.0) if config else 1.0
+        cfg = config or {}
+        precision = cfg.get("precision", 1.0)
         diff = z_latent - z_mu
-        # Sum over all non-batch dimensions
+        # Precision is applied INSIDE the sum so a per-feature (diagonal) precision vector
+        # broadcasts over the feature/channel axis. Identical to the scalar form for a scalar.
         axes_to_sum = tuple(range(1, len(diff.shape)))
-        return 0.5 * precision * jnp.sum(diff**2, axis=axes_to_sum)
+        e = 0.5 * jnp.sum(precision * diff**2, axis=axes_to_sum)
+        if cfg.get("include_log_precision", False):
+            # +0.5*sum(ln(2*pi) - ln Pi): Gaussian NLL normalizer. CONSTANT in z and W, so it
+            # does not affect inference/weight gradients; reported for the true free energy.
+            normalizer = 0.5 * (jnp.log(2.0 * jnp.pi) - jnp.log(jnp.asarray(precision)))
+            e = e + jnp.sum(jnp.broadcast_to(normalizer, diff.shape[1:]))
+        return e
 
     @staticmethod
     def grad_latent(

--- a/fabricpc/core/precision.py
+++ b/fabricpc/core/precision.py
@@ -1,0 +1,135 @@
+"""
+Diagonal precision estimation for predictive-coding graphs.
+
+In a Gaussian predictive-coding network the energy of layer ``l`` is
+
+    E_l = (1/2) * (z_l - mu_l)^T Pi_l (z_l - mu_l)
+
+where ``Pi_l = Sigma_l^{-1}`` is the precision (inverse covariance) of the
+prediction error ``e_l = z_l - mu_l``. With ``Pi_l = I`` (the framework default)
+every feature contributes to the energy in proportion to its raw error variance,
+so in a deep residual network the channels/layers whose errors happen to be large
+dominate the global energy and drown out the rest. This is one of the mechanisms
+behind depth degradation in deep PC.
+
+Setting ``Pi_l`` to (an estimate of) the inverse error covariance whitens the
+errors: every feature is rescaled to unit precision-weighted variance, so each
+channel keeps an equal voice. A **diagonal** ``Pi_l`` (this module) is the cheap,
+per-feature version of that whitening — the predictive-coding analogue of a
+diagonal natural-gradient (NGD) preconditioner.
+
+``probe_residual_precision`` runs a single clamped inference pass over one batch,
+measures the per-channel residual variance at every internal Gaussian-energy node,
+and returns ``Pi_l = 1 / (Var(e_l) + eps)`` as a per-node vector. The estimate is
+frozen (static config); it does not adapt during training. Feed the returned map
+back into the graph builder so each node is constructed with
+``GaussianEnergy(precision=Pi_l)``.
+"""
+
+from typing import Dict, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from fabricpc.core.energy import GaussianEnergy
+from fabricpc.core.inference import run_inference
+from fabricpc.core.types import GraphParams, GraphStructure
+
+
+def probe_residual_precision(
+    params: GraphParams,
+    structure: GraphStructure,
+    batch: Dict[str, jnp.ndarray],
+    rng_key: jax.Array,
+    *,
+    eps: float = 1e-3,
+    clip: Optional[Tuple[float, float]] = (0.1, 10.0),
+    normalize: str = "mean",
+    channel_axis: int = -1,
+) -> Dict[str, np.ndarray]:
+    """
+    Estimate a per-node diagonal precision from one clamped inference pass.
+
+    The pass clamps the same task nodes that PC *training* clamps (every entry
+    of ``batch`` whose key is in ``structure.task_map`` — typically both the
+    input ``x`` and the target ``y``), so the measured residuals are the ones
+    the network actually learns from. For each internal node carrying a
+    ``GaussianEnergy`` the per-channel error variance is measured and inverted.
+
+    Args:
+        params: Model parameters (precision is independent of these — any
+            initialized params for ``structure`` are fine).
+        structure: The graph to probe. Must already be finalized (built).
+        batch: A batch of data with task-named keys (e.g. ``{"x": ..., "y": ...}``).
+        rng_key: PRNG key for latent-state initialization.
+        eps: Floor added to the variance before inversion (numerical stability
+            and a cap on how large precision can get for near-dead channels).
+        clip: Optional ``(lo, hi)`` clamp applied to the precision *after*
+            normalization, to bound the effect of extreme channels. ``None``
+            disables clipping.
+        normalize: Per-node normalization of the precision vector:
+            - ``"mean"`` (default): divide by the mean so the average precision
+              is 1.0. Preserves the layer's overall energy scale (so the learning
+              rate need not be retuned) while redistributing weight across
+              channels — this isolates the *diagonal* (whitening) effect from any
+              change in cross-layer balance, which remains muPC's job.
+            - ``"none"``: return the raw ``1/(var+eps)`` (changes energy scale).
+        channel_axis: Axis treated as the feature/channel axis (default ``-1``).
+            Variance is reduced over every other axis.
+
+    Returns:
+        Dict mapping node name -> diagonal precision vector (``np.float32``,
+        shape ``(C,)``) for every internal (``in_degree > 0``) Gaussian-energy
+        node. Nodes with non-Gaussian energy (e.g. the softmax/cross-entropy
+        output) and terminal input nodes are omitted; build those with their
+        default energy.
+    """
+    if normalize not in ("mean", "none"):
+        raise ValueError(f"normalize must be 'mean' or 'none', got {normalize!r}")
+
+    batch_size = next(iter(batch.values())).shape[0]
+
+    # Clamp every task node present in the batch (training-style: x and y).
+    clamps = {
+        structure.task_map[task_name]: value
+        for task_name, value in batch.items()
+        if task_name in structure.task_map
+    }
+
+    # Run inference to equilibrium. JIT-compiled (same calls train uses) so the
+    # one-off probe over a full batch stays cheap; structure/rng_key are captured
+    # as constants, params/clamps are traced.
+    from fabricpc.graph_initialization.state_initializer import initialize_graph_state
+
+    def _infer(p, clamp_arrays):
+        init_state = initialize_graph_state(
+            structure, batch_size, rng_key, clamps=clamp_arrays, params=p
+        )
+        return run_inference(p, init_state, clamp_arrays, structure)
+
+    final_state = jax.jit(_infer)(params, clamps)
+
+    precision_map: Dict[str, np.ndarray] = {}
+    for node_name, node in structure.nodes.items():
+        info = node.node_info
+        if info.in_degree == 0:
+            continue
+        if not isinstance(info.energy, GaussianEnergy):
+            continue
+
+        error = final_state.nodes[node_name].error  # (batch, *spatial, C)
+        axis = channel_axis % error.ndim
+        reduce_axes = tuple(i for i in range(error.ndim) if i != axis)
+
+        var = jnp.var(error, axis=reduce_axes)  # (C,)
+        precision = 1.0 / (var + eps)
+
+        if normalize == "mean":
+            precision = precision / jnp.mean(precision)
+        if clip is not None:
+            precision = jnp.clip(precision, clip[0], clip[1])
+
+        precision_map[node_name] = np.asarray(precision, dtype=np.float32)
+
+    return precision_map

--- a/fabricpc/core/types.py
+++ b/fabricpc/core/types.py
@@ -127,6 +127,12 @@ class NodeState(NamedTuple):
     energy: jnp.ndarray  # per-sample energy, shape (batch_size,)
     pre_activation: jnp.ndarray
     latent_grad: jnp.ndarray  # For local gradient accumulation
+    # Optional per-node DIAGONAL precision (inverse error variance), broadcast over the
+    # feature/channel axis. None (default) -> energy uses the static config precision
+    # (standard behavior, no extra pytree leaves -> backward-compatible). When set (online
+    # NGD trainer), energy_functional uses it, so a dynamic precision reaches both inference
+    # and weight grads without recompiling.
+    precision: Optional[jnp.ndarray] = None
 
 
 class GraphState(NamedTuple):
@@ -197,6 +203,7 @@ tree_util.register_pytree_node(
             ns.energy,
             ns.pre_activation,
             ns.latent_grad,
+            ns.precision,  # None -> empty subtree (no extra leaves); array -> traced leaf
         ),
         None,
     ),

--- a/fabricpc/graph_initialization/state_initializer.py
+++ b/fabricpc/graph_initialization/state_initializer.py
@@ -356,6 +356,7 @@ def initialize_graph_state(
     clamps: Dict[str, jnp.ndarray] = None,
     state_init: StateInitBase = None,
     params: GraphParams = None,
+    precision_map: Dict[str, jnp.ndarray] = None,
 ) -> GraphState:
     """
     Initialize graph state using the specified strategy.
@@ -384,6 +385,21 @@ def initialize_graph_state(
     if state_init is None:
         state_init = structure.config["graph_state_initializer"]
 
-    return type(state_init).initialize_state(
+    state = type(state_init).initialize_state(
         structure, batch_size, rng_key, clamps, state_init.config, params
     )
+
+    # Attach an optional per-node diagonal precision to each node's state (used by the
+    # online-precision NGD trainer). None -> standard behavior.
+    if precision_map is not None:
+        nodes = {
+            name: (
+                ns._replace(precision=precision_map[name])
+                if name in precision_map
+                else ns
+            )
+            for name, ns in state.nodes.items()
+        }
+        state = state._replace(nodes=nodes)
+
+    return state

--- a/fabricpc/nodes/base.py
+++ b/fabricpc/nodes/base.py
@@ -550,6 +550,12 @@ class NodeBase(ABC):
         energy_cls = type(energy_obj)
         config = energy_obj.config
 
+        # Dynamic-precision override: a per-node precision carried in the state (set by the
+        # online-precision NGD trainer) takes priority over the static config precision, so it
+        # flows through both inference and the autodiffed weight grads. None -> unchanged.
+        if state.precision is not None:
+            config = {**config, "precision": state.precision}
+
         energy = energy_cls.energy(state.z_latent, state.z_mu, config)
         return state._replace(energy=energy)
 

--- a/fabricpc/training/ngd_trainer.py
+++ b/fabricpc/training/ngd_trainer.py
@@ -1,0 +1,320 @@
+"""
+Natural-gradient (NGD) trainer with ONLINE diagonal precision for predictive coding.
+
+This implements the precision-as-natural-gradient scheme of Ofner et al. 2021
+("Predictive Coding, Precision and Natural Gradients", arXiv:2111.06942) for the
+FabricPC graph framework:
+
+  * Per-node DIAGONAL precision Pi_l (inverse error variance) is learned ONLINE:
+    after each batch's inference reaches equilibrium, the per-channel error variance
+    is folded into a running EMA  var_l <- (1-lam)*var_l + lam*mean(e_l^2)  and the
+    precision used by the next step is Pi_l = 1/(var_l + eps)  (eq. 8, diagonal form;
+    the EMA is the closed-form fixed point of the precision sub-problem that the
+    +ln 2*pi*Sigma term in the free energy enforces -- so no gradient on Sigma needed).
+
+  * That precision is fed back into the ENERGY via NodeState.precision, so it scales
+    BOTH the inference latent updates AND the local weight gradients (which both route
+    through energy_functional). Because the energy is already precision-weighted, the
+    weight gradient carries Pi_l implicitly (the Explore-mapped fact that muPC's
+    weight_grad_scale is 1.0 means there is no double application).
+
+  * With a plain SGD optimizer the precision therefore acts as the per-channel adaptive
+    learning rate -- this is the natural-gradient update (eqs. 10-11), the paper's
+    "PC-SGD". Adam would re-normalize each gradient by its own RMS and largely cancel
+    the precision scaling, which is why NGD uses SGD here, not Adam.
+
+Precision is carried as a traced per-node dict through the jitted step, so it updates
+every iteration with NO recompilation. The verified `train_pcn` path is untouched;
+this is a separate, opt-in trainer.
+
+Only internal nodes (in_degree > 0) carrying a GaussianEnergy get a learned precision;
+terminal inputs and non-Gaussian outputs (e.g. softmax/cross-entropy) are left alone.
+"""
+
+from typing import Dict, List, Tuple
+
+import jax
+import jax.numpy as jnp
+import optax
+
+from fabricpc.core.energy import GaussianEnergy
+from fabricpc.core.inference import run_inference
+from fabricpc.core.types import GraphParams, GraphStructure
+from fabricpc.core.learning import compute_local_weight_gradients
+from fabricpc.graph_initialization.state_initializer import initialize_graph_state
+
+# ---------------------------------------------------------------------------
+# Which nodes get a learned precision
+# ---------------------------------------------------------------------------
+
+
+def precision_node_names(structure: GraphStructure) -> List[str]:
+    """Internal (in_degree>0) nodes whose energy is Gaussian -> get a learned Pi."""
+    names = []
+    for name, node in structure.nodes.items():
+        info = node.node_info
+        if info.in_degree > 0 and isinstance(info.energy, GaussianEnergy):
+            names.append(name)
+    return names
+
+
+def init_precision_vars(
+    structure: GraphStructure, names: List[str]
+) -> Dict[str, jnp.ndarray]:
+    """Initial running variance = 1.0 per channel (so Pi=1: warm-starts at baseline)."""
+    var = {}
+    for name in names:
+        channels = structure.nodes[name].node_info.shape[-1]
+        var[name] = jnp.ones((channels,), dtype=jnp.float32)
+    return var
+
+
+# ---------------------------------------------------------------------------
+# var (running EMA) <-> precision map
+# ---------------------------------------------------------------------------
+
+
+def _vars_to_precision(
+    var: Dict[str, jnp.ndarray], eps: float, clip: Tuple[float, float], normalize: bool
+) -> Dict[str, jnp.ndarray]:
+    """Pi = 1/(var+eps), per-layer mean-normalized (optional) and clipped."""
+    pmap = {}
+    for name, v in var.items():
+        pi = 1.0 / (v + eps)
+        if normalize:
+            pi = pi / jnp.mean(pi)
+        if clip is not None:
+            pi = jnp.clip(pi, clip[0], clip[1])
+            if normalize:
+                # Re-normalize AFTER clipping so the per-layer mean precision stays 1.0.
+                # Clipping dead/extreme channels would otherwise rescale the effective
+                # per-layer SGD learning rate (the "mean Pi=1" NGD property). Any tiny
+                # post-renorm excursion past the clip bounds is acceptable.
+                pi = pi / jnp.mean(pi)
+        pmap[name] = pi
+    return pmap
+
+
+def _update_vars(
+    var: Dict[str, jnp.ndarray], final_state, names: List[str], lam: float
+) -> Dict[str, jnp.ndarray]:
+    """EMA update of per-channel error variance from the inference equilibrium."""
+    new = {}
+    for name in names:
+        err = final_state.nodes[name].error  # (batch, *spatial, C)
+        # Channel-last assumption: precision is per LAST-axis channel. Holds for all
+        # resnet18 nodes (conv NHWC, avgpool (B,C), skip NHWC). A node whose feature
+        # axis is not last would need the channel_axis plumbing that
+        # probe_residual_precision exposes.
+        reduce_axes = tuple(range(err.ndim - 1))  # all but channel (last) axis
+        # mean(err^2), NOT jnp.var: Sigma is the error SECOND MOMENT (zero-mean error at
+        # the PC equilibrium per Ofner et al. eq. 8). This is intentionally the same
+        # quantity diag_probe's precision targets, estimated without mean subtraction.
+        batch_var = jnp.mean(err**2, axis=reduce_axes)  # (C,)
+        new[name] = (1.0 - lam) * var[name] + lam * batch_var
+    return new
+
+
+# ---------------------------------------------------------------------------
+# One NGD training step (jitted by the caller's closure)
+# ---------------------------------------------------------------------------
+
+
+def ngd_train_step(
+    params: GraphParams,
+    opt_state: optax.OptState,
+    var: Dict[str, jnp.ndarray],
+    batch: Dict[str, jnp.ndarray],
+    structure: GraphStructure,
+    optimizer: optax.GradientTransformation,
+    names: List[str],
+    rng_key: jax.Array,
+    *,
+    lam: float,
+    eps: float,
+    clip: Tuple[float, float],
+    normalize: bool,
+):
+    """
+    Inference (with current online precision) -> local grads -> SGD -> precision EMA.
+
+    Returns (params, opt_state, new_var, energy_per_sample_sum).
+    """
+    batch_size = next(iter(batch.values())).shape[0]
+    clamps = {
+        structure.task_map[t]: v for t, v in batch.items() if t in structure.task_map
+    }
+
+    precision_map = _vars_to_precision(var, eps, clip, normalize)
+    # Invariant (guards the fori_loop carry structure): precision covers EXACTLY the
+    # learned-precision node set, so which nodes carry a precision array is stable
+    # across inference steps and across training steps. Static keys -> trace-time check.
+    assert set(precision_map) == set(names), "precision_map must cover exactly `names`"
+
+    init_state = initialize_graph_state(
+        structure,
+        batch_size,
+        rng_key,
+        clamps=clamps,
+        params=params,
+        precision_map=precision_map,
+    )
+    final_state = run_inference(params, init_state, clamps, structure)
+
+    # Local (precision-weighted) weight gradients; SGD preserves the precision scaling.
+    grads = compute_local_weight_gradients(params, final_state, structure)
+    updates, opt_state = optimizer.update(grads, opt_state, params)
+    params = optax.apply_updates(params, updates)
+
+    # Energy over internal nodes (per-sample, summed) for monitoring.
+    energy = (
+        sum(
+            jnp.sum(final_state.nodes[n].energy)
+            for n in structure.nodes
+            if structure.nodes[n].node_info.in_degree > 0
+        )
+        / batch_size
+    )
+
+    new_var = _update_vars(var, final_state, names, lam)
+    return params, opt_state, new_var, energy
+
+
+# ---------------------------------------------------------------------------
+# Training loop
+# ---------------------------------------------------------------------------
+
+
+def train_ngd(
+    params: GraphParams,
+    structure: GraphStructure,
+    train_loader,
+    optimizer: optax.GradientTransformation,
+    num_epochs: int,
+    rng_key: jax.Array,
+    *,
+    lam: float = 0.05,
+    eps: float = 1e-3,
+    clip: Tuple[float, float] = (0.1, 10.0),
+    normalize: bool = True,
+    epoch_callback=None,
+    verbose: bool = False,
+):
+    """
+    Train with online-precision natural-gradient descent.
+
+    Args:
+        optimizer: should be plain SGD (e.g. optax.sgd(schedule)) so the per-channel
+            precision survives into the update as the natural-gradient learning rate.
+        lam: EMA rate for the online precision (per-step). Smaller = slower/steadier.
+        eps, clip, normalize: as in probe_residual_precision -- numerical floor,
+            post-normalization clamp, and per-layer mean normalization.
+
+    Returns (trained_params, final_precision, energy_history):
+      - final_precision: the resolved per-node precision map (Pi, with this call's
+        eps/clip/normalize already applied) — pass straight to probe_latent_propagation
+        so the probe uses exactly what training used (no kwarg re-derivation).
+      - energy_history: list (per epoch) of per-batch energies. SAME reduction as
+        train_pcn (sum over in_degree>0 node energies / batch_size), so the shape and
+        node set match. NOTE the energies are PRECISION-WEIGHTED here (as they are for
+        diag_probe), so compare energies within a precision mode, not across modes.
+    """
+    from fabricpc.training.train import _convert_batch
+
+    names = precision_node_names(structure)
+    var = init_precision_vars(structure, names)
+    opt_state = optimizer.init(params)
+
+    step = jax.jit(
+        lambda p, o, v, b, k: ngd_train_step(
+            p,
+            o,
+            v,
+            b,
+            structure,
+            optimizer,
+            names,
+            k,
+            lam=lam,
+            eps=eps,
+            clip=clip,
+            normalize=normalize,
+        )
+    )
+
+    energy_history = []
+    for epoch in range(num_epochs):
+        batch_energies = []
+        for batch_data in train_loader:
+            batch = _convert_batch(batch_data)
+            rng_key, step_key = jax.random.split(rng_key)
+            params, opt_state, var, energy = step(
+                params, opt_state, var, batch, step_key
+            )
+            batch_energies.append(float(energy))
+        energy_history.append(batch_energies)
+        if verbose:
+            avg = sum(batch_energies) / max(len(batch_energies), 1)
+            print(f"Epoch {epoch + 1}/{num_epochs}  energy={avg:.4f}")
+        if epoch_callback is not None:
+            epoch_callback(epoch, params, structure, {}, rng_key)
+
+    final_precision = _vars_to_precision(var, eps, clip, normalize)
+    return params, final_precision, energy_history
+
+
+# ---------------------------------------------------------------------------
+# Verification probe: does signal reach the early layers?
+# ---------------------------------------------------------------------------
+
+
+def probe_latent_propagation(
+    params: GraphParams,
+    structure: GraphStructure,
+    batch: Dict[str, jnp.ndarray],
+    rng_key: jax.Array,
+    precision_map: Dict[str, jnp.ndarray] = None,
+) -> Dict[str, Dict[str, float]]:
+    """
+    Run one clamped inference pass and report, per node, whether the latent states are
+    non-zero and how far they moved from initialization -- i.e. whether the (precision-
+    weighted) error signal actually propagates back to the EARLY layers, or whether the
+    early latents stay stuck at their init.
+
+    Returns {node_name: {z_rms, err_rms, zmu_rms, move_rms, in_degree}} where:
+        z_rms    = RMS of the converged latent state z_latent
+        err_rms  = RMS of the prediction error (z_latent - z_mu)
+        zmu_rms  = RMS of the prediction z_mu
+        move_rms = RMS of (z_converged - z_init): how much inference moved the latent
+        in_degree= node in-degree (0 = clamped input / terminal)
+    """
+    batch_size = next(iter(batch.values())).shape[0]
+    clamps = {
+        structure.task_map[t]: v for t, v in batch.items() if t in structure.task_map
+    }
+    init_state = initialize_graph_state(
+        structure,
+        batch_size,
+        rng_key,
+        clamps=clamps,
+        params=params,
+        precision_map=precision_map,
+    )
+    final_state = run_inference(params, init_state, clamps, structure)
+
+    def rms(x):
+        return float(jnp.sqrt(jnp.mean(x**2)))
+
+    report = {}
+    for name in structure.node_order:
+        info = structure.nodes[name].node_info
+        z0 = init_state.nodes[name].z_latent
+        zf = final_state.nodes[name].z_latent
+        report[name] = {
+            "z_rms": rms(zf),
+            "err_rms": rms(final_state.nodes[name].error),
+            "zmu_rms": rms(final_state.nodes[name].z_mu),
+            "move_rms": rms(zf - z0),
+            "in_degree": int(info.in_degree),
+        }
+    return report

--- a/tests/test_ngd_precision.py
+++ b/tests/test_ngd_precision.py
@@ -1,0 +1,254 @@
+"""
+Tests for the online-precision natural-gradient (NGD) machinery.
+
+Covers:
+- NodeState.precision backward-compat + pytree round-trip.
+- GaussianEnergy optional log-precision term (value changes, gradient does NOT).
+- initialize_graph_state attaching a precision_map to node states.
+- _vars_to_precision / _update_vars math.
+- train_ngd end-to-end on a tiny graph (params + precision update, energy finite).
+- probe_latent_propagation shape / non-zero latents.
+"""
+
+import math
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+import pytest
+
+from fabricpc.core.topology import Edge
+from fabricpc.graph_assembly import TaskMap, graph
+from fabricpc.core import InferenceSGD
+from fabricpc.core.activations import ReLUActivation
+from fabricpc.core.energy import GaussianEnergy
+from fabricpc.core.inference import run_inference
+from fabricpc.core.types import GraphState, NodeState
+from fabricpc.graph_initialization import initialize_params
+from fabricpc.core.learning import compute_local_weight_gradients
+from fabricpc.graph_initialization.state_initializer import initialize_graph_state
+from fabricpc.nodes import Linear
+from fabricpc.training.ngd_trainer import (
+    _update_vars,
+    _vars_to_precision,
+    init_precision_vars,
+    precision_node_names,
+    probe_latent_propagation,
+    train_ngd,
+)
+
+
+@pytest.fixture
+def rng_key():
+    return jax.random.PRNGKey(0)
+
+
+@pytest.fixture
+def small_graph(rng_key):
+    """input(8) -> h1(6, relu) -> output(4), all GaussianEnergy."""
+    inp = Linear(shape=(8,), name="input")
+    h1 = Linear(shape=(6,), activation=ReLUActivation(), name="h1")
+    out = Linear(shape=(4,), name="output")
+    structure = graph(
+        nodes=[inp, h1, out],
+        edges=[
+            Edge(source=inp, target=h1.slot("in")),
+            Edge(source=h1, target=out.slot("in")),
+        ],
+        task_map=TaskMap(x=inp, y=out),
+        inference=InferenceSGD(),
+    )
+    params = initialize_params(structure, rng_key)
+    return params, structure
+
+
+# ---------------------------------------------------------------------------
+# NodeState.precision
+# ---------------------------------------------------------------------------
+
+
+def test_nodestate_precision_default_and_pytree():
+    z = jnp.zeros((2, 3))
+    ns = NodeState(z, z, z, jnp.zeros((2,)), z, z)
+    assert ns.precision is None
+    # None contributes no leaves -> backward-compatible leaf count
+    assert len(jax.tree_util.tree_leaves(ns)) == 6
+
+    ns2 = ns._replace(precision=jnp.ones((3,)))
+    assert len(jax.tree_util.tree_leaves(ns2)) == 7
+
+    flat, treedef = jax.tree_util.tree_flatten(ns2)
+    ns3 = jax.tree_util.tree_unflatten(treedef, flat)
+    assert ns3.precision.shape == (3,)
+    assert jnp.allclose(ns3.z_latent, z)
+
+
+# ---------------------------------------------------------------------------
+# Log-precision energy term
+# ---------------------------------------------------------------------------
+
+
+def test_log_precision_term_value_and_grad(rng_key):
+    k1, k2 = jax.random.split(rng_key)
+    z = jax.random.normal(k1, (2, 4))
+    mu = jax.random.normal(k2, (2, 4))
+
+    base = GaussianEnergy.energy(z, mu, {"precision": 2.0})
+    withlog = GaussianEnergy.energy(
+        z, mu, {"precision": 2.0, "include_log_precision": True}
+    )
+    # normalizer = 0.5*(ln 2pi - ln precision) per element, 4 non-batch elements
+    norm = 0.5 * (math.log(2 * math.pi) - math.log(2.0)) * 4
+    assert jnp.allclose(withlog, base + norm, atol=1e-5)
+
+    # The log term is constant in z -> gradient must be unchanged.
+    g1 = GaussianEnergy.grad_latent(z, mu, {"precision": 2.0})
+    g2 = GaussianEnergy.grad_latent(
+        z, mu, {"precision": 2.0, "include_log_precision": True}
+    )
+    assert jnp.allclose(g1, g2)
+
+
+# ---------------------------------------------------------------------------
+# precision helpers
+# ---------------------------------------------------------------------------
+
+
+def test_vars_to_precision():
+    var = {"a": jnp.array([1.0, 4.0, 0.25])}
+    raw = _vars_to_precision(var, eps=0.0, clip=None, normalize=False)
+    assert jnp.allclose(raw["a"], jnp.array([1.0, 0.25, 4.0]))
+
+    normed = _vars_to_precision(var, eps=0.0, clip=None, normalize=True)
+    assert abs(float(jnp.mean(normed["a"])) - 1.0) < 1e-6
+
+    clipped = _vars_to_precision(
+        {"a": jnp.array([1e-9])}, eps=0.0, clip=(0.1, 10.0), normalize=False
+    )
+    assert float(clipped["a"][0]) == pytest.approx(10.0)
+
+
+def test_vars_to_precision_renormalizes_after_clip():
+    """When clipping bites, normalize→clip→re-normalize restores per-layer mean Pi≈1
+    (the property the NGD 'precision doesn't rescale the global LR' claim relies on).
+    Note: the final re-normalize can nudge values slightly past the clip bounds — that
+    is accepted by design; the invariant under test is the mean, not the bounds."""
+    # One channel has tiny variance -> huge raw precision that the clip will catch.
+    var = {"a": jnp.array([1e-6, 1.0, 1.0, 1.0])}
+    pi = _vars_to_precision(var, eps=1e-3, clip=(0.1, 10.0), normalize=True)["a"]
+    assert jnp.all(pi > 0) and jnp.all(jnp.isfinite(pi))
+    # mean restored to ~1 by the post-clip re-normalize (would be far from 1 without it)
+    assert float(jnp.mean(pi)) == pytest.approx(1.0, abs=1e-5)
+    # clip still limited the spread (the tiny-variance channel didn't run away)
+    assert float(jnp.max(pi)) < 20.0
+
+
+def test_init_precision_vars(small_graph):
+    params, structure = small_graph
+    names = precision_node_names(structure)
+    # internal Gaussian nodes: h1 and output (input has in_degree 0)
+    assert set(names) == {"h1", "output"}
+    var = init_precision_vars(structure, names)
+    assert var["h1"].shape == (6,) and jnp.allclose(var["h1"], 1.0)
+    assert var["output"].shape == (4,)
+
+
+# ---------------------------------------------------------------------------
+# train_ngd end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_train_ngd_updates_params_and_precision(small_graph, rng_key):
+    params, structure = small_graph
+    rng = np.random.default_rng(0)
+    loader = [
+        (
+            rng.standard_normal((8, 8)).astype("float32"),
+            rng.standard_normal((8, 4)).astype("float32"),
+        )
+        for _ in range(3)
+    ]
+    opt = optax.sgd(0.05)
+    new_params, precision, hist = train_ngd(
+        params, structure, loader, opt, num_epochs=2, rng_key=rng_key, lam=0.2
+    )
+
+    before = jax.tree_util.tree_leaves(params)
+    after = jax.tree_util.tree_leaves(new_params)
+    assert any(
+        not jnp.allclose(a, b) for a, b in zip(before, after)
+    ), "params unchanged"
+    # train_ngd returns the resolved precision map (Pi=1/(var+eps), mean-normalized).
+    # After learning, Pi is non-uniform across channels (not all-ones) for some layer.
+    assert any(not jnp.allclose(v, jnp.ones_like(v)) for v in precision.values())
+    assert len(hist) == 2 and all(np.isfinite(e) for e in hist[-1])
+
+
+# ---------------------------------------------------------------------------
+# latent-propagation probe
+# ---------------------------------------------------------------------------
+
+
+def test_update_vars_nhwc_shape_and_ema():
+    """_update_vars reduces a 4-D (B,H,W,C) error to (C,) and applies the EMA."""
+    B, H, W, C = 2, 4, 4, 3
+    err = jnp.ones((B, H, W, C)) * 2.0  # err^2 = 4 everywhere
+    z = jnp.zeros((B, H, W, C))
+    ns = NodeState(z, z, err, jnp.zeros((B,)), z, z)
+    state = GraphState(nodes={"a": ns}, batch_size=B)
+    new = _update_vars({"a": jnp.ones((C,))}, state, ["a"], lam=0.5)
+    assert new["a"].shape == (C,)
+    # EMA: 0.5*1 + 0.5*mean(err^2)=0.5 + 0.5*4 = 2.5
+    assert jnp.allclose(new["a"], 2.5)
+
+
+def test_precision_changes_weight_gradients(small_graph, rng_key):
+    """The headline invariant: attaching a non-uniform precision changes the local
+    WEIGHT gradients (precision genuinely flows through to the weight update)."""
+    params, structure = small_graph
+    kx, ky, kp = jax.random.split(rng_key, 3)
+    batch = {"x": jax.random.normal(kx, (5, 8)), "y": jax.random.normal(ky, (5, 4))}
+    clamps = {
+        structure.task_map[t]: v for t, v in batch.items() if t in structure.task_map
+    }
+
+    # Baseline: no precision (uniform Pi=1 via config).
+    s0 = initialize_graph_state(structure, 5, kp, clamps=clamps, params=params)
+    g0 = compute_local_weight_gradients(
+        params, run_inference(params, s0, clamps, structure), structure
+    )
+
+    # Non-uniform diagonal precision on h1.
+    pmap = {
+        "h1": jnp.array([5.0, 5.0, 5.0, 0.2, 0.2, 0.2]),
+        "output": jnp.ones((4,)),
+    }
+    s1 = initialize_graph_state(
+        structure, 5, kp, clamps=clamps, params=params, precision_map=pmap
+    )
+    g1 = compute_local_weight_gradients(
+        params, run_inference(params, s1, clamps, structure), structure
+    )
+
+    l0 = jax.tree_util.tree_leaves(g0)
+    l1 = jax.tree_util.tree_leaves(g1)
+    assert any(
+        not jnp.allclose(a, b) for a, b in zip(l0, l1)
+    ), "precision did not change the weight gradients"
+
+
+def test_probe_latent_propagation(small_graph, rng_key):
+    params, structure = small_graph
+    kx, ky, kp = jax.random.split(rng_key, 3)
+    batch = {
+        "x": jax.random.normal(kx, (5, 8)),
+        "y": jax.random.normal(ky, (5, 4)),
+    }
+    rep = probe_latent_propagation(params, structure, batch, kp)
+    assert set(rep) == set(structure.node_order)
+    for name, m in rep.items():
+        for key in ("z_rms", "err_rms", "zmu_rms", "move_rms"):
+            assert np.isfinite(m[key])
+        if m["in_degree"] > 0:
+            assert m["z_rms"] >= 0.0

--- a/tests/test_precision_weighting.py
+++ b/tests/test_precision_weighting.py
@@ -1,0 +1,160 @@
+"""
+Tests for diagonal precision weighting.
+
+Covers:
+- GaussianEnergy with scalar precision (backward compatibility).
+- GaussianEnergy with a diagonal (per-channel) precision vector.
+- probe_residual_precision: shapes, positivity, normalization, node selection.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from fabricpc.core.topology import Edge
+from fabricpc.graph_assembly import TaskMap, graph
+from fabricpc.core import InferenceSGD
+from fabricpc.core.activations import ReLUActivation
+from fabricpc.core.energy import GaussianEnergy
+from fabricpc.core.precision import probe_residual_precision
+from fabricpc.graph_initialization import initialize_params
+from fabricpc.nodes import Linear
+
+
+@pytest.fixture
+def rng_key():
+    return jax.random.PRNGKey(0)
+
+
+# ---------------------------------------------------------------------------
+# GaussianEnergy: scalar precision (backward compatibility)
+# ---------------------------------------------------------------------------
+
+
+def test_scalar_precision_matches_legacy_formula(rng_key):
+    k1, k2 = jax.random.split(rng_key)
+    z = jax.random.normal(k1, (3, 5))
+    mu = jax.random.normal(k2, (3, 5))
+    diff = z - mu
+
+    # Default precision 1.0 == 0.5 * sum(diff^2)
+    e1 = GaussianEnergy.energy(z, mu, {"precision": 1.0})
+    assert jnp.allclose(e1, 0.5 * jnp.sum(diff**2, axis=1))
+
+    # Scalar precision scales linearly.
+    e2 = GaussianEnergy.energy(z, mu, {"precision": 2.0})
+    assert jnp.allclose(e2, 2.0 * e1)
+
+    # Gradient: precision * (z - mu)
+    g = GaussianEnergy.grad_latent(z, mu, {"precision": 2.0})
+    assert jnp.allclose(g, 2.0 * diff)
+
+    # No config -> default precision 1.0
+    assert jnp.allclose(GaussianEnergy.energy(z, mu, None), e1)
+
+
+# ---------------------------------------------------------------------------
+# GaussianEnergy: diagonal (per-channel) precision
+# ---------------------------------------------------------------------------
+
+
+def test_diagonal_precision_energy_and_grad(rng_key):
+    k1, k2 = jax.random.split(rng_key)
+    # Conv-shaped latent: (batch, H, W, C). Precision is per-channel (C,).
+    B, H, W, C = 2, 4, 4, 3
+    z = jax.random.normal(k1, (B, H, W, C))
+    mu = jax.random.normal(k2, (B, H, W, C))
+    diff = z - mu
+    pi = jnp.array([0.5, 1.0, 4.0])
+
+    e = GaussianEnergy.energy(z, mu, {"precision": pi})
+    expected = 0.5 * jnp.sum(pi * diff**2, axis=(1, 2, 3))
+    assert e.shape == (B,)
+    assert jnp.allclose(e, expected)
+
+    g = GaussianEnergy.grad_latent(z, mu, {"precision": pi})
+    assert g.shape == z.shape
+    assert jnp.allclose(g, pi * diff)
+
+
+def test_ones_vector_equals_scalar(rng_key):
+    k1, k2 = jax.random.split(rng_key)
+    z = jax.random.normal(k1, (2, 4, 4, 6))
+    mu = jax.random.normal(k2, (2, 4, 4, 6))
+    e_scalar = GaussianEnergy.energy(z, mu, {"precision": 1.0})
+    e_ones = GaussianEnergy.energy(z, mu, {"precision": jnp.ones(6)})
+    assert jnp.allclose(e_scalar, e_ones)
+
+
+# ---------------------------------------------------------------------------
+# probe_residual_precision
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def small_graph(rng_key):
+    """input(8) -> h1(6, relu) -> output(4), all GaussianEnergy."""
+    inp = Linear(shape=(8,), name="input")
+    h1 = Linear(shape=(6,), activation=ReLUActivation(), name="h1")
+    out = Linear(shape=(4,), name="output")
+    structure = graph(
+        nodes=[inp, h1, out],
+        edges=[
+            Edge(source=inp, target=h1.slot("in")),
+            Edge(source=h1, target=out.slot("in")),
+        ],
+        task_map=TaskMap(x=inp, y=out),
+        inference=InferenceSGD(),
+    )
+    params = initialize_params(structure, rng_key)
+    return params, structure
+
+
+def test_probe_shapes_and_node_selection(small_graph, rng_key):
+    params, structure = small_graph
+    kx, ky, kp = jax.random.split(rng_key, 3)
+    batch = {
+        "x": jax.random.normal(kx, (5, 8)),
+        "y": jax.random.normal(ky, (5, 4)),
+    }
+    pmap = probe_residual_precision(params, structure, batch, kp)
+
+    # Internal Gaussian nodes only: h1 and output (input has in_degree 0).
+    assert set(pmap.keys()) == {"h1", "output"}
+    assert pmap["h1"].shape == (6,)
+    assert pmap["output"].shape == (4,)
+
+
+def test_probe_values_positive_normalized_clipped(small_graph, rng_key):
+    params, structure = small_graph
+    kx, ky, kp = jax.random.split(rng_key, 3)
+    batch = {
+        "x": jax.random.normal(kx, (16, 8)),
+        "y": jax.random.normal(ky, (16, 4)),
+    }
+    pmap = probe_residual_precision(
+        params, structure, batch, kp, clip=(0.1, 10.0), normalize="mean"
+    )
+    for name, pi in pmap.items():
+        assert np.all(np.isfinite(pi)), name
+        assert np.all(pi > 0), name
+        assert np.all(pi >= 0.1 - 1e-6) and np.all(pi <= 10.0 + 1e-6), name
+        # mean normalization: average precision ~ 1 (exact unless clipping bites)
+        assert abs(float(np.mean(pi)) - 1.0) < 0.5, name
+
+
+def test_probe_normalize_none_changes_scale(small_graph, rng_key):
+    params, structure = small_graph
+    kx, ky, kp = jax.random.split(rng_key, 3)
+    batch = {
+        "x": jax.random.normal(kx, (16, 8)),
+        "y": jax.random.normal(ky, (16, 4)),
+    }
+    raw = probe_residual_precision(
+        params, structure, batch, kp, normalize="none", clip=None
+    )
+    # Raw precision is 1/(var+eps); for unit-ish residuals it is finite & positive
+    # but not mean-normalized to 1.
+    for pi in raw.values():
+        assert np.all(np.isfinite(pi)) and np.all(pi > 0)


### PR DESCRIPTION
## Precision weighting + natural-gradient (NGD) for predictive coding

Adds uncertainty-aware (precision-weighted) predictive coding to FabricPC and benchmarks it on the
ResNet-18 / CIFAR-10 muPC demo. Precision ≈ inverse error covariance ≈ Fisher information, so this is
a mechanism-grounded **conditioning** lever (complementary to muPC scaling).

### What's added
- `GaussianEnergy`: per-channel **diagonal** precision (scalar path unchanged) + optional report-only
  log-precision term.
- `NodeState.precision`: optional per-node precision carried in state (default `None` ⇒
  **bitwise-identical** to prior behaviour, no extra pytree leaves). Consumed at the single
  `energy_functional` choke point, so a dynamic precision reaches **both** inference and the local
  weight gradients with no node `forward()` / inference changes. muPC `weight_grad_scale=1.0` ⇒ no
  double application.
- `core/precision.py::probe_residual_precision` — one-pass diagonal Π = 1/Var(residual).
- `training/ngd_trainer.py` — `train_ngd` (online EMA precision; NGD via precision-weighted SGD),
  `probe_latent_propagation` (per-layer signal-propagation diagnostic).
- `resnet18_cifar10_demo.py` — `--precision {none,diag_probe,online}`, `--optimizer {adamw,ngd}`,
  `--momentum`, `--seed`, `--probe_latents`; machine-readable `[RESULT]` line.
- `precision_experiment.py` — paired multi-seed sweep driver (CSV checkpoint, `--resume`, per-epoch
  progress capture, retries, optimizer/momentum-keyed paired-stats report).
- Tests: `tests/test_precision_weighting.py`, `tests/test_ngd_precision.py`.

### Results (CIFAR-10, muPC ResNet-18) — two **separate** modes

**Mode A — `diag_probe` (frozen diagonal precision, AdamW).** Π=1/Var estimated once pre-training,
then fixed.
- **Consistently better in EARLY training** (2 epochs, every seed): **+1.57 / +2.84 / +3.14** pts over
  the Π=1 baseline, with lower train energy in all three.
- **But the gain washes out at convergence.** 30 epochs, 3 paired seeds:

  | seed | none | diag_probe | Δacc |
  |---|---|---|---|
  | 0 | 42.17% | 40.71% | −1.46 |
  | 1 | 42.16% | 42.87% | +0.71 |
  | 2 | 41.77% | 42.45% | +0.68 |

  none **42.03 ± 0.23%** vs diag_probe **42.01 ± 1.15%** → paired **Δ = −0.02 pts, p = 0.977** (not
  significant); train energy marginally lower for diag_probe (2/3 seeds).
- **Interpretation:** precision weighting is a **convergence-speed / conditioning** effect — it
  accelerates early training but does **not** change the converged accuracy. (Likely the frozen Π,
  estimated from the untrained net, goes stale as the error structure evolves.)

**Mode B — `online` / NGD (per-step EMA precision, plain SGD).** Π updated every step; SGD so precision
is the per-channel adaptive LR. Finding: SGD/NGD trains far slower than AdamW here (narrow stable-LR
window; momentum helps but doesn't match Adam in equal epochs) and does not reach the AdamW baseline —
reported as a negative result.

**Honest framing:** precision weighting is a conditioning/robustness/convergence-speed lever. It is
**not** a path to backprop-level accuracy — PC-ResNet-18 plateaus ~42% (backprop ResNet-18 ≈90%); that
ceiling is a property of PC training on this task, which precision does not move.

### Tests
Full suite **229 passed** (the `NodeState` pytree change is a clean no-op regression); the 2 new files
add **15** tests (diagonal/scalar energy, `NodeState.precision` backward-compat, precision reaching the
weight gradients, online EMA update, normalize-after-clip invariant, latent probe). Run with the
venv (CUDA→CPU fallback is normal): `PYTHONPATH=. python -m pytest tests/ -q`.

### Reproduce
```
PYTHONPATH=. python examples/precision_experiment.py --seeds 0 1 2 --arms none diag_probe \
    --num_epochs 30 --activation tanh --no_augment --eval_every 5 --resume \
    --out precision_30ep.csv --md precision_30ep.md
```

### Follow-ups (not in this PR)
- PC-vs-backprop reference run for the ~upper bound.
- 30-epoch `online`/NGD (Mode B) paired sweep at a tuned SGD LR.
