### PR TITLE
Unify graph-energy summation behind a single core helper

### DIFF
--- a/fabricpc/core/__init__.py
+++ b/fabricpc/core/__init__.py
@@ -37,6 +37,7 @@ from fabricpc.core.energy import (
     compute_energy,
     compute_energy_gradient,
     get_energy_and_gradient,
+    total_graph_energy,
 )
 
 # Inference functions and classes
@@ -92,6 +93,7 @@ __all__ = [
     "compute_energy",
     "compute_energy_gradient",
     "get_energy_and_gradient",
+    "total_graph_energy",
     # Inference
     "InferenceBase",
     "InferenceSGD",

--- a/fabricpc/core/energy.py
+++ b/fabricpc/core/energy.py
@@ -41,6 +41,8 @@ from typing import Dict, Any, Tuple
 
 import jax.numpy as jnp
 
+from fabricpc.core.types import GraphState, GraphStructure
+
 # =============================================================================
 # Energy Functional Base Class
 # =============================================================================
@@ -518,3 +520,34 @@ def get_energy_and_gradient(
     g = energy_cls.grad_latent(z_latent, z_mu, config)
 
     return e, g
+
+
+def total_graph_energy(
+    state: GraphState,
+    structure: GraphStructure,
+    *,
+    internal_only: bool,
+) -> jnp.ndarray:
+    """
+    Sum the per-node energies stored in state over the graph's nodes.
+
+    Each node's per-sample energy (state.nodes[name].energy, shape (batch,)) is
+    summed to a scalar. Iterates structure.nodes in insertion order; the order is
+    preserved deliberately because float summation is not associative.
+
+    Args:
+        state: Graph state holding each node's per-sample energy.
+        structure: Graph structure providing node in_degree metadata.
+        internal_only: If True, skip terminal input nodes (in_degree == 0), the
+            PC training objective. If False, sum all nodes (evaluation).
+
+    Returns:
+        Scalar total energy, summed over the selected nodes without batch
+        normalization. Callers divide by batch_size for a per-sample mean.
+    """
+    energy = jnp.array(0.0)
+    for name in structure.nodes:
+        if internal_only and structure.nodes[name].node_info.in_degree == 0:
+            continue
+        energy = energy + jnp.sum(state.nodes[name].energy)
+    return energy

--- a/fabricpc/training/train.py
+++ b/fabricpc/training/train.py
@@ -15,6 +15,7 @@ import optax
 from tqdm.auto import tqdm as _tqdm_cls
 
 from fabricpc.core.types import GraphParams, GraphState, GraphStructure
+from fabricpc.core.energy import total_graph_energy
 from fabricpc.core.inference import run_inference
 from fabricpc.core.learning import compute_local_weight_gradients
 from fabricpc.graph_initialization.state_initializer import initialize_graph_state
@@ -152,14 +153,7 @@ def get_graph_param_gradient(
     final_state = run_inference(params, init_state, clamps, structure)
 
     # Compute energy (ignore terminal input nodes), normalized per sample
-    energy = sum(
-        [
-            sum(final_state.nodes[node_name].energy)
-            for node_name in structure.nodes
-            if structure.nodes[node_name].node_info.in_degree > 0
-        ]
-    )
-    energy = energy / batch_size
+    energy = total_graph_energy(final_state, structure, internal_only=True) / batch_size
 
     # Compute LOCAL gradients for each node
     grads = compute_local_weight_gradients(params, final_state, structure)
@@ -516,11 +510,9 @@ def eval_step(
     final_state = run_inference(params, state, clamps, structure)
 
     # Compute total network energy
-    total_energy = jnp.array(0.0)
-    for node_name in structure.nodes:
-        total_energy = total_energy + jnp.sum(final_state.nodes[node_name].energy)
-
-    avg_energy = total_energy / batch_size
+    avg_energy = (
+        total_graph_energy(final_state, structure, internal_only=False) / batch_size
+    )
     # Note: In evaluation mode, the output node won't be clamped to a label and doesn't contribute to energy. Evaluation energy is only from internal nodes.
     # Use a proper metric to assess task performance, not energy.
 
@@ -768,11 +760,8 @@ def evaluate_transformer(
 
         # Calculate energy per device (internal + external/output error)
         def get_device_energy(fs, batch_y):
-            e = 0.0
             # Internal energy
-            for node_name in structure.nodes:
-                if structure.nodes[node_name].node_info.in_degree > 0:
-                    e += jnp.sum(fs.nodes[node_name].energy)
+            e = total_graph_energy(fs, structure, internal_only=True)
 
             # External energy (Output prediction error)
             if "y" in structure.task_map:

--- a/fabricpc/training/train_autoregressive.py
+++ b/fabricpc/training/train_autoregressive.py
@@ -21,6 +21,7 @@ import jax.numpy as jnp
 import optax
 
 from fabricpc.core.types import GraphParams, GraphState, GraphStructure
+from fabricpc.core.energy import total_graph_energy
 from fabricpc.core.inference import run_inference
 from fabricpc.core.learning import compute_local_weight_gradients
 from fabricpc.graph_initialization.state_initializer import initialize_graph_state
@@ -144,12 +145,9 @@ def train_step_autoregressive(
     final_state = run_inference(params, init_state, clamps, structure)
 
     # Compute total energy (sum over nodes with in_degree>0)
-    energy = jnp.array(0.0)
-    for node_name, node in structure.nodes.items():
-        if node.node_info.in_degree > 0:
-            energy = energy + jnp.sum(final_state.nodes[node_name].energy)
-
-    avg_energy = energy / batch_size
+    avg_energy = (
+        total_graph_energy(final_state, structure, internal_only=True) / batch_size
+    )
 
     # Compute local gradients
     grads = compute_local_weight_gradients(params, final_state, structure)

--- a/fabricpc/utils/dashboarding/extractors.py
+++ b/fabricpc/utils/dashboarding/extractors.py
@@ -10,6 +10,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from fabricpc.core.types import GraphState, GraphParams, GraphStructure
+from fabricpc.core.energy import total_graph_energy
 
 
 def extract_node_energies(state: GraphState) -> Dict[str, np.ndarray]:
@@ -40,11 +41,7 @@ def extract_total_energy(
     Returns:
         Total energy as float.
     """
-    total = 0.0
-    for node_name, node_info in structure.nodes.items():
-        if node_info.in_degree > 0:
-            total += float(jnp.sum(state.nodes[node_name].energy))
-    return total
+    return float(total_graph_energy(state, structure, internal_only=True))
 
 
 def extract_latent_statistics(

--- a/fabricpc/utils/dashboarding/inference_tracking.py
+++ b/fabricpc/utils/dashboarding/inference_tracking.py
@@ -15,6 +15,7 @@ from fabricpc.core.types import (
     GraphStructure,
     NodeState,
 )
+from fabricpc.core.energy import total_graph_energy
 from fabricpc.core.learning import compute_local_weight_gradients
 from fabricpc.graph_initialization.state_initializer import initialize_graph_state
 
@@ -222,9 +223,7 @@ def train_step_with_history(
     )
 
     # Compute energy
-    energy = sum(
-        [jnp.sum(final_state.nodes[node_name].energy) for node_name in structure.nodes]
-    )
+    energy = total_graph_energy(final_state, structure, internal_only=False)
 
     # Compute gradients and update
     grads = compute_local_weight_gradients(params, final_state, structure)

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -16,11 +16,12 @@ from fabricpc.core.energy import (
     CrossEntropyEnergy,
     LaplacianEnergy,
     KLDivergenceEnergy,
+    total_graph_energy,
 )
+from fabricpc.core.types import GraphState, NodeState
 from fabricpc.nodes import Linear
 from fabricpc.core.topology import Edge
 from fabricpc.graph_assembly import TaskMap, graph
-from fabricpc.graph_initialization import initialize_params
 from fabricpc.core.inference import InferenceSGD
 
 
@@ -159,6 +160,85 @@ class TestCustomEnergy:
 
         grad = L1Energy.grad_latent(z_latent, z_mu)
         assert jnp.allclose(grad, jnp.array([[1.0, -1.0, 1.0]]))
+
+
+class TestTotalGraphEnergy:
+    """Test the graph-level energy reducer."""
+
+    def _build_chain(self):
+        """Tiny input -> hidden -> output chain (in_degree: 0, 1, 1)."""
+        input_node = Linear(shape=(8,), name="input")
+        hidden_node = Linear(shape=(4,), name="hidden")
+        output_node = Linear(shape=(2,), name="output")
+
+        structure = graph(
+            nodes=[input_node, hidden_node, output_node],
+            edges=[
+                Edge(source=input_node, target=hidden_node.slot("in")),
+                Edge(source=hidden_node, target=output_node.slot("in")),
+            ],
+            task_map=TaskMap(x=input_node, y=output_node),
+            inference=InferenceSGD(),
+        )
+        return structure
+
+    def _state_with_energies(self, energies):
+        """GraphState whose nodes carry the given per-sample energy arrays."""
+        nodes = {}
+        for name, energy in energies.items():
+            dummy = jnp.zeros_like(energy)
+            nodes[name] = NodeState(
+                z_latent=dummy,
+                z_mu=dummy,
+                error=dummy,
+                energy=energy,
+                pre_activation=dummy,
+                latent_grad=dummy,
+            )
+        batch_size = next(iter(energies.values())).shape[0]
+        return GraphState(nodes=nodes, batch_size=batch_size)
+
+    def test_internal_only_skips_input_nodes(self):
+        """internal_only=True skips in_degree==0 nodes (the input node)."""
+        structure = self._build_chain()
+        state = self._state_with_energies(
+            {
+                "input": jnp.array([1.0, 1.0, 1.0]),  # in_degree 0, skipped
+                "hidden": jnp.array([2.0, 2.0, 2.0]),  # sum 6
+                "output": jnp.array([3.0, 3.0, 3.0]),  # sum 9
+            }
+        )
+
+        total = total_graph_energy(state, structure, internal_only=True)
+        assert jnp.allclose(total, 15.0)  # 6 + 9, input excluded
+
+    def test_all_nodes_summed_when_not_internal_only(self):
+        """internal_only=False sums every node, including inputs."""
+        structure = self._build_chain()
+        state = self._state_with_energies(
+            {
+                "input": jnp.array([1.0, 1.0, 1.0]),  # sum 3
+                "hidden": jnp.array([2.0, 2.0, 2.0]),  # sum 6
+                "output": jnp.array([3.0, 3.0, 3.0]),  # sum 9
+            }
+        )
+
+        total = total_graph_energy(state, structure, internal_only=False)
+        assert jnp.allclose(total, 18.0)  # 3 + 6 + 9
+
+    def test_returns_unnormalized_sum(self):
+        """The reducer returns the summed energy without batch normalization."""
+        structure = self._build_chain()
+        state = self._state_with_energies(
+            {
+                "input": jnp.zeros(4),
+                "hidden": jnp.array([1.0, 1.0, 1.0, 1.0]),  # sum 4
+                "output": jnp.array([2.0, 2.0, 2.0, 2.0]),  # sum 8
+            }
+        )
+
+        total = total_graph_energy(state, structure, internal_only=True)
+        assert jnp.allclose(total, 12.0)  # not divided by batch_size (4)
 
 
 class TestIntegration:

--- a/tests/test_fabricpc.py
+++ b/tests/test_fabricpc.py
@@ -29,7 +29,7 @@ from fabricpc.core.activations import (
     SigmoidActivation,
 )
 from fabricpc.core.initializers import XavierInitializer
-from fabricpc.core.energy import GaussianEnergy
+from fabricpc.core.energy import GaussianEnergy, total_graph_energy
 from conftest import with_inference
 
 
@@ -196,16 +196,10 @@ class TestInference:
         assert "latent_grad" in final_state.nodes["hidden1"]._fields
         assert final_state.nodes["hidden1"].latent_grad.shape == (batch_size, 20)
 
-        initial_energy = sum(
-            jnp.sum(state_after_1_step.nodes[name].energy)
-            for name in structure.nodes
-            if structure.nodes[name].node_info.in_degree > 0
+        initial_energy = total_graph_energy(
+            state_after_1_step, structure, internal_only=True
         )
-        final_energy = sum(
-            jnp.sum(final_state.nodes[name].energy)
-            for name in structure.nodes
-            if structure.nodes[name].node_info.in_degree > 0
-        )
+        final_energy = total_graph_energy(final_state, structure, internal_only=True)
 
         assert final_energy < initial_energy
 

--- a/tests/test_storkey_hopfield.py
+++ b/tests/test_storkey_hopfield.py
@@ -12,7 +12,7 @@ from fabricpc.graph_initialization.state_initializer import initialize_graph_sta
 from fabricpc.core.learning import compute_local_weight_gradients
 from fabricpc.core.inference import InferenceSGD, run_inference
 from fabricpc.core.activations import SigmoidActivation, SoftmaxActivation
-from fabricpc.core.energy import CrossEntropyEnergy
+from fabricpc.core.energy import CrossEntropyEnergy, total_graph_energy
 from fabricpc.core.initializers import XavierInitializer, NormalInitializer
 from fabricpc.training import train_step
 from conftest import with_inference
@@ -123,11 +123,7 @@ class TestEnergy:
             params=params,
         )
         state_few = run_inference(params, state_init, clamps, struct_few)
-        energy_few = sum(
-            float(jnp.sum(state_few.nodes[n].energy))
-            for n in structure.nodes
-            if structure.nodes[n].node_info.in_degree > 0
-        )
+        energy_few = float(total_graph_energy(state_few, structure, internal_only=True))
 
         # More steps
         struct_many = with_inference(structure, infer_steps=50, eta_infer=0.05)
@@ -139,10 +135,8 @@ class TestEnergy:
             params=params,
         )
         state_many = run_inference(params, state_init, clamps, struct_many)
-        energy_many = sum(
-            float(jnp.sum(state_many.nodes[n].energy))
-            for n in structure.nodes
-            if structure.nodes[n].node_info.in_degree > 0
+        energy_many = float(
+            total_graph_energy(state_many, structure, internal_only=True)
         )
 
         assert (


### PR DESCRIPTION
## Summary

Across the codebase, "sum the graph's per-node energies" was re-implemented inline in many places (`sum`/`jnp.sum` loops over `structure.nodes`). This PR introduces one reusable core function, `fabricpc.core.energy.total_graph_energy(state, structure, *, internal_only)`, and routes every clean call site through it.

This is a behavior-preserving deduplication — no energy computation is removed. The per-node energy functionals and the actual reductions are unchanged; the duplicated loops are replaced by one shared, tested helper.

## The helper

```python
def total_graph_energy(state, structure, *, internal_only):
    energy = jnp.array(0.0)
    for name in structure.nodes:
        if internal_only and structure.nodes[name].node_info.in_degree == 0:
            continue
        energy = energy + jnp.sum(state.nodes[name].energy)
    return energy
```

- `internal_only=True` skips terminal input nodes (`in_degree == 0`) — the PC training objective; `False` sums all nodes (evaluation).
- Returns the summed energy **without** batch normalization; callers divide by `batch_size` when they want a per-sample mean (several callers add an MSE term, compare relatively, or want the raw sum, so a built-in mean would be wrong for them).
- Iterates `structure.nodes` in insertion order (float summation is order-sensitive).
- Exported from `fabricpc.core` (import block + `__all__`).

## Call sites routed through the helper

| File | Site | Mode |
|---|---|---|
| `training/train.py` | `get_graph_param_gradient` energy | `internal_only=True`, `/batch_size` |
| `training/train.py` | `eval_step` energy | `internal_only=False`, `/batch_size` |
| `training/train.py` | `evaluate_transformer` per-device internal energy (inside `vmap`) | `internal_only=True`; output-MSE term kept separate |
| `training/train_autoregressive.py` | `train_step_autoregressive` energy | `internal_only=True`, `/batch_size` |
| `utils/dashboarding/extractors.py` | `extract_total_energy` | `float(... internal_only=True)` |
| `utils/dashboarding/inference_tracking.py` | `train_step_with_history` energy | `internal_only=False` |
| `tests/test_fabricpc.py` | energy-decrease assertion | `internal_only=True` (×2) |
| `tests/test_storkey_hopfield.py` | energy-decrease assertion | `internal_only=True` (×2) |

Plus three focused unit tests for the helper in `tests/test_energy.py`.

## Intentionally left inline

- `training/train.py` `evaluate_pcn` multi-GPU (pmap) path: each node's energy is reshaped across devices and **sliced to drop padded samples** before summing. The helper sums the full per-node array, so it cannot reproduce the padding-trim — routing it would wrongly include padded samples.
- Per-node `jnp.sum(state.energy)` returns inside node `forward()` methods, and `jnp.mean`-based diagnostics — these are single-node returns or mean (not sum) reductions, not graph-level aggregations.

## Verification

`JAX_PLATFORMS=cpu PYTHONPATH=. python -m pytest tests/ -q` → **217 passed**.

The swaps preserve behavior: same node set (the `in_degree > 0` keep is equivalent to the helper's `in_degree == 0` skip), same insertion order, and the same `/batch_size` normalization at each caller.