### PR TITLE
docs: add issue and pull request templates (#58)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+﻿name: Bug Report
+description: Report a reproducible bug or unexpected behavior in FabricPC
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report an issue!
+        Please review the [Troubleshooting Guide](https://github.com/trueagi-io/FabricPC/blob/main/docs/user_guides/16_troubleshooting.md) first to check for common environment and setup issues.
+  - type: input
+    id: version
+    attributes:
+      label: FabricPC Version
+      description: What version of FabricPC are you using? (e.g. `0.5.0`, or git commit SHA)
+      placeholder: e.g. 0.5.0
+    validations:
+      required: true
+  - type: checkboxes
+    id: install_extras
+    attributes:
+      label: Install Extras Used
+      description: Select all installation extras present in your environment.
+      options:
+        - label: cpu
+        - label: cuda12
+        - label: cuda13
+        - label: tfds
+        - label: viz
+        - label: all
+        - label: dev
+  - type: textarea
+    id: env_info
+    attributes:
+      label: JAX Environment Info
+      description: |
+        Please paste the output of:
+        ```python
+        import jax
+        jax.print_environment_info()
+        print("default_backend:", jax.default_backend())
+        print("devices:", jax.devices())
+        ```
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: env_vars
+    attributes:
+      label: Environment Variables & JAX Setup
+      description: |
+        Please provide the values of relevant environment variables and whether `setup_jax()` was called before the first JAX computation.
+        - `XLA_FLAGS`:
+        - `JAX_PLATFORMS`:
+        - `FABRICPC_SKIP_XLA_FLAGS`:
+        - `FABRICPC_DISABLE_TRITON_GEMM`:
+        - Did `setup_jax()` run before the first JAX computation? Did its post-init warning fire?
+        - XLA flag profile (if applicable):
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: packages
+    attributes:
+      label: Key Package Versions
+      description: Paste the output of `pip list | grep -Ei "jax|nvidia|tensorflow|fabricpc"` (or PowerShell equivalent `pip list | Select-String -Pattern "jax|nvidia|tensorflow|fabricpc"`).
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: gpu_info
+    attributes:
+      label: NVIDIA GPU & Driver Info (if GPU is used)
+      description: Paste the driver line or summary output from `nvidia-smi`.
+      render: shell
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal Reproduction Script
+      description: |
+        Please provide a self-contained, minimal code snippet that reproduces the issue, including the exact import order.
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: expected_vs_observed
+    attributes:
+      label: Expected vs Observed Behavior
+      description: What did you expect to happen, and what happened instead? Include full traceback if an error occurred.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+﻿blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/trueagi-io/FabricPC/blob/main/CONTRIBUTING.md#questions
+    about: Please ask questions in discussions or consult CONTRIBUTING.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+﻿name: Feature Request
+description: Suggest an idea or feature for FabricPC
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting a feature for FabricPC!
+        Please check [CONTRIBUTING.md](https://github.com/trueagi-io/FabricPC/blob/main/CONTRIBUTING.md) to understand our design-first workflow.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Is your feature request related to a problem or limitation? Please describe clearly.
+    validations:
+      required: true
+  - type: textarea
+    id: proposed_behavior
+    attributes:
+      label: Proposed Behavior / Solution
+      description: Describe the feature, API, or behavior you would like to see added.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or workarounds you have considered.
+    validations:
+      required: false
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Add any other context, diagrams, or references here.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+﻿## Summary
+
+<!-- Provide a brief explanation of what this pull request does and why. -->
+
+Closes #<!-- Issue number if applicable -->
+
+## What Changed
+
+- <!-- Bullet points of changes -->
+
+## Design Document
+
+<!-- If this is a non-trivial change, link the committed design document in docs/dev_plans_archive/ -->
+- [Design Plan](<!-- docs/dev_plans_archive/... -->) (if applicable)
+
+## Testing & Verification
+
+- [ ] Unit/integration tests added or updated
+- [ ] Ran `pytest -q` locally (all tests passing)
+- [ ] Ran `pre-commit run --all-files` (formatting and linting checks pass)
+- [ ] Demo baselines match their module `Results:` block (or divergence explained below)
+- [ ] All cited numbers, benchmark results, and `file:line` references are verified and reproducible
+
+## Notes & Divergence Explanations
+
+<!-- Explain any benchmark or demo divergence if applicable -->

--- a/docs/dev_plans_archive/issue_and_pr_templates_plan.md
+++ b/docs/dev_plans_archive/issue_and_pr_templates_plan.md
@@ -1,0 +1,32 @@
+﻿# Design Plan: GitHub Issue and Pull Request Templates
+
+## Status
+- **Issue**: #58
+- **Date**: 2026-08-30
+- **Author**: mhaye9545
+
+## Problem Statement
+Bug reports without diagnostic context (JAX version, backend, installed extras, device topology, reproduction scripts) cost maintainers multiple communication round-trips to triage. With the upcoming public hackathon release in October 2026, establishing standardized issue and pull request templates is essential to capture mandatory environment diagnostics up front and guide new contributors.
+
+## Chosen Approach
+1. **GitHub Issue Form for Bug Reports (`.github/ISSUE_TEMPLATE/bug_report.yml`)**:
+   - Includes a reference to the troubleshooting guide (`docs/user_guides/16_troubleshooting.md`).
+   - Fields for version, extras selected, JAX environment info (`jax.print_environment_info()`, `jax.default_backend()`, `jax.devices()`), environment variables, key package list, GPU/driver status, minimal reproduction script, and expected vs observed behavior.
+2. **GitHub Issue Form for Feature Requests (`.github/ISSUE_TEMPLATE/feature_request.yml`)**:
+   - Collects problem statement, proposed behavior, alternatives considered, and links to `CONTRIBUTING.md`.
+3. **Issue Config (`.github/ISSUE_TEMPLATE/config.yml`)**:
+   - Disables blank issues (`blank_issues_enabled: false`) and redirects questions to discussions and `CONTRIBUTING.md`.
+4. **Pull Request Template (`.github/PULL_REQUEST_TEMPLATE.md`)**:
+   - Mirrors `CONTRIBUTING.md` standards: linked issue, summary of changes, design document link, testing checklist (tests, linter, demo baseline fidelity, reference verification).
+
+## Alternatives Considered
+- **Standard Markdown Issue Templates**:
+  - *Pros*: Simple markdown files.
+  - *Cons*: Users frequently delete sections or leave required diagnostic details blank. Issue forms (`.yml`) allow structured fields, dropdowns, checkboxes, and required validation.
+- **Requiring bot triage**:
+  - *Pros*: Automated labeling.
+  - *Cons*: Adds infrastructure overhead and external dependencies; native GitHub forms achieve the same validation natively.
+
+## Testing & Verification
+- Validated YAML schema syntax of issue templates and config.
+- Checked template rendering and links against existing documentation (`docs/user_guides/16_troubleshooting.md` and `CONTRIBUTING.md`).


### PR DESCRIPTION
Closes #58.

## Summary

Adds GitHub issue form templates and a pull request template to establish clear diagnostic requirements up front and enforce the repository's design-first contributing workflow.

## What Changed

- **`.github/ISSUE_TEMPLATE/bug_report.yml`**:
  - Prepend pointer to troubleshooting guide (`docs/user_guides/16_troubleshooting.md`).
  - Fields for FabricPC version, install extras checkboxes (`cpu`, `cuda12`, `cuda13`, `tfds`, `viz`, `all`, `dev`).
  - JAX environment diagnostic output (`jax.print_environment_info()`, `jax.default_backend()`, `jax.devices()`).
  - Flags and setup state (`XLA_FLAGS`, `JAX_PLATFORMS`, `FABRICPC_SKIP_XLA_FLAGS`, `FABRICPC_DISABLE_TRITON_GEMM`, `setup_jax()` call timing).
  - Key package versions list (`pip list | grep -Ei "jax|nvidia|tensorflow|fabricpc"`).
  - NVIDIA GPU & driver line from `nvidia-smi`.
  - Minimal reproduction script with import order and expected vs observed behavior.
- **`.github/ISSUE_TEMPLATE/feature_request.yml`**:
  - Fields for problem statement, proposed behavior, and alternatives considered.
- **`.github/ISSUE_TEMPLATE/config.yml`**:
  - Disables blank issues (`blank_issues_enabled: false`) and links `CONTRIBUTING.md`.
- **`.github/PULL_REQUEST_TEMPLATE.md`**:
  - Standard PR structure including linked issue, summary, design plan link, testing checklist, and divergence notes mirroring `CONTRIBUTING.md`.
- **`docs/dev_plans_archive/issue_and_pr_templates_plan.md`**:
  - Committed design document for this change as required by `CONTRIBUTING.md`.

## Design Document

- [Design Plan](docs/dev_plans_archive/issue_and_pr_templates_plan.md)

## Testing & Verification

- [x] YAML schemas validated using `yaml.safe_load`.
- [x] Links to troubleshooting guide and contributing guidelines verified.
