### PR TITLE
Update learning rate for ResNet18 demo

### DIFF
--- a/examples/resnet18_cifar10_demo.py
+++ b/examples/resnet18_cifar10_demo.py
@@ -475,7 +475,7 @@ def parse_args():
         "--eta_infer", type=float, default=0.1, help="Inference rate (default: 0.1)"
     )
     parser.add_argument(
-        "--lr", type=float, default=0.01, help="Learning rate (default: 0.001)"
+        "--lr", type=float, default=0.001, help="Learning rate (default: 0.001)"
     )
     parser.add_argument(
         "--weight_decay", type=float, default=0.01, help="Weight decay (default: 0.01)"


### PR DESCRIPTION
Corrects a discrepancy between the default learning rate and the help text in examples/resnet18_cifar10_demo.py. Changed the default value from 0.01 to 0.001 to align with the documented help string, as 0.001 is the intended standard for this demo.