### PR TITLE
Add model checkpointing: save/load params, optimizer state, and structure

### DIFF
--- a/docs/dev_plans_archive/COMPARISON_checkpointing.md
+++ b/docs/dev_plans_archive/COMPARISON_checkpointing.md
@@ -1,0 +1,210 @@
+# Model-Checkpointing Comparison — `fabricpc/serialization.py` (YOURS) vs `HANDOFF_compare.md` reference
+
+Comparison along two lenses (design/robustness and API/correctness/tests), grounded
+against three empirical probes (flax dtype round-trip; load-path structure dependency;
+class-rename failure). "YOURS" = the Task-4 implementation on branch
+`worktree-task4-checkpointing`; "REFERENCE" = the design + full source in
+`HANDOFF_compare.md`. File:line citations are to `fabricpc/serialization.py` unless
+noted. **No code was modified** (per the handoff).
+
+---
+
+## 1. Summary verdict
+
+**Materially different in design philosophy; convergent in mechanics for the common
+case.** Both make the same core decisions: params always saved as the model; opt_state
+optional and restored into an `optimizer.init(params)` template; JSON metadata; a
+format-version gate; atomic writes; lossless dtypes. They split on the single hardest
+question — **GraphStructure**:
+
+- **YOURS serializes the structure** (versioned JSON snapshot, objects rebuilt via
+  `cls.__new__` + `.config`/attr assignment) and therefore needs **no caller-supplied
+  model code** to return a fully usable model. Cost: loading **anything** (params
+  included) reconstructs the structure and imports every node/component class by its
+  saved path — so a single class rename/move bricks the **whole** checkpoint.
+- **REFERENCE never serializes structure.** Params are self-describing from the
+  manifest and load with zero model imports; structure is an *optional* load input used
+  only for validation and GraphState. Cost: you must rebuild the structure in code to
+  get a usable model back.
+
+Neither is a superset. YOURS optimizes for *self-contained reload*; REFERENCE optimizes
+for *survival across code evolution*. The right answer is a merge (§5) whose linchpin is:
+**decouple params decoding from structure reconstruction** (adopt REFERENCE here), while
+**keeping YOURS' structure snapshot as an optional, best-effort bonus.**
+
+---
+
+## 2. Dimension table (13 dimensions from HANDOFF §4)
+
+| # | Dimension | YOURS | REFERENCE | Diverge? | Preferable + why |
+|---|-----------|-------|-----------|----------|------------------|
+| 1 | What is persisted | params (always), opt_state (opt.), **structure (always)**, metadata under `user`, + provenance: format_version, library_versions, per-leaf param shapes+dtypes, node/edge counts (`save_checkpoint` L497–509; `_param_leaf_metadata` L389). No GraphState, step, rng. | params (always), opt_state (opt.), **GraphState (opt.)**, metadata, fabricpc_version, created_at, batch_size. No structure, step, rng. | **Yes** | Merge — each saves what the other drops (structure vs GraphState). |
+| 2 | GraphState | **Not saved** (intentional; std trainer re-inits `z` per batch). | Optional `state=`, with the per-batch re-init rationale documented; restored into `initialize_graph_state` template. | **Yes** | **Reference** — covers persistent-latent/Hopfield + state inspection at ~zero cost when unused. YOURS has a real (if niche) capability gap. |
+| 3 | GraphStructure | **Serialized** as versioned JSON snapshot; `cls.__new__` + restore private attrs/`.config`; embeds class import paths (L131, L211–224, L299–332); persists computed `node_order` + muPC factors. **No pickle.** | **Never serialized**; user rebuilds in code; optional `structure=` validates. | **Yes (central)** | Merge — YOURS wins self-containedness & deterministic `node_order`; REFERENCE wins refactor-robustness & simplicity. See §3.1. |
+| 4 | Load-time inputs | **Loading params REQUIRES reconstructing structure** (`deserialize_structure` → `initialize_params(structure)` builds the decode target, L600→606→608), i.e. all node/component classes must be importable. `optimizer=` only for opt_state; `strict` gates the no-optimizer case. Returns `Checkpoint(params, opt_state, structure)`. | params self-describing — load from file alone, **no model imports**. `structure=`/`optimizer=` optional (validation / GraphState / opt_state). | **Yes** | **Reference** — self-describing params decouple weight recovery from code identity (the decisive point, §3.1/R1). |
+| 5 | Format & deps | **Directory** of 4 files (2 JSON + 2 flax-msgpack); dep on flax (already transitive); no pickle (L5–11, L92–95, L374–379). | **Single `.npz`** (numpy only), JSON manifest as unicode array, explicit `allow_pickle=False`. | **Yes** | Slight edge **Reference** — one portable artifact + explicit pickle ban. YOURS' JSON is human-inspectable and the array backend is isolated (L372–379) for an easy Orbax swap. Toss-up. |
+| 6 | Dtype fidelity | flax msgpack. **Verified lossless** for bf16/fp16/int32/0-d scalar (disk dtype wins over target). | Raw uint8 byte codec + `(dtype,shape)`; flattens to 1-D for 0-d; lossless by construction. | **No (equivalent)** | Equivalent outcome. Note: REFERENCE's stated motivation ("numpy can't store bf16") is **partly outdated** — `ml_dtypes` registers bf16 with numpy on this stack — but its codec remains a fair portability hedge. flax is fewer lines. |
+| 7 | Atomicity / crash safety | Staging dir + `os.replace`; on overwrite, old ckpt renamed to `.bak` first, restored if swap fails (L511–543; tested). **No lost-checkpoint window.** | tmp file + single `os.replace` (atomic; single-file so replace *is* the swap). | **Yes (degree)** | **YOURS** for overwrite — genuinely no instant where both copies are absent. (Directory format *needs* this dance; single-file gets atomicity for free.) One minor cleanup caveat: R3. |
+| 8 | Wrong-model safety | Per-leaf **keypath+shape** validation vs reconstructed structure **on every load, before decode** (L401–422, called L607); format-version gate; flax-drift warning. | name+shape **signature** validation **only when `structure=` passed**; treedef-length+shape check for opt_state/state. | **Yes** | **YOURS** — validation is automatic & unconditional (it always has the structure); REFERENCE leaves params unchecked unless you opt in. Neither catches a wrong-but-shape-identical model (R4). |
+| 9 | opt_state / resume | flax `from_bytes` into `optimizer.init(params)`; recovers exact NamedTuple types; wrong optimizer → flax raises on **field-name** mismatch (verified); `strict` gates absent-optimizer (L610–624); bitwise resume parity tested. | `tree_unflatten` into `optimizer.init(params)`; checks treedef **length + leaf shape only, NOT field names**. | **Yes** | **YOURS** — field-name matching catches a same-arity/same-shape but different optimizer that REFERENCE would accept silently (R2). Both share the curated-message vs flax-phrased trade-off; REFERENCE's message is more bespoke. |
+| 10 | API surface | `save_checkpoint(params, opt_state, structure, path, *, overwrite=False, metadata=None) -> None`; `load_checkpoint(path, *, optimizer=None, strict=True) -> Checkpoint` NamedTuple (L461, L546, L114). Module `fabricpc.serialization`; exported `__init__.py:51,62–65`. **`opt_state`/`structure` are required positionals; `overwrite` defaults False.** | `save(path, params, *, opt_state=None, state=None, metadata=None, overwrite=True) -> Path`; `load(path, *, structure=None, optimizer=None) -> dict`. Module `fabricpc/training/serialization.py`. | **Yes** | Mixed → merge. **YOURS**: typed NamedTuple return (tuple-unpack + named, typo-proof) and safe `overwrite=False`. **REFERENCE**: `path`-first + all-optional kwargs → trivial params-only save (YOURS forces `save_checkpoint(params, None, structure, path)`). Adopt REFERENCE's signature shape + YOURS' return type & default. |
+| 11 | Versioning | `FORMAT_VERSION=1`, checked first; rejects `version > FORMAT_VERSION` or missing (L587–593); backward-compatible. | `format`+`version`; rejects `version != FORMAT_VERSION` (also rejects readable older/newer-minor). | **Yes** | **YOURS** — `>` is correct forward-incompat/backward-compat semantics. (REFERENCE's explicit `format` magic string is a nice touch worth borrowing — dim 12.) |
+| 12 | Error handling | Missing dir/file → `FileNotFoundError` w/ name (L576–582); version & shape mismatch → clear `ValueError`. **But:** corrupt `params.msgpack`→raw `ExtraData`; corrupt `structure.json`→raw `JSONDecodeError`; class rename→raw `AttributeError`/`ModuleNotFoundError`; non-JSON metadata→bare `TypeError` (L509) — all **unwrapped** (verified). | All read failures wrapped by `_open` into "Could not read … as a FabricPC checkpoint"; missing manifest, bad format/version, non-JSON metadata → framed `ValueError`s naming allowed types. | **Yes** | **Reference** — uniformly checkpoint-aware messages. YOURS is loud (never silently misloads) but leaks raw library exceptions on corruption/rename. Concrete, cheap gap to close. |
+| 13 | Tests | **21 passing** (verified): param/opt-state exact value+type, tuple-unpack, full structure fidelity incl. `UniformInitializer` ctor-quirk, nested-component state-init, conv tuple config, muPC scaling, re-init-identically, **resume parity**, strict/non-strict, params-only, overwrite guard+force, user metadata, missing files, future version, shape mismatch, staging cleanup, **overwrite-crash rollback**. | **16** (claimed): params no-structure, lossless bf16/fp16/int, metadata, structure validation + wrong-structure, opt_state resume + skip, **state round-trip**, atomic, overwrite, **no-pickle load**, future-version, **corrupt-file**. | **Yes** | Each tests its own design. **YOURS gaps:** no class-rename test (the risk its design *introduces*), no explicit bf16/fp16 dtype test, no corrupt-file/non-JSON-metadata test. **REFERENCE gaps:** no structure-snapshot round-trip (can't — no structure on disk), no overwrite-crash rollback. |
+
+### Load-capability matrices
+
+**YOURS** — always returns `Checkpoint(params, opt_state, structure)`:
+
+| call | params | structure | opt_state |
+|---|---|---|---|
+| `load_checkpoint(path)`, no opt_state in file | ✅ | ✅ (from disk) | None |
+| `load_checkpoint(path)`, file *has* opt_state, `strict=True` | — | — | **raises** (L614) |
+| `load_checkpoint(path, strict=False)` | ✅ | ✅ | None (skipped) |
+| `load_checkpoint(path, optimizer=opt)` | ✅ | ✅ | ✅ |
+
+**REFERENCE** — returns `{params, opt_state, state, metadata}`:
+
+| call | params | opt_state | state |
+|---|---|---|---|
+| `load(path)` | ✅ | None | None |
+| `load(path, optimizer=opt)` | ✅ | ✅ | None |
+| `load(path, structure=s)` | ✅ (validated) | None | ✅ |
+| `load(path, structure=s, optimizer=opt)` | ✅ (validated) | ✅ | ✅ |
+
+Asymmetry: YOURS *returns* structure with zero inputs and validates params
+unconditionally, but **cannot decode params if any class is unimportable**; REFERENCE
+never returns structure but decodes params from the file alone and validates only on
+opt-in.
+
+---
+
+## 3. Key divergences (the branching points) — pros, cons, and the grounded call
+
+### 3.1 Serialize structure (YOURS) vs rebuild-in-code (REFERENCE) — and the load-coupling that decides it
+
+- **YOURS pros:** self-contained reload (hand someone a directory, they get a working
+  model with no model-definition code); deterministic persisted `node_order` (avoids the
+  builder's best-effort topological sort on cyclic PC graphs); faithfully round-trips
+  constructor-quirk components (`UniformInitializer` key-rename, `GlobalStateInit`
+  nesting) that `cls(**config)` would break; human-inspectable JSON; not pickle.
+- **YOURS cons:** ~470 lines of bespoke codec coupled to **private** attribute names
+  (`_decode_node` writes `_name`, `_node_info`, … L323–332) and to **class import
+  paths** (L131). **Decisively:** `load_checkpoint` reconstructs the structure to build
+  the params decode target (L600→606), so **params can't load unless every node and
+  component class is still importable at its saved path** — verified: renaming `Linear`
+  in `structure.json` raised a bare `AttributeError` and lost the weights too.
+- **REFERENCE pros:** tiny, robust to refactors (no class identity persisted); params
+  self-describing and decoded directly from manifest names; orthodox flax/orbax
+  philosophy ("structure lives in code").
+- **REFERENCE cons:** the checkpoint alone is not a complete model — you must re-run your
+  model-definition code to get a usable structure back; can't snapshot structure for a
+  fresh-process/deploy/inspect scenario.
+
+**Better, grounded:** **Split the decision.** Adopt the REFERENCE's stance *for params*
+(self-describing, target-free decode — params must never depend on class identity), and
+keep YOURS' structure snapshot *as an optional, best-effort* artifact. YOURS' own design
+doc rejects pickle because "pickle breaks on any class rename — fatal for a framework
+that actively migrates node types"; the JSON snapshot **shares that exact
+rename-fragility for class identity** and, worse, currently propagates it to params. The
+fix preserves YOURS' headline capability while removing the high-severity risk.
+
+### 3.2 Self-containedness vs robustness to evolution
+
+This is the philosophical axis underneath 3.1. YOURS buys "reload with no code";
+REFERENCE buys "survive node-type migration" (which this repo's git history shows is
+active). **Better:** keep YOURS' self-containedness as a *convenience* layered on a
+REFERENCE-style robust core — i.e. params + manifest are the durable artifact; the
+structure snapshot is a bonus that degrades gracefully ("params loaded; structure
+unavailable: class X moved") instead of aborting.
+
+### 3.3 Directory + flax msgpack (YOURS) vs single `.npz` (REFERENCE)
+
+- **YOURS pros:** human-readable JSON; array backend isolated for a future Orbax swap.
+- **YOURS cons:** four files to move together; needs the `.bak` dance for atomic
+  overwrite; couples the array format to flax's msgpack (warns, doesn't fail, on drift).
+- **REFERENCE pros:** one portable file; `allow_pickle=False`; atomic overwrite for free;
+  no flax dep; self-owned dtype codec.
+- **REFERENCE cons:** binary blob (less inspectable); the raw-uint8 codec is extra code
+  whose original motivation is partly obsolete here.
+
+**Better, grounded:** roughly a wash for a research framework; **lean REFERENCE on
+portability/packaging**. If YOURS keeps the directory, borrow the explicit `format` magic
+string and the wrapped corrupt-file errors.
+
+### 3.4 Dtype: flax msgpack vs raw codec — a non-divergence
+
+Empirically both round-trip bf16/fp16/int/0-d losslessly. **Better:** either; flax is
+less code and verified. Add an explicit dtype-fidelity test (YOURS lacks one).
+
+### 3.5 opt_state matching & wrong-model safety
+
+YOURS validates params on every load and matches opt_state by **field name** (catches a
+wrong optimizer — verified); REFERENCE validates params only on opt-in and matches
+opt_state by **length+shape only** (a same-shape different optimizer loads silently).
+**Better:** **YOURS** on both. Neither catches a wrong model with coincidentally identical
+shapes — close that in both with a content fingerprint (R4).
+
+### 3.6 Atomicity on overwrite
+
+YOURS' rename-aside `.bak` + restore (L511–543) is strictly more defensive than a single
+`os.replace`. **Better:** **YOURS** (with the R3 cleanup fix).
+
+---
+
+## 4. Correctness risks
+
+- **R1 (YOURS, HIGH) — a class rename/move bricks the entire checkpoint, with a cryptic
+  error.** Params decode requires structure reconstruction (L600→606→`graph_net`
+  initialize_params→`_import_class` L134–142). Verified: renaming a node class in
+  `structure.json` → bare `AttributeError`, weights unrecoverable. REFERENCE has no
+  equivalent risk for params. *This is the most important finding.*
+- **R2 (REFERENCE, MEDIUM) — silent wrong-optimizer / unvalidated params.** `_unpack_tree`
+  checks treedef length + shape only (not field names); params load unvalidated unless
+  `structure=` is passed. YOURS is safer on both.
+- **R3 (YOURS, LOW) — overwrite `finally` can delete the backup after a failed restore.**
+  L539–543 `shutil.rmtree(backup)` runs unconditionally; if the `except`-path restore
+  `os.replace(backup, path)` (L537) were itself interrupted, the only surviving copy
+  could be removed. Narrow window; add a guard.
+- **R4 (BOTH, LOW) — no content fingerprint.** A model with coincidentally identical leaf
+  shapes loads with mismatched weights without error (YOURS L401–422; REFERENCE
+  `_validate`). A params/structure hash in metadata closes it.
+- **R5 (YOURS, INFO) — array format coupled to flax.** msgpack format is flax-owned;
+  YOURS only warns on major.minor drift (L425–441). Acceptable; REFERENCE avoids it by
+  owning its byte codec.
+
+---
+
+## 5. Recommendation — single merged design
+
+Keep YOURS as the base (richer validation, stronger atomicity, typed result, correct
+version semantics, field-name opt_state matching) and graft the REFERENCE's decoupling,
+GraphState, and error framing:
+
+1. **Params: self-describing, target-free decode (ADOPT REFERENCE).** Record
+   node/weight/bias names in the manifest and decode params **without** building an
+   `initialize_params` target — so `load_checkpoint(path)` recovers weights with **no
+   model-class imports**. *Removes R1.* This is the single most important change.
+2. **Structure: keep YOURS' JSON snapshot but make it optional & best-effort (MERGE).**
+   Store `structure.json`; on load, wrap `_import_class` failures and degrade to
+   "params loaded; structure unavailable: <class> renamed/moved" instead of aborting.
+   *Fixes R1's blast radius + the dim-12 error quality.*
+3. **GraphState: add optional `state=` (ADOPT REFERENCE)** + `batch_size` in metadata,
+   restored into `initialize_graph_state` only when `structure` is available.
+4. **Atomicity: keep YOURS' staging + `.bak` overwrite-rollback (KEEP)**, but guard the
+   `finally` so a failed restore can't delete the backup (*fix R3*).
+5. **opt_state: keep YOURS' flax field-name matching + strict/non-strict (KEEP)** over
+   length-only (*addresses R2*); keep always-validating params.
+6. **Versioning: keep YOURS' `> FORMAT_VERSION` (KEEP)**; borrow REFERENCE's explicit
+   `format` magic string for "is this even ours" rejection.
+7. **Error framing: adopt REFERENCE's wrapping (ADOPT)** — wrap array/JSON reads and the
+   metadata `json.dumps` into checkpoint-aware `ValueError`s.
+8. **API: adopt REFERENCE's optional-kwarg save signature (ADOPT)**
+   `save(path, params, *, opt_state=None, structure=None, state=None, metadata=None,
+   overwrite=False)`; keep YOURS' `Checkpoint` NamedTuple return & `overwrite=False`.
+9. **Dtype: keep flax msgpack (KEEP)**; add an explicit bf16/fp16/0-d round-trip test.
+10. **Add a params/structure fingerprint to metadata (NEW)** — closes R4 in both.
+
+Net result: one ergonomic `save`; self-describing params that load regardless of code
+drift; an optional, graceful structure snapshot; optional GraphState; unconditional
+validation; best-in-class crash safety; and checkpoint-aware errors everywhere.

--- a/docs/dev_plans_archive/design_culprits_checkpointing.md
+++ b/docs/dev_plans_archive/design_culprits_checkpointing.md
@@ -1,0 +1,99 @@
+# Design culprits — `fabricpc/serialization.py` (Task 4: Model Checkpointing)
+
+Rationale for the non-obvious decisions, so a reviewer can judge intent. This is the
+**merged** design: the original implementation was compared against a reference design
+(`HANDOFF_compare.md`); the comparison (`COMPARISON_checkpointing.md`) adopted the better
+choice at each branch point. Scope: `save_checkpoint` / `load_checkpoint`
+serializing params, optimizer state, graph structure, and (optionally) inference state.
+
+## What a checkpoint is
+A **directory**: `metadata.json` (format magic + version, library versions, per-file
+sha256 checksums), `params.msgpack` (always), and optionally `structure.json`,
+`opt_state.msgpack`, `state.msgpack`.
+
+## Public API
+```python
+save_checkpoint(path, params, *, opt_state=None, structure=None, state=None,
+                metadata=None, overwrite=False) -> Path
+load_checkpoint(path, *, optimizer=None, strict=True)
+    -> Checkpoint(params, opt_state, structure, state, metadata)  # NamedTuple, named access
+```
+`path`-first + everything-else-optional (adopted from the reference): a params-only
+save is `save_checkpoint(path, params)`. The typed `Checkpoint` NamedTuple (kept from the
+original) is typo-proof vs a string-keyed dict.
+
+## The four payloads, and why each is handled the way it is
+
+1. **`params` — always saved, and SELF-DESCRIBING (the key correctness fix).** flax
+   msgpack stores the pytree keyed by node/weight/bias names, so on load
+   `flax.serialization.msgpack_restore` rebuilds the nested dict (dtype preserved, incl.
+   bf16/fp16) and we wrap it straight back into `GraphParams`/`NodeParams`
+   (`_restore_params`). **No `structure`, and no model-definition classes, are needed to
+   recover weights.** The original design decoded params into an
+   `initialize_params(structure)` *target*, which meant a single renamed/moved node class
+   made even the params unloadable — the comparison's highest-severity finding (R1). The
+   reference's self-describing approach is strictly more robust here, so it was adopted.
+
+2. **`opt_state` — optional; restored into `optimizer.init(params)`.** Its pytree *type*
+   is defined by the optimizer, not the data on disk, so the only way to recover exact
+   optax NamedTuple types is a template from the optimizer. Hence `load_checkpoint` takes
+   the `optimizer`. flax `from_bytes` matches by **field name**, so a wrong optimizer
+   raises rather than silently misloading (kept over the reference's length-only check).
+   `strict` governs the has-opt_state-but-no-optimizer case (raise vs skip).
+
+3. **`structure` — optional, reconstructed BEST-EFFORT.** Still serialized as a versioned
+   JSON *snapshot* of `NodeInfo`, with each object restored via `cls.__new__(cls)` +
+   direct attribute/`.config` assignment. `__new__` (not `cls(**config)`) is required
+   because several real constructors aren't round-trippable through `__init__`
+   (`UniformInitializer` renames config keys, `ZerosInitializer` drops `gain`,
+   `GlobalStateInit` nests a component). A snapshot (persisting `node_order` + muPC
+   factors) rather than re-running the `graph` builder avoids the builder's best-effort
+   topological sort on cyclic PC graphs. **New:** *any* failure to rebuild the structure
+   (a class that can no longer be imported, an evolved snapshot schema → `KeyError`, a
+   malformed path / unknown tag → `ValueError`, or a corrupt structure file) is caught,
+   **warns, and returns `structure=None`** — it never blocks the params (this is what
+   makes #1's robustness real end-to-end). When the structure *does* rebuild, the loaded
+   params are validated against it (node-set + shapes); a genuine mismatch there still
+   raises (it is an integrity error, not a graceful-degradation case).
+
+4. **`state: GraphState` — optional (adopted from the reference).** Only for
+   persistent-latent / Hopfield-style runs; the standard PC trainer re-initialises `z`
+   each batch, so it is not needed to resume normal training. Restored into an
+   `initialize_graph_state` template, so it loads only when `structure` was rebuilt.
+
+## Robustness decisions
+- **Format magic + version.** `metadata.json` carries `format == "fabricpc-checkpoint"`
+  and `format_version`; load checks both *before* decoding (unrelated dir → clear "not a
+  FabricPC checkpoint"; future format → clear version error). `version > FORMAT_VERSION`
+  rejects only *newer* files (forward-incompat, backward-compat) — kept over the
+  reference's `!=`.
+- **Per-file sha256 checksums** recorded at save, verified on load → a corrupt payload
+  that still decodes is caught with a clear "is corrupt" message.
+- **Error framing** (adopted from the reference): bad JSON, a non-checkpoint dir, a
+  non-JSON `metadata`, and unreadable payloads all raise checkpoint-aware `ValueError`s.
+- **Crash-safe writes.** Staged in a sibling `.tmp-<pid>` dir, moved with atomic
+  `os.replace`. On `overwrite` the existing checkpoint is renamed aside to `.bak` and
+  restored if the swap fails. The `finally` only discards the backup once `path` holds a
+  valid checkpoint, so a failed *restore* can't delete the last copy (fixes comparison R3).
+- **Array backend isolated** behind `_save_arrays`/`_load_arrays`/`_restore_params` (flax
+  msgpack now; swappable for Orbax later). flax round-trips every dtype losslessly
+  (verified incl. bf16/fp16), so no bespoke byte codec is needed.
+
+## What is intentionally NOT done
+- **No pickle** (version-brittle for arrays; breaks on class rename). The JSON snapshot is
+  inspectable and degrades gracefully instead.
+- **No Orbax dependency** (its async/sharding/CompositeHandler machinery buys little for a
+  single-host research framework).
+- **No content fingerprint of the *model*** beyond per-file checksums — in this bundled
+  design structure+params come from the same file, so they are always mutually consistent.
+
+## Constraints honored
+- **Additive:** only new file `fabricpc/serialization.py`, three exports in
+  `fabricpc/__init__.py`, and the opt-in `--checkpoint` branch in `examples/mnist_demo.py`.
+- **No new demo:** an existing demo is extended, per the plan.
+- **Tested:** `tests/test_serialization.py` (27 tests) covers self-describing param
+  round-trip (incl. bf16/fp16 and no-structure), the class-rename → params-only
+  degradation (R1), opt_state resume parity + wrong-optimizer, structure fidelity (the
+  `UniformInitializer` violator, nested-component state-init, conv config, muPC),
+  GraphState round-trip, and the full error contract (checksum corruption, format magic,
+  version, non-JSON metadata, overwrite crash-safety, missing files).

--- a/examples/mnist_demo.py
+++ b/examples/mnist_demo.py
@@ -11,6 +11,15 @@ Architecture::
 
 For optimizer selection and advanced controls, see mnist_advanced.py.
 
+Checkpointing
+-------------
+Run with ``--checkpoint <dir>`` to demonstrate model checkpointing: the demo
+trains half the epochs, saves params + optimizer state + structure to <dir>,
+reloads them with ``load_checkpoint`` (verifying the params round-trip exactly),
+then continues training the remaining epochs from the restored checkpoint::
+
+    python examples/mnist_demo.py --checkpoint /tmp/mnist_ckpt --epochs 6
+
 Results:
 Avg training time: 1.37s per epoch
 20 epochs
@@ -29,7 +38,9 @@ from fabricpc.core.inference import InferenceSGD
 from fabricpc.core.initializers import XavierInitializer
 import optax
 from fabricpc.training import train_pcn, evaluate_pcn
+from fabricpc import save_checkpoint, load_checkpoint
 from fabricpc.utils.data.dataloader import MnistLoader
+import argparse
 import time
 from fabricpc import setup_jax
 
@@ -73,13 +84,23 @@ structure = graph(
 
 # --- Hyperparameters ---
 
-train_config = {"num_epochs": 20}
 batch_size = 200
 optimizer = optax.adamw(0.001, weight_decay=0.1)
 
 # --- Train & Evaluate ---
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--epochs", type=int, default=20, help="Total training epochs.")
+    parser.add_argument(
+        "--checkpoint",
+        type=str,
+        default=None,
+        help="Directory to demonstrate save/load: train half the epochs, save, "
+        "reload, and continue training the rest from the checkpoint.",
+    )
+    args = parser.parse_args()
+
     master_rng_key = jax.random.PRNGKey(0)
     graph_key, train_key, eval_key = jax.random.split(master_rng_key, 3)
 
@@ -92,25 +113,90 @@ if __name__ == "__main__":
         "test", batch_size=batch_size, tensor_format="flat", shuffle=False
     )
 
-    print("\nTraining (JIT compilation on first batch)...")
-    start_time = time.time()
-    trained_params, energy_history, _ = train_pcn(
-        params=params,
-        structure=structure,
-        train_loader=train_loader,
-        optimizer=optimizer,
-        config=train_config,
-        rng_key=train_key,
-        verbose=True,
-    )
-    elapsed = time.time() - start_time
-    print(f"Avg training time: {elapsed / train_config['num_epochs']:.2f}s per epoch")
+    def evaluate(p, label):
+        metrics = evaluate_pcn(p, structure, test_loader, {}, eval_key)
+        print(f"{label} Test Accuracy: {metrics['accuracy'] * 100:.2f}%")
+        return metrics["accuracy"]
 
-    print("\nEvaluating...")
-    metrics = evaluate_pcn(
-        trained_params, structure, test_loader, train_config, eval_key
-    )
-    print(f"Test Accuracy: {metrics['accuracy'] * 100:.2f}%")
+    if args.checkpoint is None:
+        # --- Standard run: train all epochs straight through. ---
+        print("\nTraining (JIT compilation on first batch)...")
+        start_time = time.time()
+        trained_params, energy_history, _ = train_pcn(
+            params=params,
+            structure=structure,
+            train_loader=train_loader,
+            optimizer=optimizer,
+            config={"num_epochs": args.epochs},
+            rng_key=train_key,
+            verbose=True,
+        )
+        elapsed = time.time() - start_time
+        print(f"Avg training time: {elapsed / args.epochs:.2f}s per epoch")
+        print("\nEvaluating...")
+        evaluate(trained_params, "")
+    else:
+        # --- Checkpoint demo: train half -> save -> load -> train the rest. ---
+        first = args.epochs // 2
+        rest = args.epochs - first
+
+        print(f"\nTraining first {first} epochs...")
+        trained_params, _, _ = train_pcn(
+            params=params,
+            structure=structure,
+            train_loader=train_loader,
+            optimizer=optimizer,
+            config={"num_epochs": first},
+            rng_key=train_key,
+            verbose=True,
+        )
+        acc_mid = evaluate(trained_params, "[checkpoint] mid-training")
+
+        # Persist params + optimizer state + structure. NOTE: train_pcn manages
+        # its own optimizer state internally and neither returns nor accepts one,
+        # so this demo cannot thread real optimizer momentum across the save/load
+        # boundary — we capture a fresh opt_state purely to exercise the full
+        # save/load API. Bitwise optimizer-state resume parity (continuing with
+        # the *restored* opt_state) is proven in tests/test_serialization.py
+        # (test_resume_training_parity) via the lower-level train_step.
+        opt_state = optimizer.init(trained_params)
+        save_checkpoint(
+            args.checkpoint,
+            trained_params,
+            opt_state=opt_state,
+            structure=structure,
+            metadata={"epochs_so_far": first},
+            overwrite=True,
+        )
+        print(f"[checkpoint] saved to {args.checkpoint}")
+
+        # Reload — structure comes back from disk, so we don't need the code that
+        # built it. Pass the optimizer so its state pytree can be reconstructed.
+        loaded = load_checkpoint(args.checkpoint, optimizer=optimizer)
+        matches = all(
+            bool((a == b).all())
+            for a, b in zip(
+                jax.tree_util.tree_leaves(trained_params),
+                jax.tree_util.tree_leaves(loaded.params),
+            )
+        )
+        print(f"[checkpoint] reloaded; params identical to pre-save: {matches}")
+
+        print(f"\nContinuing {rest} more epochs from the checkpoint...")
+        trained_params, _, _ = train_pcn(
+            params=loaded.params,
+            structure=loaded.structure,
+            train_loader=train_loader,
+            optimizer=optimizer,
+            config={"num_epochs": rest},
+            rng_key=train_key,
+            verbose=True,
+        )
+        acc_final = evaluate(trained_params, "[checkpoint] final")
+        print(
+            f"[checkpoint] accuracy {acc_mid * 100:.2f}% (mid) -> "
+            f"{acc_final * 100:.2f}% (after resuming)"
+        )
 
     print(
         f"\n{len(structure.nodes)} nodes, {len(structure.edges)} edges, "

--- a/fabricpc/__init__.py
+++ b/fabricpc/__init__.py
@@ -59,6 +59,9 @@ from fabricpc.graph_initialization import initialize_params
 from fabricpc.training import train_pcn, evaluate_pcn
 from fabricpc.jax_config import setup_jax
 
+# Checkpointing
+from fabricpc.serialization import save_checkpoint, load_checkpoint, Checkpoint
+
 # Types - for type hints
 from fabricpc.core.types import GraphParams, GraphState, GraphStructure
 
@@ -68,6 +71,10 @@ __all__ = [
     "train_pcn",
     "evaluate_pcn",
     "setup_jax",
+    # Checkpointing
+    "save_checkpoint",
+    "load_checkpoint",
+    "Checkpoint",
     # Types (for type hints)
     "GraphParams",
     "GraphState",

--- a/fabricpc/serialization.py
+++ b/fabricpc/serialization.py
@@ -1,0 +1,790 @@
+"""
+Model checkpointing for FabricPC: save/load of parameters, optimizer state,
+graph structure, and (optionally) inference state.
+
+A checkpoint is a **directory**:
+
+    <ckpt>/
+        metadata.json      # format magic + version, library versions, checksums
+        params.msgpack     # GraphParams arrays (flax msgpack) — always present
+        structure.json     # the GraphStructure snapshot          (optional)
+        opt_state.msgpack  # optax optimizer state arrays          (optional)
+        state.msgpack      # a settled GraphState                  (optional)
+
+What is persisted, and how it round-trips:
+
+1. ``params: GraphParams`` — the model; always saved. **Self-describing:** flax
+   msgpack stores the pytree keyed by node / weight / bias names, so on load
+   ``msgpack_restore`` rebuilds ``GraphParams``/``NodeParams`` *from the file
+   alone* — no ``structure`` and **no model-definition classes required**. This
+   is what lets a checkpoint's weights load even if a node class was renamed or
+   moved since it was written.
+
+2. ``opt_state: optax.OptState`` — optional; for *resuming training*. Its pytree
+   *type* is defined by the optimizer, not the data on disk, so it is restored
+   into a template ``optimizer.init(params)`` — pass the ``optimizer`` to
+   :func:`load_checkpoint`. (flax matches by field name, so a wrong optimizer
+   raises rather than silently misloads.)
+
+3. ``structure: GraphStructure`` — optional, and reconstructed **best-effort** on
+   load. It holds arbitrary Python class instances; we serialize a versioned JSON
+   *snapshot* of ``NodeInfo`` (class import path + data) and restore each object
+   via ``cls.__new__(cls)`` + direct attribute / ``.config`` assignment.
+   ``__new__`` (not ``cls(**config)``) is required because several real
+   constructors aren't round-trippable through ``__init__`` (``UniformInitializer``
+   renames config keys, ``ZerosInitializer`` drops ``gain``, ``GlobalStateInit``
+   nests a component). A *snapshot* (persisting ``node_order`` + muPC factors)
+   rather than re-running the ``graph`` builder avoids the builder's best-effort
+   topological sort on cyclic PC graphs. Saving the structure lets a model reload
+   in a fresh process with no model code; **but any failure to rebuild it (a class
+   that can no longer be imported, an evolved snapshot schema, a corrupt structure
+   file) degrades to ``structure=None`` with a warning and still returns the
+   params** — the snapshot never blocks weight recovery. (A structure that *does*
+   rebuild but disagrees with the params on shape still raises — a real integrity
+   error, not a graceful-degradation case.)
+
+4. ``state: GraphState`` — optional; only for persistent-latent / Hopfield-style
+   runs (the standard PC trainer re-initialises ``z`` each batch). Restored into
+   an ``initialize_graph_state`` template, so it loads only when ``structure`` was
+   rebuilt.
+
+Robustness: a ``format`` magic string + ``format_version`` are checked before any
+decode; each binary payload carries a sha256 ``checksum`` verified on load
+(corruption → clear error); writes are crash-safe (staged in a temp dir, moved
+with atomic ``os.replace``, and on overwrite the previous checkpoint is moved
+aside and restored on failure so it is never lost); and when ``structure`` is
+present the loaded params are validated against it (node-set + shapes).
+No pickle anywhere.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import os
+import shutil
+import types
+import uuid
+import warnings
+from pathlib import Path
+from typing import Any, Dict, NamedTuple, Optional, Tuple, Union
+
+import jax
+import numpy as np
+import flax.serialization as flax_ser
+
+from fabricpc.core.types import (
+    GraphParams,
+    NodeParams,
+    GraphStructure,
+    NodeInfo,
+    SlotInfo,
+    EdgeInfo,
+)
+from fabricpc.core.activations import ActivationBase
+from fabricpc.core.energy import EnergyFunctional
+from fabricpc.core.initializers import InitializerBase
+from fabricpc.core.inference import InferenceBase
+from fabricpc.core.mupc import MuPCScalingFactors
+from fabricpc.graph_initialization import initialize_params
+from fabricpc.graph_initialization.state_initializer import (
+    StateInitBase,
+    initialize_graph_state,
+)
+
+# Magic string identifying our checkpoints — lets load reject an unrelated
+# directory with a clear message before attempting to decode anything.
+FORMAT = "fabricpc-checkpoint"
+
+# Bump when the on-disk format changes incompatibly. load_checkpoint refuses any
+# checkpoint whose format_version exceeds the version it understands.
+FORMAT_VERSION = 1
+
+# File names within the checkpoint directory.
+_METADATA_FILE = "metadata.json"
+_STRUCTURE_FILE = "structure.json"
+_PARAMS_FILE = "params.msgpack"
+_OPT_STATE_FILE = "opt_state.msgpack"
+_STATE_FILE = "state.msgpack"
+
+# Reserved key used to tag non-plain values in the JSON encoding. A config dict
+# must not use this key (it is internal to the codec).
+_TAG = "__fpc__"
+
+# Component base classes whose instances are reconstructed from (class, config).
+_COMPONENT_BASES = (
+    ActivationBase,
+    EnergyFunctional,
+    InitializerBase,
+    InferenceBase,
+    StateInitBase,
+)
+
+
+PathLike = Union[str, os.PathLike]
+
+
+class Checkpoint(NamedTuple):
+    """Result of :func:`load_checkpoint`. Use named access (``ckpt.params``).
+
+    - ``params`` always loads (self-describing — no model code required).
+    - ``opt_state`` is ``None`` unless the file stored one *and* an ``optimizer``
+      was passed to reconstruct its pytree types.
+    - ``structure`` is the rebuilt graph, or ``None`` if the file stored none or
+      a node/component class can no longer be imported (best-effort).
+    - ``state`` is a restored ``GraphState``, or ``None`` unless the file stored
+      one *and* ``structure`` was rebuilt to template it.
+    - ``metadata`` is the user metadata dict passed at save time (``{}`` if none).
+    """
+
+    params: GraphParams
+    opt_state: Optional[Any]
+    structure: Optional[GraphStructure]
+    state: Optional[Any]
+    metadata: Dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Class path import / export
+# ---------------------------------------------------------------------------
+def _class_path(cls: type) -> str:
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _import_class(path: str) -> type:
+    module_name, _, qualname = path.rpartition(".")
+    if not module_name:
+        raise ValueError(f"Malformed class path: {path!r}")
+    module = importlib.import_module(module_name)
+    obj: Any = module
+    for attr in qualname.split("."):
+        obj = getattr(obj, attr)
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Recursive JSON codec for structure metadata
+#
+# Plain JSON scalars / lists / dicts pass through unchanged so the file stays
+# human-readable; only values JSON cannot represent faithfully are tagged with
+# the reserved _TAG key: tuples (to distinguish from lists) and component
+# instances (class + config). Component configs are themselves encoded
+# recursively, which transparently handles nested components (e.g. the
+# InitializerBase stored inside GlobalStateInit's config).
+# ---------------------------------------------------------------------------
+def _to_jsonable(obj: Any) -> Any:
+    if obj is None or isinstance(obj, (bool, str)):
+        return obj
+    # numpy scalars -> python scalars (python float repr round-trips exactly)
+    if isinstance(obj, (int, np.integer)):
+        return int(obj)
+    if isinstance(obj, (float, np.floating)):
+        return float(obj)
+    if isinstance(obj, _COMPONENT_BASES):
+        return {
+            _TAG: "component",
+            "class": _class_path(type(obj)),
+            "config": _to_jsonable(dict(obj.config)),
+        }
+    if isinstance(obj, tuple):
+        return {_TAG: "tuple", "items": [_to_jsonable(v) for v in obj]}
+    if isinstance(obj, list):
+        return [_to_jsonable(v) for v in obj]
+    if isinstance(obj, (dict, types.MappingProxyType)):
+        out: Dict[str, Any] = {}
+        for k, v in obj.items():
+            if not isinstance(k, str):
+                raise ValueError(
+                    f"Cannot serialize structure: dict key {k!r} is not a string."
+                )
+            if k == _TAG:
+                raise ValueError(
+                    f"Cannot serialize structure: config uses reserved key {_TAG!r}."
+                )
+            out[k] = _to_jsonable(v)
+        return out
+    raise ValueError(
+        f"Cannot serialize value of type {type(obj).__name__!r} in graph "
+        f"structure metadata. Supported: None, bool, int, float, str, tuple, "
+        f"list, dict, and component instances (activation/energy/initializer/"
+        f"inference/state-init). Arrays belong in params, not structure config."
+    )
+
+
+def _from_jsonable(spec: Any) -> Any:
+    if isinstance(spec, list):
+        return [_from_jsonable(v) for v in spec]
+    if isinstance(spec, dict):
+        tag = spec.get(_TAG)
+        if tag is None:
+            return {k: _from_jsonable(v) for k, v in spec.items()}
+        if tag == "tuple":
+            return tuple(_from_jsonable(v) for v in spec["items"])
+        if tag == "component":
+            cls = _import_class(spec["class"])
+            config = _from_jsonable(spec["config"])
+            return _reconstruct_component(cls, config)
+        raise ValueError(f"Unknown encoding tag {tag!r} in structure file.")
+    return spec  # None / bool / int / float / str
+
+
+def _reconstruct_component(cls: type, config: Dict[str, Any]) -> Any:
+    """Rebuild a component from its class and config, bypassing ``__init__``.
+
+    All components only read from ``self.config``, so restoring that attribute
+    yields a fully functional instance regardless of constructor quirks.
+    ``StateInitBase`` stores a plain dict; the others use ``MappingProxyType`` —
+    we match the original so immutability semantics are preserved.
+    """
+    obj = cls.__new__(cls)
+    if issubclass(cls, StateInitBase):
+        obj.config = config
+    else:
+        obj.config = types.MappingProxyType(config)
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Structure encode / decode
+# ---------------------------------------------------------------------------
+def _encode_component_or_none(obj: Any) -> Any:
+    return None if obj is None else _to_jsonable(obj)
+
+
+def _encode_slot(slot: SlotInfo) -> Dict[str, Any]:
+    return {
+        "name": slot.name,
+        "parent_node": slot.parent_node,
+        "is_multi_input": slot.is_multi_input,
+        "is_variance_scalable": slot.is_variance_scalable,
+        "is_skip_connection": slot.is_skip_connection,
+        "in_neighbors": list(slot.in_neighbors),
+    }
+
+
+def _decode_slot(d: Dict[str, Any]) -> SlotInfo:
+    return SlotInfo(
+        name=d["name"],
+        parent_node=d["parent_node"],
+        is_multi_input=d["is_multi_input"],
+        is_variance_scalable=d["is_variance_scalable"],
+        is_skip_connection=d["is_skip_connection"],
+        in_neighbors=tuple(d["in_neighbors"]),
+    )
+
+
+def _encode_scaling(sc: Optional[MuPCScalingFactors]) -> Any:
+    if sc is None:
+        return None
+    return {
+        "forward_scale": {k: float(v) for k, v in sc.forward_scale.items()},
+        "self_grad_scale": float(sc.self_grad_scale),
+        "topdown_grad_scale": {k: float(v) for k, v in sc.topdown_grad_scale.items()},
+        "weight_grad_scale": {k: float(v) for k, v in sc.weight_grad_scale.items()},
+    }
+
+
+def _decode_scaling(d: Optional[Dict[str, Any]]) -> Optional[MuPCScalingFactors]:
+    if d is None:
+        return None
+    return MuPCScalingFactors(
+        forward_scale=dict(d["forward_scale"]),
+        self_grad_scale=d["self_grad_scale"],
+        topdown_grad_scale=dict(d["topdown_grad_scale"]),
+        weight_grad_scale=dict(d["weight_grad_scale"]),
+    )
+
+
+def _encode_node(node: Any) -> Dict[str, Any]:
+    ni: NodeInfo = node.node_info
+    return {
+        "class": _class_path(type(node)),
+        "name": ni.name,
+        "shape": list(ni.shape),
+        "node_type": ni.node_type,
+        "node_config": _to_jsonable(dict(ni.node_config)),
+        "activation": _encode_component_or_none(ni.activation),
+        "energy": _encode_component_or_none(ni.energy),
+        "latent_init": _encode_component_or_none(ni.latent_init),
+        "weight_init": _encode_component_or_none(ni.weight_init),
+        "slots": {name: _encode_slot(s) for name, s in ni.slots.items()},
+        "in_degree": ni.in_degree,
+        "out_degree": ni.out_degree,
+        "in_edges": list(ni.in_edges),
+        "out_edges": list(ni.out_edges),
+        "scaling_config": _encode_scaling(ni.scaling_config),
+    }
+
+
+def _decode_node(d: Dict[str, Any]) -> Any:
+    cls = _import_class(d["class"])
+    node_config = types.MappingProxyType(_from_jsonable(d["node_config"]))
+    node_info = NodeInfo(
+        name=d["name"],
+        shape=tuple(d["shape"]),
+        node_type=d["node_type"],
+        node_class=cls,
+        node_config=node_config,
+        activation=_from_jsonable(d["activation"]) if d["activation"] else None,
+        energy=_from_jsonable(d["energy"]) if d["energy"] else None,
+        latent_init=_from_jsonable(d["latent_init"]) if d["latent_init"] else None,
+        weight_init=_from_jsonable(d["weight_init"]) if d["weight_init"] else None,
+        slots={name: _decode_slot(s) for name, s in d["slots"].items()},
+        in_degree=d["in_degree"],
+        out_degree=d["out_degree"],
+        in_edges=tuple(d["in_edges"]),
+        out_edges=tuple(d["out_edges"]),
+        scaling_config=_decode_scaling(d["scaling_config"]),
+    )
+    # Reconstruct the node instance by restoring its state directly (bypassing
+    # __init__). Setting the final namespace-prefixed name verbatim avoids the
+    # double-prefixing that re-running a constructor under a GraphNamespace would
+    # cause.
+    node = cls.__new__(cls)
+    node._name = node_info.name
+    node._shape = node_info.shape
+    node._activation = node_info.activation
+    node._energy = node_info.energy
+    node._latent_init = node_info.latent_init
+    node._weight_init = node_info.weight_init
+    node._extra_config = node_config
+    node._node_info = node_info
+    return node
+
+
+def _encode_edge(edge: EdgeInfo) -> Dict[str, Any]:
+    return {
+        "key": edge.key,
+        "source": edge.source,
+        "target": edge.target,
+        "slot": edge.slot,
+    }
+
+
+def _decode_edge(d: Dict[str, Any]) -> EdgeInfo:
+    return EdgeInfo(
+        key=d["key"], source=d["source"], target=d["target"], slot=d["slot"]
+    )
+
+
+def serialize_structure(structure: GraphStructure) -> Dict[str, Any]:
+    """Encode a :class:`GraphStructure` into a JSON-serializable dict."""
+    return {
+        "nodes": {name: _encode_node(node) for name, node in structure.nodes.items()},
+        "edges": {key: _encode_edge(e) for key, e in structure.edges.items()},
+        "task_map": dict(structure.task_map),
+        "node_order": list(structure.node_order),
+        "config": _to_jsonable(dict(structure.config)),
+    }
+
+
+def deserialize_structure(d: Dict[str, Any]) -> GraphStructure:
+    """Decode a dict produced by :func:`serialize_structure` back into a
+    :class:`GraphStructure`."""
+    return GraphStructure(
+        nodes={name: _decode_node(nd) for name, nd in d["nodes"].items()},
+        edges={key: _decode_edge(ed) for key, ed in d["edges"].items()},
+        task_map=dict(d["task_map"]),
+        node_order=tuple(d["node_order"]),
+        config=_from_jsonable(d["config"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Array I/O (isolated so the backend can be swapped for orbax later)
+# ---------------------------------------------------------------------------
+def _save_arrays(pytree: Any, file_path: Path) -> None:
+    file_path.write_bytes(flax_ser.to_bytes(pytree))
+
+
+def _load_arrays(target: Any, file_path: Path) -> Any:
+    """Restore arrays into a *template* pytree (recovers exact NamedTuple types).
+
+    Used for opt_state / GraphState, whose pytree types are defined by the
+    optimizer / structure rather than by the data on disk.
+    """
+    return flax_ser.from_bytes(target, file_path.read_bytes())
+
+
+def _restore_params(file_path: Path) -> GraphParams:
+    """Rebuild ``GraphParams`` from the file alone — **no structure or model
+    classes required**.
+
+    ``flax`` msgpack stores the pytree as a nested dict keyed by the node /
+    weight / bias names, so ``msgpack_restore`` recovers that dict (dtype
+    preserved, incl. bfloat16/float16) and we wrap it back into the
+    ``GraphParams``/``NodeParams`` types directly. This is what lets a checkpoint
+    load even if a node class was renamed or moved since it was written.
+    """
+    restored = flax_ser.msgpack_restore(file_path.read_bytes())
+    return GraphParams(
+        nodes={
+            name: NodeParams(
+                weights={k: jax.numpy.asarray(v) for k, v in nd["weights"].items()},
+                biases={k: jax.numpy.asarray(v) for k, v in nd["biases"].items()},
+            )
+            for name, nd in restored["nodes"].items()
+        }
+    )
+
+
+def _sha256(file_path: Path) -> str:
+    return hashlib.sha256(file_path.read_bytes()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Metadata & validation
+# ---------------------------------------------------------------------------
+def _keypath_str(path: Tuple[Any, ...]) -> str:
+    return jax.tree_util.keystr(path)
+
+
+def _leaf_shape_map(params: GraphParams) -> Dict[str, Tuple[int, ...]]:
+    leaves = jax.tree_util.tree_flatten_with_path(params)[0]
+    return {_keypath_str(p): tuple(np.shape(leaf)) for p, leaf in leaves}
+
+
+def _validate_params_against_structure(
+    params: GraphParams, structure: GraphStructure
+) -> None:
+    """Check the loaded params are compatible with a (re)built structure, raising
+    a clear error on any node-set or shape mismatch — catches a structure whose
+    node shapes drifted in code since the checkpoint was written."""
+    got = _leaf_shape_map(params)
+    want = _leaf_shape_map(initialize_params(structure, jax.random.PRNGKey(0)))
+
+    missing = sorted(set(want) - set(got))
+    extra = sorted(set(got) - set(want))
+    if missing or extra:
+        raise ValueError(
+            "Loaded params are incompatible with the structure. Missing leaves "
+            f"(structure expects, file lacks): {missing}. Extra leaves (file has, "
+            f"structure lacks): {extra}."
+        )
+    for path, want_shape in want.items():
+        if got[path] != want_shape:
+            raise ValueError(
+                f"Shape mismatch at {path}: file has {got[path]}, structure "
+                f"expects {want_shape}."
+            )
+
+
+def _warn_on_flax_drift(saved_flax: Optional[str]) -> None:
+    """Soft-warn if the flax version that wrote the arrays differs (major.minor)
+    from the one loading them — the msgpack array format is flax-owned."""
+    if not saved_flax:
+        return
+    import flax
+
+    current = flax.__version__
+    if saved_flax.split(".")[:2] != current.split(".")[:2]:
+        warnings.warn(
+            f"Checkpoint arrays were written with flax {saved_flax}, but flax "
+            f"{current} is loading them. The msgpack array format is usually "
+            f"stable across versions, but verify the loaded parameters if you "
+            f"see decode issues.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+def _library_versions() -> Dict[str, str]:
+    import optax
+    import flax
+
+    versions = {
+        "jax": jax.__version__,
+        "optax": optax.__version__,
+        "flax": flax.__version__,
+    }
+    try:  # fabricpc may not be pip-installed in a dev checkout
+        from importlib.metadata import version as _pkg_version
+
+        versions["fabricpc"] = _pkg_version("fabricpc")
+    except Exception:
+        versions["fabricpc"] = "unknown"
+    return versions
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+def save_checkpoint(
+    path: PathLike,
+    params: GraphParams,
+    *,
+    opt_state: Optional[Any] = None,
+    structure: Optional[GraphStructure] = None,
+    state: Optional[Any] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    overwrite: bool = False,
+) -> Path:
+    """Save a checkpoint to ``path``.
+
+    Args:
+        path: Destination directory for the checkpoint (created if absent).
+        params: Network parameters (``GraphParams`` pytree) — always saved; this
+            is the model.
+        opt_state: Optimizer state from ``optimizer.init(params)``. Pass it to
+            *resume training* later; omit for an inference-only model.
+        structure: The graph structure. Optional: params load without it (they
+            are self-describing), but saving it lets the model be reloaded in a
+            fresh process with no model-definition code, and enables loading any
+            saved ``state``.
+        state: A settled ``GraphState`` to snapshot — only for persistent-latent /
+            Hopfield-style runs; the standard PC trainer re-initialises ``z`` each
+            batch, so it is not needed to resume normal training.
+        metadata: Optional user metadata (any JSON-serializable dict) — e.g.
+            epoch, accuracy, config. Returned by :func:`load_checkpoint`.
+        overwrite: If False (default), raise ``FileExistsError`` when ``path``
+            exists. If True, atomically replace it.
+
+    Returns:
+        The ``Path`` written.
+
+    The write is crash-safe: files are staged in a sibling temp directory and
+    moved into place only with atomic ``os.replace`` calls. On ``overwrite`` an
+    existing checkpoint is moved aside (not deleted) and restored on failure, so a
+    crash during the swap leaves the *previous* checkpoint intact, never nothing.
+    """
+    path = Path(path)
+    if path.exists() and not overwrite:
+        raise FileExistsError(
+            f"Checkpoint path {str(path)!r} already exists. Pass overwrite=True "
+            f"to replace it."
+        )
+
+    if metadata is not None:
+        try:
+            user_meta = json.loads(json.dumps(metadata))
+        except TypeError as e:
+            raise ValueError(
+                f"metadata is not JSON-serializable: {e}. Use only "
+                f"str/int/float/bool/list/dict (no arrays or custom objects)."
+            ) from e
+    else:
+        user_meta = {}
+
+    meta = {
+        "format": FORMAT,
+        "format_version": FORMAT_VERSION,
+        "library_versions": _library_versions(),
+        "has_opt_state": opt_state is not None,
+        "has_structure": structure is not None,
+        "has_state": state is not None,
+        "batch_size": int(state.batch_size) if state is not None else None,
+        "user": user_meta,
+        # checksums of the binary payloads, filled in after they are written.
+        "checksums": {},
+    }
+
+    # Unique scratch names (pid + random) so concurrent saves to the same path
+    # — even within one process — never share or clobber each other's staging.
+    token = f"{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    staging = path.parent / f".{path.name}.tmp-{token}"
+    backup = path.parent / f".{path.name}.bak-{token}"
+    for scratch in (staging, backup):
+        if scratch.exists():
+            shutil.rmtree(scratch)
+    staging.mkdir(parents=True)
+
+    moved_to_backup = False
+    try:
+        _save_arrays(params, staging / _PARAMS_FILE)
+        meta["checksums"][_PARAMS_FILE] = _sha256(staging / _PARAMS_FILE)
+        if structure is not None:
+            (staging / _STRUCTURE_FILE).write_text(
+                json.dumps(serialize_structure(structure), indent=2)
+            )
+            meta["checksums"][_STRUCTURE_FILE] = _sha256(staging / _STRUCTURE_FILE)
+        if opt_state is not None:
+            _save_arrays(opt_state, staging / _OPT_STATE_FILE)
+            meta["checksums"][_OPT_STATE_FILE] = _sha256(staging / _OPT_STATE_FILE)
+        if state is not None:
+            _save_arrays(state, staging / _STATE_FILE)
+            meta["checksums"][_STATE_FILE] = _sha256(staging / _STATE_FILE)
+        # metadata.json is written last (it carries the other files' checksums).
+        (staging / _METADATA_FILE).write_text(json.dumps(meta, indent=2))
+
+        # Crash-safe swap: each step is an atomic os.replace, and any existing
+        # checkpoint is moved aside (not deleted) before the new one moves in, so
+        # a crash between the two replaces leaves the previous checkpoint intact.
+        if path.exists():
+            os.replace(path, backup)
+            moved_to_backup = True
+        os.replace(staging, path)
+    except BaseException:
+        # The new checkpoint never landed — restore the previous one if we had
+        # moved it aside, so `path` is never left empty.
+        if moved_to_backup and not path.exists() and backup.exists():
+            os.replace(backup, path)
+        raise
+    finally:
+        if staging.exists():
+            shutil.rmtree(staging)
+        # Only discard the backup once `path` holds a valid checkpoint (the new
+        # one landed, or the restore above succeeded). If `path` is somehow empty
+        # — e.g. the restore itself was interrupted — keep the backup for manual
+        # recovery rather than deleting the last copy.
+        if backup.exists() and path.exists():
+            shutil.rmtree(backup)
+    return path
+
+
+def _verify_checksum(path: Path, filename: str, meta: Dict[str, Any]) -> None:
+    """Raise a clear error if a payload file's content doesn't match the hash
+    recorded at save time (detects silent corruption that still decodes)."""
+    expected = meta.get("checksums", {}).get(filename)
+    if expected is None:
+        return  # nothing recorded (e.g. older writer) — skip
+    actual = _sha256(path / filename)
+    if actual != expected:
+        raise ValueError(
+            f"Checkpoint file {filename!r} in {str(path)!r} is corrupt: its "
+            f"checksum does not match the one recorded at save time."
+        )
+
+
+def load_checkpoint(
+    path: PathLike,
+    *,
+    optimizer: Optional[Any] = None,
+    strict: bool = True,
+) -> Checkpoint:
+    """Load a checkpoint saved by :func:`save_checkpoint`.
+
+    ``params`` always load — they are self-describing and need no ``structure``
+    or model-definition code. ``structure`` is rebuilt best-effort (``None`` if
+    the file stored none, or a node/component class can no longer be imported).
+
+    Args:
+        path: Checkpoint directory.
+        optimizer: The optax optimizer used during training. Required to rebuild
+            the *exact* optimizer-state pytree types for resuming (that type is
+            defined by the optimizer, not the data on disk). If the file has
+            optimizer state but none is given, behavior depends on ``strict``.
+        strict: If True (default), raise when the file contains optimizer state
+            but no ``optimizer`` was provided. If False, skip it (``opt_state``
+            stays ``None``; params/structure still load).
+
+    Returns:
+        ``Checkpoint(params, opt_state, structure, state, metadata)`` — use named
+        access. ``opt_state``/``structure``/``state`` are ``None`` when absent or
+        not requestable (see the type's docstring).
+
+    Raises:
+        FileNotFoundError: If ``path`` or a required file is missing.
+        ValueError: On a non-/future-format checkpoint, a corrupt payload, or a
+            params/structure shape mismatch.
+    """
+    path = Path(path)
+    if not path.is_dir():
+        raise FileNotFoundError(f"Checkpoint directory not found: {str(path)!r}")
+    for required in (_METADATA_FILE, _PARAMS_FILE):
+        if not (path / required).is_file():
+            raise FileNotFoundError(
+                f"Checkpoint at {str(path)!r} is missing required file {required!r}."
+            )
+
+    # Identify + version-gate before decoding anything, so an unrelated directory
+    # or a future-format file fails with a clear message, not an opaque error.
+    try:
+        meta = json.loads((path / _METADATA_FILE).read_text())
+    except (ValueError, UnicodeDecodeError) as e:
+        raise ValueError(
+            f"Could not read {str(path)!r} as a FabricPC checkpoint: its "
+            f"{_METADATA_FILE} is not valid JSON ({e})."
+        ) from e
+    if meta.get("format") != FORMAT:
+        raise ValueError(
+            f"{str(path)!r} is not a FabricPC checkpoint (expected format "
+            f"{FORMAT!r}, found {meta.get('format')!r})."
+        )
+    file_version = meta.get("format_version")
+    if file_version is None or file_version > FORMAT_VERSION:
+        raise ValueError(
+            f"Checkpoint format_version {file_version!r} is not supported by this "
+            f"version of FabricPC (understands up to {FORMAT_VERSION}). The "
+            f"checkpoint was likely written by a newer release."
+        )
+
+    # The msgpack array format is owned by flax; warn (don't fail) on drift.
+    _warn_on_flax_drift(meta.get("library_versions", {}).get("flax"))
+
+    # --- params: self-describing, no structure/classes required. ---
+    _verify_checksum(path, _PARAMS_FILE, meta)
+    try:
+        params = _restore_params(path / _PARAMS_FILE)
+    except Exception as e:
+        raise ValueError(
+            f"Could not read {_PARAMS_FILE} in {str(path)!r} as checkpoint "
+            f"parameters: {e}"
+        ) from e
+
+    # --- structure: best-effort, and never blocks params. ANY failure to rebuild
+    #     it — a renamed/moved class, an evolved snapshot schema, a corrupt
+    #     structure file — degrades to structure=None with a warning rather than
+    #     propagating, because the (self-describing) params are the durable
+    #     artifact. A structure that *does* rebuild but is inconsistent with the
+    #     params (shape/node-set mismatch) is a genuine integrity error and still
+    #     raises, so tampering/corruption that survives rebuild is not silenced. ---
+    structure = None
+    if (path / _STRUCTURE_FILE).is_file():
+        try:
+            _verify_checksum(path, _STRUCTURE_FILE, meta)
+            structure = deserialize_structure(
+                json.loads((path / _STRUCTURE_FILE).read_text())
+            )
+        except Exception as e:
+            structure = None
+            warnings.warn(
+                f"Checkpoint at {str(path)!r} stores a structure that could not "
+                f"be rebuilt ({type(e).__name__}: {e}) — e.g. a node/component "
+                f"class was renamed or moved, the snapshot schema changed, or the "
+                f"structure file is corrupt. Returning params only (structure="
+                f"None); any saved state cannot be restored.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        else:
+            _validate_params_against_structure(params, structure)
+
+    # --- opt_state: restored into optimizer.init(params); needs the optimizer. ---
+    opt_state = None
+    opt_file = path / _OPT_STATE_FILE
+    if opt_file.is_file():
+        if optimizer is None:
+            if strict:
+                raise ValueError(
+                    f"Checkpoint at {str(path)!r} contains optimizer state, but no "
+                    f"`optimizer` was provided. Pass the optax optimizer used for "
+                    f"training so its state pytree can be reconstructed, or call "
+                    f"with strict=False to load params only."
+                )
+            # Non-strict: skip opt_state.
+        else:
+            _verify_checksum(path, _OPT_STATE_FILE, meta)
+            opt_state = _load_arrays(optimizer.init(params), opt_file)
+
+    # --- state: restored into an initialize_graph_state template; needs structure. ---
+    state = None
+    state_file = path / _STATE_FILE
+    if state_file.is_file() and structure is not None:
+        _verify_checksum(path, _STATE_FILE, meta)
+        template = initialize_graph_state(
+            structure,
+            meta["batch_size"],
+            jax.random.PRNGKey(0),
+            clamps={},
+            params=params,
+        )
+        state = _load_arrays(template, state_file)
+
+    return Checkpoint(
+        params=params,
+        opt_state=opt_state,
+        structure=structure,
+        state=state,
+        metadata=meta.get("user", {}),
+    )

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""
+Tests for model checkpointing: fabricpc.serialization.save_checkpoint / load_checkpoint.
+
+Covers self-describing param round-trips (exact values, types, and dtypes — no
+structure required), optional best-effort structure recovery (incl. the
+class-rename degradation), optional GraphState, optimizer-state resume parity,
+and the error / edge-case contract (checksums, format magic, version, overwrite
+crash-safety, metadata).
+"""
+
+import json
+
+import pytest
+import jax
+import jax.numpy as jnp
+import optax
+
+from fabricpc.nodes import Linear, IdentityNode, ConvNode
+from fabricpc.core.topology import Edge
+from fabricpc.graph_assembly import TaskMap, graph
+from fabricpc.graph_initialization import initialize_params
+from fabricpc.graph_initialization.state_initializer import (
+    GlobalStateInit,
+    initialize_graph_state,
+)
+from fabricpc.core.types import GraphParams, NodeParams
+from fabricpc.core.activations import SigmoidActivation, SoftmaxActivation
+from fabricpc.core.energy import CrossEntropyEnergy
+from fabricpc.core.inference import InferenceSGD
+from fabricpc.core.initializers import (
+    XavierInitializer,
+    UniformInitializer,
+    NormalInitializer,
+)
+from fabricpc.core.mupc import MuPCConfig
+from fabricpc import serialization
+from fabricpc.serialization import (
+    save_checkpoint,
+    load_checkpoint,
+    serialize_structure,
+    deserialize_structure,
+    FORMAT,
+    FORMAT_VERSION,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+def _leaves_equal(a, b):
+    la = jax.tree_util.tree_leaves(a)
+    lb = jax.tree_util.tree_leaves(b)
+    return len(la) == len(lb) and all(jnp.array_equal(x, y) for x, y in zip(la, lb))
+
+
+def _mlp_structure():
+    """Small MLP whose hidden layer uses UniformInitializer — a component whose
+    config keys do NOT match its constructor params, exercising the
+    reconstruct-object-state (not replay-constructor) code path."""
+    x = IdentityNode(shape=(12,), name="pixels")
+    h = Linear(
+        shape=(8,),
+        activation=SigmoidActivation(),
+        name="h",
+        weight_init=UniformInitializer(min_val=-0.2, max_val=0.2),
+    )
+    y = Linear(
+        shape=(4,),
+        activation=SoftmaxActivation(),
+        energy=CrossEntropyEnergy(),
+        name="class",
+        weight_init=XavierInitializer(),
+    )
+    return graph(
+        nodes=[x, h, y],
+        edges=[
+            Edge(source=x, target=h.slot("in")),
+            Edge(source=h, target=y.slot("in")),
+        ],
+        task_map=TaskMap(x=x, y=y),
+        inference=InferenceSGD(eta_infer=0.05, infer_steps=5),
+    )
+
+
+@pytest.fixture
+def mlp():
+    structure = _mlp_structure()
+    params = initialize_params(structure, jax.random.PRNGKey(0))
+    optimizer = optax.adamw(1e-3)
+    opt_state = optimizer.init(params)
+    # Take one real step so opt_state holds non-trivial moments.
+    grads = jax.tree_util.tree_map(lambda p: jnp.full_like(p, 0.1), params)
+    updates, opt_state = optimizer.update(grads, opt_state, params)
+    params = optax.apply_updates(params, updates)
+    return structure, params, optimizer, opt_state
+
+
+# ---------------------------------------------------------------------------
+# Parameter round-trips — self-describing (no structure needed)
+# ---------------------------------------------------------------------------
+def test_params_roundtrip_exact_and_typed_without_structure(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params)  # params only, no structure
+    loaded = load_checkpoint(ckpt)
+    assert _leaves_equal(params, loaded.params)
+    assert isinstance(loaded.params, GraphParams)
+    assert all(isinstance(np_, NodeParams) for np_ in loaded.params.nodes.values())
+    assert loaded.structure is None  # none was saved
+    assert loaded.opt_state is None
+
+
+def test_params_dtype_fidelity_bf16_fp16(tmp_path):
+    """Self-describing params must round-trip bf16/fp16 and 0-d scalars exactly."""
+    params = GraphParams(
+        nodes={
+            "h": NodeParams(
+                weights={"in->h": jnp.array([[1.5, -2.25]], dtype=jnp.bfloat16)},
+                biases={"b": jnp.array([0.5, -0.5], dtype=jnp.float16)},
+            ),
+            "x": NodeParams(weights={}, biases={}),  # terminal node, no params
+        }
+    )
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params)
+    loaded = load_checkpoint(ckpt).params
+    assert _leaves_equal(params, loaded)
+    assert loaded.nodes["h"].weights["in->h"].dtype == jnp.bfloat16
+    assert loaded.nodes["h"].biases["b"].dtype == jnp.float16
+
+
+def test_opt_state_roundtrip_exact_typed_and_usable(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, opt_state=opt_state, structure=structure)
+    loaded = load_checkpoint(ckpt, optimizer=optimizer)
+    assert _leaves_equal(opt_state, loaded.opt_state)
+    assert type(loaded.opt_state) is type(opt_state)
+    grads = jax.tree_util.tree_map(jnp.ones_like, loaded.params)
+    optimizer.update(grads, loaded.opt_state, loaded.params)
+
+
+def test_metadata_returned(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, metadata={"epoch": 7, "acc": 0.98})
+    loaded = load_checkpoint(ckpt)
+    assert loaded.metadata == {"epoch": 7, "acc": 0.98}
+
+
+# ---------------------------------------------------------------------------
+# Structure fidelity (optional payload)
+# ---------------------------------------------------------------------------
+def test_structure_full_fidelity(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, structure=structure)
+    loaded = load_checkpoint(ckpt).structure
+    assert loaded is not None
+
+    assert set(loaded.nodes) == set(structure.nodes)
+    assert set(loaded.edges) == set(structure.edges)
+    assert loaded.task_map == structure.task_map
+    assert loaded.node_order == structure.node_order
+
+    for name, node in structure.nodes.items():
+        ln = loaded.nodes[name]
+        assert type(ln) is type(node)
+        assert ln.name == node.name
+        assert ln.shape == node.shape
+        oi, li = node.node_info, ln.node_info
+        assert li.in_edges == oi.in_edges
+        assert li.out_edges == oi.out_edges
+        assert type(li.activation) is type(oi.activation)
+        assert type(li.energy) is type(oi.energy)
+        assert li.slots.keys() == oi.slots.keys()
+
+    inf_o = structure.config["inference"]
+    inf_l = loaded.config["inference"]
+    assert type(inf_l) is type(inf_o)
+    assert dict(inf_l.config) == dict(inf_o.config)
+
+
+def test_violator_initializer_roundtrips(mlp, tmp_path):
+    """UniformInitializer renames its config keys (min/max vs min_val/max_val),
+    so cls(**config) would raise. The snapshot/__new__ path must restore it."""
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, structure=structure)
+    loaded = load_checkpoint(ckpt).structure
+    wi = loaded.nodes["h"].node_info.weight_init
+    assert isinstance(wi, UniformInitializer)
+    assert dict(wi.config) == {"min": -0.2, "max": 0.2}
+
+
+def test_reconstructed_structure_reinitializes_identically(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, structure=structure)
+    loaded = load_checkpoint(ckpt).structure
+    p_orig = initialize_params(structure, jax.random.PRNGKey(7))
+    p_recon = initialize_params(loaded, jax.random.PRNGKey(7))
+    assert _leaves_equal(p_orig, p_recon)
+
+
+def test_nested_component_state_init_roundtrips(tmp_path):
+    """GlobalStateInit nests an InitializerBase inside its config — the hardest
+    reconstruction case. It must round-trip."""
+    x = IdentityNode(shape=(6,), name="x")
+    y = Linear(shape=(3,), activation=SigmoidActivation(), name="y")
+    structure = graph(
+        nodes=[x, y],
+        edges=[Edge(source=x, target=y.slot("in"))],
+        task_map=TaskMap(x=x, y=y),
+        inference=InferenceSGD(eta_infer=0.1, infer_steps=3),
+        graph_state_initializer=GlobalStateInit(
+            initializer=NormalInitializer(std=0.123)
+        ),
+    )
+    params = initialize_params(structure, jax.random.PRNGKey(0))
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, structure=structure)
+    loaded = load_checkpoint(ckpt).structure
+    si = loaded.config["graph_state_initializer"]
+    assert isinstance(si, GlobalStateInit)
+    nested = si.config["initializer"]
+    assert isinstance(nested, NormalInitializer)
+    assert dict(nested.config)["std"] == 0.123
+
+
+def test_conv_node_config_and_mupc_roundtrip(tmp_path):
+    """Conv2D stores tuple kernel_size/stride/padding in node_config; muPC
+    attaches MuPCScalingFactors — both must round-trip exactly."""
+    img = IdentityNode(shape=(8, 8, 1), name="img")
+    conv = ConvNode(shape=(8, 8, 4), name="conv", kernel_size=(3, 3), padding="SAME")
+    out = Linear(
+        shape=(5,),
+        activation=SoftmaxActivation(),
+        energy=CrossEntropyEnergy(),
+        name="out",
+        flatten_input=True,
+    )
+    structure = graph(
+        nodes=[img, conv, out],
+        edges=[
+            Edge(source=img, target=conv.slot("in")),
+            Edge(source=conv, target=out.slot("in")),
+        ],
+        task_map=TaskMap(x=img, y=out),
+        inference=InferenceSGD(eta_infer=0.05, infer_steps=3),
+        scaling=MuPCConfig(),
+    )
+    params = initialize_params(structure, jax.random.PRNGKey(1))
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, structure=structure)
+    loaded = load_checkpoint(ckpt).structure
+
+    cfg = dict(loaded.nodes["conv"].node_info.node_config)
+    assert cfg["kernel_size"] == (3, 3)  # tuple, not list
+    assert cfg["stride"] == (1, 1)
+    assert cfg["padding"] == "SAME"
+
+    sc_o = structure.nodes["conv"].node_info.scaling_config
+    sc_l = loaded.nodes["conv"].node_info.scaling_config
+    assert sc_l is not None
+    assert sc_l.forward_scale == sc_o.forward_scale
+    assert sc_l.self_grad_scale == sc_o.self_grad_scale
+
+
+def test_serialize_structure_is_json_roundtrippable(mlp):
+    structure = mlp[0]
+    payload = serialize_structure(structure)
+    text = json.dumps(payload)
+    restored = deserialize_structure(json.loads(text))
+    assert restored.node_order == structure.node_order
+    assert set(restored.nodes) == set(structure.nodes)
+
+
+# ---------------------------------------------------------------------------
+# R1: params load even when a structure class is gone (best-effort structure)
+# ---------------------------------------------------------------------------
+def test_renamed_class_degrades_to_params_only(mlp, tmp_path):
+    """If a node class can no longer be imported, structure recovery must degrade
+    to None (with a warning) WITHOUT blocking the (self-describing) params."""
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, structure=structure)
+
+    # Simulate a class rename/move: point a node at a non-existent class path.
+    spath = ckpt / "structure.json"
+    payload = json.loads(spath.read_text())
+    payload["nodes"]["h"]["class"] = "fabricpc.nodes.linear.RenamedAwayLinear"
+    spath.write_text(json.dumps(payload))
+    # Keep the checksum consistent so we exercise the import-failure path, not
+    # the corruption path.
+    mpath = ckpt / "metadata.json"
+    meta = json.loads(mpath.read_text())
+    meta["checksums"]["structure.json"] = serialization._sha256(spath)
+    mpath.write_text(json.dumps(meta))
+
+    with pytest.warns(RuntimeWarning, match="could not"):
+        loaded = load_checkpoint(ckpt)
+    assert loaded.structure is None
+    assert _leaves_equal(params, loaded.params)  # weights still recovered
+
+
+def test_unrebuildable_structure_degrades_to_params_only(mlp, tmp_path):
+    """A structure that fails to rebuild for a NON-import reason (evolved/garbled
+    snapshot schema) must still degrade to structure=None — not crash the load
+    and take the self-describing params down with it."""
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, structure=structure)
+
+    # Corrupt the snapshot in a way that breaks rebuild but isn't an import error:
+    # drop a required NodeInfo field. Keep the checksum consistent so we exercise
+    # the rebuild-failure path, not the corruption path.
+    spath = ckpt / "structure.json"
+    payload = json.loads(spath.read_text())
+    del payload["nodes"]["h"]["shape"]  # -> KeyError deep in _decode_node
+    spath.write_text(json.dumps(payload))
+    mpath = ckpt / "metadata.json"
+    meta = json.loads(mpath.read_text())
+    meta["checksums"]["structure.json"] = serialization._sha256(spath)
+    mpath.write_text(json.dumps(meta))
+
+    with pytest.warns(RuntimeWarning, match="could not be rebuilt"):
+        loaded = load_checkpoint(ckpt)
+    assert loaded.structure is None
+    assert _leaves_equal(params, loaded.params)
+
+
+# ---------------------------------------------------------------------------
+# GraphState (optional)
+# ---------------------------------------------------------------------------
+def test_graph_state_roundtrip(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    state = initialize_graph_state(
+        structure, 3, jax.random.PRNGKey(5), clamps={}, params=params
+    )
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, structure=structure, state=state)
+    loaded = load_checkpoint(ckpt)
+    assert loaded.state is not None
+    assert _leaves_equal(state, loaded.state)
+    assert loaded.state.batch_size == state.batch_size
+
+
+def test_graph_state_skipped_without_structure(mlp, tmp_path):
+    """state restoration needs a structure template; if structure can't be
+    rebuilt, state is skipped rather than erroring."""
+    structure, params, optimizer, opt_state = mlp
+    state = initialize_graph_state(
+        structure, 2, jax.random.PRNGKey(5), clamps={}, params=params
+    )
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, structure=structure, state=state)
+    # Drop the structure file so structure=None on load.
+    (ckpt / "structure.json").unlink()
+    meta = json.loads((ckpt / "metadata.json").read_text())
+    meta["checksums"].pop("structure.json", None)
+    (ckpt / "metadata.json").write_text(json.dumps(meta))
+    loaded = load_checkpoint(ckpt)
+    assert loaded.structure is None
+    assert loaded.state is None
+    assert _leaves_equal(params, loaded.params)
+
+
+# ---------------------------------------------------------------------------
+# Resume-training parity
+# ---------------------------------------------------------------------------
+def test_resume_training_parity(mlp, tmp_path):
+    """Train straight through == train 1 step -> save -> load -> train 1 step,
+    bitwise, for both params and opt_state."""
+    from fabricpc.training import train_step
+
+    structure, params0, optimizer, opt_state0 = mlp
+    batch = {
+        "x": jax.random.normal(jax.random.PRNGKey(11), (5, 12)),
+        "y": jax.nn.one_hot(jnp.array([0, 1, 2, 3, 0]), 4),
+    }
+    k1, k2 = jax.random.split(jax.random.PRNGKey(99))
+
+    p, o = params0, opt_state0
+    p, o, _, _ = train_step(p, o, batch, structure, optimizer, k1)
+    p_ref, o_ref, _, _ = train_step(p, o, batch, structure, optimizer, k2)
+
+    p, o = params0, opt_state0
+    p, o, _, _ = train_step(p, o, batch, structure, optimizer, k1)
+    ckpt = tmp_path / "resume"
+    save_checkpoint(ckpt, p, opt_state=o, structure=structure)
+    loaded = load_checkpoint(ckpt, optimizer=optimizer)
+    p_res, o_res, _, _ = train_step(
+        loaded.params, loaded.opt_state, batch, loaded.structure, optimizer, k2
+    )
+
+    assert _leaves_equal(p_ref, p_res)
+    assert _leaves_equal(o_ref, o_res)
+
+
+# ---------------------------------------------------------------------------
+# Error / edge-case contract
+# ---------------------------------------------------------------------------
+def test_strict_requires_optimizer_for_opt_state(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, opt_state=opt_state, structure=structure)
+    with pytest.raises(ValueError, match="optimizer state"):
+        load_checkpoint(ckpt)
+
+
+def test_non_strict_skips_opt_state(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, opt_state=opt_state, structure=structure)
+    loaded = load_checkpoint(ckpt, strict=False)
+    assert loaded.opt_state is None
+    assert _leaves_equal(params, loaded.params)
+
+
+def test_wrong_optimizer_raises(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, opt_state=opt_state, structure=structure)
+    # adamw state has fields plain sgd lacks -> flax field-name mismatch raises.
+    with pytest.raises(ValueError):
+        load_checkpoint(ckpt, optimizer=optax.sgd(1e-3))
+
+
+def test_overwrite_guard_and_force(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, opt_state=opt_state, structure=structure)
+    with pytest.raises(FileExistsError):
+        save_checkpoint(ckpt, params, structure=structure)
+    save_checkpoint(ckpt, params, structure=structure, overwrite=True)  # no opt_state
+    assert load_checkpoint(ckpt).opt_state is None
+
+
+def test_non_json_metadata_raises_actionable(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    with pytest.raises(ValueError, match="JSON-serializable"):
+        save_checkpoint(ckpt, params, metadata={"bad": {1, 2, 3}})  # set is not JSON
+    assert not ckpt.exists()  # nothing partial written
+
+
+def test_missing_directory_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_checkpoint(tmp_path / "does_not_exist")
+
+
+def test_missing_required_file_raises(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, structure=structure)
+    (ckpt / "params.msgpack").unlink()
+    with pytest.raises(FileNotFoundError, match="params.msgpack"):
+        load_checkpoint(ckpt)
+
+
+def test_not_a_checkpoint_rejected(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params)
+    mpath = ckpt / "metadata.json"
+    meta = json.loads(mpath.read_text())
+    meta["format"] = "something-else"
+    mpath.write_text(json.dumps(meta))
+    with pytest.raises(ValueError, match="not a FabricPC checkpoint"):
+        load_checkpoint(ckpt)
+
+
+def test_future_format_version_rejected(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params)
+    mpath = ckpt / "metadata.json"
+    meta = json.loads(mpath.read_text())
+    meta["format_version"] = FORMAT_VERSION + 1
+    mpath.write_text(json.dumps(meta))
+    with pytest.raises(ValueError, match="format_version"):
+        load_checkpoint(ckpt)
+
+
+def test_corrupt_payload_detected_by_checksum(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params)
+    (ckpt / "params.msgpack").write_bytes(b"corrupted-not-msgpack")
+    with pytest.raises(ValueError, match="corrupt"):
+        load_checkpoint(ckpt)
+
+
+def test_params_structure_shape_mismatch_rejected(tmp_path):
+    """If structure.json describes a model whose param shapes disagree with the
+    saved params, validation must raise a clear shape error."""
+    s1 = _mlp_structure()
+    p1 = initialize_params(s1, jax.random.PRNGKey(0))
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, p1, structure=s1)
+
+    # Build a structurally different model and splice its structure.json in
+    # (keeping the checksum consistent so we hit the shape check, not corruption).
+    x = IdentityNode(shape=(12,), name="pixels")
+    h = Linear(shape=(99,), activation=SigmoidActivation(), name="h")  # 8 -> 99
+    y = Linear(
+        shape=(4,),
+        activation=SoftmaxActivation(),
+        energy=CrossEntropyEnergy(),
+        name="class",
+    )
+    s2 = graph(
+        nodes=[x, h, y],
+        edges=[
+            Edge(source=x, target=h.slot("in")),
+            Edge(source=h, target=y.slot("in")),
+        ],
+        task_map=TaskMap(x=x, y=y),
+        inference=InferenceSGD(eta_infer=0.05, infer_steps=5),
+    )
+    spath = ckpt / "structure.json"
+    spath.write_text(json.dumps(serialize_structure(s2)))
+    mpath = ckpt / "metadata.json"
+    meta = json.loads(mpath.read_text())
+    meta["checksums"]["structure.json"] = serialization._sha256(spath)
+    mpath.write_text(json.dumps(meta))
+
+    with pytest.raises(ValueError, match="[Ss]hape"):
+        load_checkpoint(ckpt)
+
+
+def test_no_scratch_dirs_left_on_success(mlp, tmp_path):
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, opt_state=opt_state, structure=structure)
+    leftovers = [
+        p
+        for p in tmp_path.iterdir()
+        if p.name.startswith(".ckpt.tmp-") or p.name.startswith(".ckpt.bak-")
+    ]
+    assert leftovers == []
+
+
+def test_overwrite_crash_preserves_old_checkpoint(mlp, tmp_path, monkeypatch):
+    """If the process dies mid-swap during an overwrite, the previous checkpoint
+    must survive intact (not be destroyed and replaced by nothing)."""
+    import os as _os
+
+    structure, params, optimizer, opt_state = mlp
+    ckpt = tmp_path / "ckpt"
+    save_checkpoint(ckpt, params, opt_state=opt_state, structure=structure)
+
+    real_replace = _os.replace
+    calls = {"n": 0}
+
+    def flaky_replace(src, dst):
+        calls["n"] += 1
+        if calls["n"] == 2:  # fail the staging -> path move
+            raise RuntimeError("simulated crash during swap")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(serialization.os, "replace", flaky_replace)
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        save_checkpoint(ckpt, params, structure=structure, overwrite=True)
+
+    monkeypatch.undo()
+    loaded = load_checkpoint(ckpt, optimizer=optimizer)
+    assert _leaves_equal(params, loaded.params)
+    assert loaded.opt_state is not None  # surviving checkpoint is the OLD one
+    leftovers = [
+        p
+        for p in tmp_path.iterdir()
+        if p.name.startswith(".ckpt.tmp-") or p.name.startswith(".ckpt.bak-")
+    ]
+    assert leftovers == []


### PR DESCRIPTION
## Task 4 — Model Checkpointing & Loading

Adds robust checkpoint save/load in a new `fabricpc/serialization.py`:

```python
save_checkpoint(path, params, *, opt_state=None, structure=None, state=None,
                metadata=None, overwrite=False) -> Path
load_checkpoint(path, *, optimizer=None, strict=True)
    -> Checkpoint(params, opt_state, structure, state, metadata)
```

A checkpoint is a **directory**: `metadata.json` (format magic + version, library
versions, per-file sha256 checksums), `params.msgpack` (always), and optionally
`structure.json`, `opt_state.msgpack`, `state.msgpack`.

### What is persisted, and how it round-trips
- **`params`** — the model; always saved and **self-describing**. flax msgpack stores
  the pytree keyed by node/weight/bias names, so `msgpack_restore` rebuilds
  `GraphParams`/`NodeParams` **from the file alone — no `structure` and no
  model-definition classes required**. Weights load even if a node class was renamed
  or moved since the checkpoint was written.
- **`opt_state`** — optional; for resuming training. Its pytree *type* is defined by the
  optimizer, so it's restored into an `optimizer.init(params)` template — pass the
  `optimizer` to `load_checkpoint`. flax matches by field name, so a wrong optimizer
  raises rather than silently misloading.
- **`structure`** — optional, reconstructed **best-effort**: a versioned JSON snapshot of
  `NodeInfo` restored via `cls.__new__` + `.config` assignment (handles components whose
  `__init__` isn't round-trippable, e.g. `UniformInitializer`/`GlobalStateInit`), with
  `node_order` + muPC factors persisted rather than recomputed. **Any** rebuild failure
  (renamed class, evolved schema, corrupt file) degrades to `structure=None` + a warning
  and still returns the params; a structure that rebuilds but disagrees with the params
  on shape raises (integrity error).
- **`state` (`GraphState`)** — optional; only for persistent-latent / Hopfield-style runs
  (the standard PC trainer re-inits `z` each batch).

### Robustness
Format magic string + version gate checked before any decode; per-file sha256 checksums
verified on load; checkpoint-aware error messages (corrupt/non-checkpoint/non-JSON
metadata/missing files); crash-safe writes (staged + atomic `os.replace`, with the prior
checkpoint moved aside and restored on overwrite failure so it's never lost). No pickle.

### Demo & tests
- Extends `examples/mnist_demo.py` with an opt-in `--checkpoint` flow
  (train → save → load → continue); no new demo file.
- `tests/test_serialization.py` (28 tests): self-describing/dtype (incl. bf16/fp16)
  round-trip, class-rename → params-only degradation, opt_state resume parity, structure
  fidelity (the `UniformInitializer` quirk, nested-component state-init, conv config, muPC
  scaling), GraphState round-trip, and the full error/edge-case contract (checksum
  corruption, format magic, version, non-JSON metadata, overwrite crash-safety).

All 28 tests pass on CPU.