### PR TITLE
Mean gradients per prediction: one global denominator for PC and backprop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ Gradients reaching optax are now means per prediction under both algorithms.
 The trainer divides the batch-summed PC weight gradients and the backprop
 objective once by one global prediction count N: the total number of
 clamped-target prediction positions in the batch (`batch` for classification,
-`batch * seq_len` for token targets, `batch` when the graph has no clamped
-target). One learning rate, clipping threshold, or Adam epsilon now means the
-same under `algorithm="pc"` and `"backprop"` and across batch sizes and
-sequence lengths. For rank-2 (classification) targets every reported number is
-unchanged; for sequence targets the PC `energy` metric moves from per sample
-to per token.
+`batch * seq_len` for token targets, summed over target heads, `batch` when the
+graph has no clamped target). One learning rate, clipping threshold, or Adam
+epsilon now means the same under `algorithm="pc"` and `"backprop"` and across
+batch sizes and sequence lengths. For rank-2 (classification) targets every
+reported number is unchanged; for sequence targets the PC `energy` metric moves
+from per sample to per token.
 
 ### Migration table
 
@@ -19,27 +19,22 @@ to per token.
 |---|---|
 | `compute_local_weight_gradients` fed directly to an optimizer in a custom loop (batch-summed gradients) | `pc_weight_gradients(params, state, structure, clamps)` — the same gradients divided by `grad_denominator(structure, clamps)` |
 | SGD-family learning rates tuned on summed PC gradients | multiply `lr` by N and divide a coupled `add_decayed_weights` rate by N (Adam/AdamW rates are unchanged) |
-| `scale_by_natural_gradient_diag(..., damping=1e-3)` / `scale_by_natural_gradient_layerwise(..., damping=1e-3)` | `relative_damping=0.1` (new, default) — damping as a fraction of the mean Fisher entry. `damping` stays as an absolute term but defaults to 0; an old value tuned on summed gradients becomes `damping / N**2`, and where it dominates the transform is SGD with rate `scale / damping` |
 | Training `energy` metric read as "per sample" | per prediction, on the same scale as `target_energy`; the node set is still algorithm-dependent |
+| `scale_by_natural_gradient_diag` / `scale_by_natural_gradient_layerwise` optimizer states saved under 0.5.0 | do not restore: both states gained a `count` field for the Fisher EMA's bias correction |
 
 ### New
 
-- `fabricpc.training.grad_denominator(structure, clamps) -> int` and
-  `fabricpc.training.pc_weight_gradients(params, state, structure, clamps)`.
-  The `grad_denominator` docstring carries the rule for future microbatch
-  accumulation and padding masks (accumulate sums, divide once by the global
-  count).
+- `fabricpc.training.grad_denominator(structure, clamps) -> int`,
+  `fabricpc.training.pc_weight_gradients(params, state, structure, clamps)`,
+  and `fabricpc.training.batch_size_of(batch, structure)`.
 - Natural-gradient transforms: bias-corrected Fisher EMA (the states gain a
-  `count` field), scale-free damping `g / (F + relative_damping * trace(F)/dim)`,
-  and a zero-denominator guard in place of an absolute floor. With
-  `damping = 0` the update is exactly covariant: scaling the gradients by c
-  scales the update by 1/c. Documented limitation: F is the squared mean
-  gradient, so `g / F` is about `1 / g`; with relative damping alone neither
-  transform trains the MNIST demo (48 settings tried); the demo presets keep
-  the parent's behavior through `relative_damping=0` and an absolute `damping`
-  that lies above 96.5% of the Fisher entries from the first step, so those
-  entries are updated as SGD and only the few large-gradient entries receive
-  the natural-gradient step.
+  `count` field) and a `damping` default of 1e-8, chosen on the
+  MNIST demo at the per-prediction gradient scale. The module docstring
+  states the two regimes the transforms have (SGD with rate
+  `scale / damping` where the damping dominates, about `1 / g` where the
+  Fisher does) and why no damping value yields a natural-gradient step; the
+  estimator redesign is tracked in
+  https://github.com/trueagi-io/FabricPC/issues/68.
 - `evaluate`'s default PC `energy` metric weights each sample by its
   prediction count, so it reports internal energy per prediction and agrees
   with the training `energy`.
@@ -48,8 +43,8 @@ to per token.
   `make_train_step`.
 - `examples/mnist_advanced.py` gains `--num_epochs`; its `sgd` preset is
   rescaled exactly (`lr` 0.01 -> 2.0, weight decay 0.1 -> 5e-4 at N = 200)
-  and the two natural-gradient presets rescale exactly (`damping / N**2`,
-  `scale / N`, `relative_damping=0`).
+  and the two natural-gradient presets use constants swept on the
+  per-prediction scale.
 
 ## [0.5.0] - 2026-08-30
 One trainer replaces the four training harnesses. `train`/`evaluate` serve both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## [Unreleased]
+
+Gradients reaching optax are now means per prediction under both algorithms.
+The trainer divides the batch-summed PC weight gradients and the backprop
+objective once by one global prediction count N: the total number of
+clamped-target prediction positions in the batch (`batch` for classification,
+`batch * seq_len` for token targets, `batch` when the graph has no clamped
+target). One learning rate, clipping threshold, or Adam epsilon now means the
+same under `algorithm="pc"` and `"backprop"` and across batch sizes and
+sequence lengths. For rank-2 (classification) targets every reported number is
+unchanged; for sequence targets the PC `energy` metric moves from per sample
+to per token.
+
+### Migration table
+
+| Changed | Replacement |
+|---|---|
+| `compute_local_weight_gradients` fed directly to an optimizer in a custom loop (batch-summed gradients) | `pc_weight_gradients(params, state, structure, clamps)` — the same gradients divided by `grad_denominator(structure, clamps)` |
+| SGD-family learning rates tuned on summed PC gradients | multiply `lr` by N and divide a coupled `add_decayed_weights` rate by N (Adam/AdamW rates are unchanged) |
+| `scale_by_natural_gradient_diag(..., damping=1e-3)` / `scale_by_natural_gradient_layerwise(..., damping=1e-3)` | `relative_damping=0.1` (new, default) — damping as a fraction of the mean Fisher entry. `damping` stays as an absolute term but defaults to 0; an old value tuned on summed gradients becomes `damping / N**2`, and where it dominates the transform is SGD with rate `scale / damping` |
+| Training `energy` metric read as "per sample" | per prediction, on the same scale as `target_energy`; the node set is still algorithm-dependent |
+
+### New
+
+- `fabricpc.training.grad_denominator(structure, clamps) -> int` and
+  `fabricpc.training.pc_weight_gradients(params, state, structure, clamps)`.
+  The `grad_denominator` docstring carries the rule for future microbatch
+  accumulation and padding masks (accumulate sums, divide once by the global
+  count).
+- Natural-gradient transforms: bias-corrected Fisher EMA (the states gain a
+  `count` field), scale-free damping `g / (F + relative_damping * trace(F)/dim)`,
+  and a zero-denominator guard in place of an absolute floor. With
+  `damping = 0` the update is exactly covariant: scaling the gradients by c
+  scales the update by 1/c. Documented limitation: F is the squared mean
+  gradient, so `g / F` is about `1 / g`; with relative damping alone neither
+  transform trains the MNIST demo (48 settings tried); the demo presets keep
+  the parent's behavior through `relative_damping=0` and an absolute `damping`
+  that lies above 96.5% of the Fisher entries from the first step, so those
+  entries are updated as SGD and only the few large-gradient entries receive
+  the natural-gradient step.
+- `evaluate`'s default PC `energy` metric weights each sample by its
+  prediction count, so it reports internal energy per prediction and agrees
+  with the training `energy`.
+- `train_step_with_history` (dashboarding) reads the batch size from the
+  task-mapped keys and normalizes like the trainer; a parity test pins it to
+  `make_train_step`.
+- `examples/mnist_advanced.py` gains `--num_epochs`; its `sgd` preset is
+  rescaled exactly (`lr` 0.01 -> 2.0, weight decay 0.1 -> 5e-4 at N = 200)
+  and the two natural-gradient presets rescale exactly (`damping / N**2`,
+  `scale / N`, `relative_damping=0`).
+
 ## [0.5.0] - 2026-08-30
 One trainer replaces the four training harnesses. `train`/`evaluate` serve both
 learning algorithms, selected by `algorithm="pc"|"backprop"`; backprop is framed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.5.1] - 2026-09-07
 
 Gradients reaching optax are now means per prediction under both algorithms.
 The trainer divides the batch-summed PC weight gradients and the backprop

--- a/docs/dev_plans_archive/mean_gradient_normalization.md
+++ b/docs/dev_plans_archive/mean_gradient_normalization.md
@@ -2,56 +2,518 @@
 
 ## Context
 
-The PC training path hands the optimizer batch-summed weight gradients (`compute_local_weight_gradients` sums each node's per-sample energy over the batch), while the backprop path divides its objective by `batch_size` (trainer.py:309). The same learning rate, Adam ε, and any future clipping threshold therefore mean different things across `algorithm="pc"` and `"backprop"`, and gradient scale changes with batch size. This change normalizes both paths to mean gradients over a single global denominator that is correct for image minibatches (B samples), timeseries targets (B·T positions), and language-model token objectives (B·S tokens), and is safe under data-parallel sharding. It also builds in the discipline that avoids the Hugging Face gradient-accumulation defect (per-microbatch means averaged over microbatches with unequal token counts overweight short microbatches): gradients stay sums everywhere; division by a global count happens exactly once, at the optimizer boundary.
+The PC training path hands the optimizer batch-summed weight gradients
+(`compute_local_weight_gradients` sums each node's per-sample energy over the
+batch), while the backprop path divides its objective by `batch_size`
+(trainer.py:309). The same learning rate, Adam ε, clipping threshold, or
+natural-gradient damping therefore means different things across
+`algorithm="pc"` and `"backprop"`, and gradient scale changes with batch size
+and sequence length. This change normalizes both paths to mean gradients over
+one global denominator that is correct for image minibatches, timeseries
+targets, and language-model token objectives, is safe under data-parallel
+sharding, and keeps the discipline that avoids the Hugging Face
+gradient-accumulation defect (per-microbatch means averaged over microbatches
+with unequal token counts overweight short microbatches): gradients stay sums
+everywhere; division by a global count happens exactly once, in one function.
 
-Symbols: B = batch size; T/S = time/sequence length of a target clamp; N = the global denominator, the total number of independent prediction terms in the batch.
+Because the change moves every gradient to a new scale, it also owns the
+optimizer components in this repository whose behavior depends on that scale:
+the natural-gradient transforms, the coupled-L2 SGD preset, and the clipping
+threshold in the transformer demo.
+
+## Symbols
+
+| Symbol | Meaning |
+|---|---|
+| B | Batch size, the leading axis of every clamp |
+| S | Prediction positions per sample: the product of a target clamp's non-batch, non-class axes (sequence length for token targets, 1 for classification) |
+| N | Prediction count, the single denominator: total clamped-target prediction positions in the batch, B·S |
+| η | `eta_infer`, the latent step size in `InferenceSGD` |
+| g | One weight-gradient leaf as handed to optax, a mean per prediction |
+| f | The Fisher EMA leaf in a natural-gradient transform, an EMA of g² |
+| r | Damping reference, trace(F)/dim: the mean of all Fisher entries across the parameter pytree |
+| ρ | `relative_damping`: damping as a fraction of r |
 
 ## Design
 
-**Denominator rule.** N = total clamped-target prediction positions, `sum(prod(clamps[name].shape[:-1]) for name in target_nodes)` — the expression already computed as `n_predictions` at trainer.py:320 and matching `evaluate()`'s per-prediction weighting (`metrics._predictions_per_sample`). A rank-2 image target `(B, C)` gives N = B; a rank-3 sequence target `(B, T, V)` gives N = B·T. Target-free PC training (no clamped `in_degree > 0` node, e.g. associative-memory graphs) falls back to N = `batch_size`. Dividing the whole gradient pytree by one scalar leaves relative layer scaling untouched; it redefines the objective as total energy per prediction.
+### Denominator rule
 
-**Placement: sum mechanics, one mean boundary.** `compute_local_weight_gradients` keeps returning batch-summed gradients — sums are associative, so they survive sharding and any future microbatch accumulation unchanged. Each optimizer-feeding call site divides once by N from a new public helper `grad_denominator(structure, clamps, batch_size)` in trainer.py. There are exactly two such call sites: `_batch_grads` (both algorithm branches) and `train_step_with_history` in inference_tracking.py. The five test files that call `compute_local_weight_gradients` directly only inspect gradients and are unaffected.
+N is the total number of clamped-target prediction positions,
+`sum(prod(clamps[name].shape[:-1]) for name in target_nodes)`, where a target
+node is a clamped node with `in_degree > 0` (`_target_node_names`). The
+trailing axis of a target clamp is the class axis: `build_clamps` validates
+every target clamp against `(batch, *node.shape)`, so rank ≥ 2 holds. A rank-2
+image target `(B, C)` gives N = B; a rank-3 token target `(B, S, V)` gives
+N = B·S. The same rule read per sample is N = B × S with S = 1 when the graph
+has no clamped target (associative-memory graphs), which is exactly the weight
+`metrics._predictions_per_sample` assigns in `evaluate()`. Dividing the whole
+gradient pytree by one scalar leaves relative layer scaling untouched; it
+redefines the objective as total energy per prediction.
 
-**Sharding safety.** Data parallelism is `jax.jit` + `NamedSharding` over a `"data"` mesh axis (trainer.py:385, 476): the jitted step traces on global logical shapes, so the static shape product N is already the global count and the batch-summed gradients are globally reduced by XLA. No collective is needed. A future `shard_map`/`pmap` port would see per-shard shapes and must `jax.lax.psum` the count over the data axis — recorded in the helper's docstring, not in code.
+Definition caveat, recorded in the helper docstring: a clamped input node that
+receives feedback edges has `in_degree > 0` and counts as a target. No graph in
+the repository does this (the cyclic and lateral MNIST demos leave `pixels`
+edge-free on the input side).
 
-**Microbatching (not applicable yet).** The train loop performs one optimizer update per loader batch; no accumulation exists, and no padding/validity masks enter any energy (the only masks are attention masks). Static shape counts are therefore exact today. Per the request, the future rule lands as docstring guidance on `grad_denominator` (referenced from `compute_local_weight_gradients`):
+### Placement: sum mechanics, one mean function
 
-> Gradients arrive batch-summed and are divided once by this global count. If gradient accumulation over microbatches is added, keep that structure: accumulate the unnormalized sums across microbatches and divide once by the count summed over the whole accumulation window — dividing per microbatch and averaging overweights predictions in small microbatches when token counts differ. If padded positions gain a validity mask, replace the static shape product with `jnp.sum(mask)`. Under jit + NamedSharding, trace-time shapes and reductions are global, so this count is already global; a shard_map/pmap port must instead `jax.lax.psum` the per-shard count over the data axis.
+`compute_local_weight_gradients` keeps returning batch-summed gradients. Sums
+are associative, so they survive sharding and any future microbatch
+accumulation unchanged. Two public functions in trainer.py own the mean:
+
+- `grad_denominator(structure, clamps) -> int`: the rule above. B is read from
+  the leading axis of the first clamp; empty `clamps` raises `ValueError`
+  (nothing is clamped, so there is no objective).
+- `pc_weight_gradients(params, state, structure, clamps) -> GraphParams`:
+  `compute_local_weight_gradients(...)` with every leaf divided by
+  `grad_denominator(structure, clamps)`.
+
+`_batch_grads` calls `pc_weight_gradients` on the PC path and divides the
+backprop objective by the same `grad_denominator`. `train_step_with_history`
+calls `pc_weight_gradients`. These are the only two optimizer-feeding sites in
+the package; no example rolls its own step. Both functions are exported from
+`fabricpc.training` so custom loops that today call
+`compute_local_weight_gradients` directly have a normalized entry point. The
+trainer, not learning.py, knows the clamps, which is why the division lives
+here.
+
+### Metrics: `energy` is the objective
+
+`energy` reports the quantity the optimizer descends, for both algorithms:
+PC reports `graph_energy` over all `in_degree > 0` nodes divided by N;
+backprop reports `graph_energy` over the target nodes divided by N, which
+equals `target_energy`. `target_energy` is unchanged (target-node energy over
+N). For rank-2 targets every number equals today's. For sequence targets
+`energy` becomes per token, on the same scale as `target_energy` and
+`perplexity`. In `evaluate()`, `internal_energy` weights each sample by its
+target prediction count S (1 when the batch carries no target key), so the
+eval `energy` of a PC model is per prediction as well.
+
+### Sharding safety
+
+Data parallelism is `jax.jit` + `NamedSharding` over a `"data"` mesh axis
+(trainer.py:385, 476). `train` and `make_train_step` place the batch under
+`NamedSharding` before the jitted step, so the step traces on global logical
+shapes: the static shape product N is the global count and the batch-summed
+gradients of the replicated parameters are an XLA all-reduce. No collective is
+needed. A future `shard_map`/`pmap` port would see per-shard shapes and must
+`jax.lax.psum` the count over the data axis. This is recorded in the
+`grad_denominator` docstring.
+
+### Microbatching (not applicable yet)
+
+The train loop performs one optimizer update per loader batch; no accumulation
+exists, and no padding or validity masks enter any energy (the only masks are
+attention masks). Static shape counts are exact today. The future rule lands
+as the `grad_denominator` docstring, referenced from
+`compute_local_weight_gradients`:
+
+> Gradients arrive batch-summed and are divided once by this global count. If
+> gradient accumulation over microbatches is added, keep that structure:
+> accumulate the unnormalized sums across microbatches and divide once by the
+> count summed over the whole accumulation window. Dividing per microbatch and
+> averaging overweights predictions in small microbatches when token counts
+> differ. If padded positions gain a validity mask, replace the static shape
+> product with `jnp.sum(mask)`. Under jit + NamedSharding, trace-time shapes
+> and reductions are global, so this count is already global; a
+> shard_map/pmap port must instead `jax.lax.psum` the per-shard count over the
+> data axis.
+
+### Natural-gradient transforms: scale-free damping
+
+Both transforms in natural_gradients.py compute `g / (f + damping)` with f an
+EMA of g². Scaling every gradient by 1/N scales f by 1/N², so a fixed
+`damping` moves N² closer to dominating. At per-prediction gradient magnitudes
+of about 1e-3 per weight, f is about 1e-6 and the current default `damping =
+1e-3` dominates every entry: the transform degenerates to SGD with learning
+rate `scale / damping`. The natural-gradient update is inherently covariant
+(scaling g by c scales `g / f` by 1/c), so no damping rule can make its
+magnitude scale-invariant; what a rule can do is make the regime, which term
+dominates, independent of scale. The transforms adopt:
+
+1. Bias-corrected Fisher: f̂ = f / (1 − fisher_decay^t), with t the step count
+   held in the state. Without this the first steps see f ≈ (1 − decay)·g² and
+   over-large updates, which the absolute damping used to mask.
+2. Damping reference r = trace(F̂)/dim, the mean of all bias-corrected Fisher
+   entries across the pytree. For the layerwise transform each leaf's scalar
+   counts with weight equal to the leaf's size, so both transforms use one
+   definition.
+3. Update `g / (f̂ + ρ·r)`, computed as `g / where(d > 0, d, 1)` with
+   d = f̂ + ρ·r. The denominator is zero only when every gradient entry seen
+   so far, including the current one, is zero (the EMA includes the current
+   g² with weight 1 − fisher_decay > 0), and then g = 0 and the guarded
+   division returns the correct update, 0, without forming 0/0. No absolute
+   constant enters the denominator. An earlier draft added `floor = 1e-12`;
+   measured in float32, that floor breaks the covariance below by about
+   5e-4 relative at c = 1e-4, and at per-prediction gradient magnitudes near
+   1e-6 (f̂ ≈ 1e-12) it halves the update, so it would have re-introduced an
+   absolute scale at the very magnitudes this change produces.
+
+Property pinned by test: `update(c·g) = update(g) / c` exactly (to float32
+rounding, about 2e-7) for any c > 0, and the set of entries where damping
+dominates is the same for g and c·g.
+Signatures become `scale_by_natural_gradient_diag(fisher_decay=0.95,
+relative_damping=0.1, damping=0.0)` and
+`scale_by_natural_gradient_layerwise(...)` with the same arguments. The state
+tuples gain a `count` field.
+
+`damping` was first removed and then restored as an explicit opt-in, default
+0, after the calibration below showed that neither transform trains the MNIST
+demo with relative damping alone. With `damping > 0` the denominator is
+`f̂ + ρ·r + damping`; wherever the constant dominates, the update is
+`g / damping`, SGD with rate `scale / damping`, and the covariance above no
+longer holds. `_validate_hparams` accepts `relative_damping >= 0` and
+`damping >= 0` and rejects both being zero (then `g / f̂ ≈ 1 / g` has no
+bound as gradients shrink). The docstrings record this and the limitation
+paragraph below as properties of the present implementations.
+
+### Limitation of the present transforms
+
+Both transforms build F from the squared *mean* gradient of the batch, not
+from per-sample gradients, so `g / F ≈ 1 / g`: the entries with the largest
+gradients receive the smallest steps, and the step grows relative to the
+gradient as training reduces it (the covariance property states this: smaller
+gradients, larger updates). On `examples/mnist_advanced.py` this leaves both
+transforms at chance accuracy with relative damping alone, at every one of 48
+settings tried (Verification, item 2). The demo presets train, weakly, only
+through an absolute damping that lies above 96.5% of the Fisher entries from
+the first step, so those entries are updated as SGD and only the few
+large-gradient entries receive the natural-gradient step. This is documented
+in the module docstring, the optimizers guide, and the changelog; fixing it
+(a per-sample Fisher, or a square-root normalization as in Adam) is outside
+this change.
+
+### Clipping thresholds
+
+`optax.clip_by_global_norm` thresholds now sit on the per-prediction scale that
+standard mean-loss training uses. `examples/transformer_demo.py` keeps
+`clip_by_global_norm(0.8)`: today the PC summed-gradient norm over
+B·S = 16384 positions exceeds 0.8 on essentially every step, so the clip acts
+as per-step normalization ahead of Adam; after the change it fires on the
+conventional schedule. The verification records perplexity in both modes.
+Outcome: backprop is unchanged; PC at the old `--lr 1e-4` destabilizes after
+about 3500 steps without that per-step normalization, and `--lr 3e-5` holds
+the full epoch at a slightly better perplexity, so the demo's PC default moves
+to 3e-5 (Verification, item 3).
+
+### SGD with coupled L2
+
+`optax.chain(add_decayed_weights(wd), sgd(lr))` applies `lr·(g_sum + wd·θ) =
+lr·N·(g_mean + (wd/N)·θ)`. The `mnist_advanced.py` `sgd` preset (B = 200) is
+rescaled exactly to `lr = 2.0`, `wd = 5e-4`, with a comment stating these are
+lr·N and wd/N of the summed-gradient values. The two natural-gradient presets
+cannot be rescaled exactly because their damping semantics change; they are
+retuned by the calibration run in Verification.
 
 ## Alternatives considered
 
-- **Divide inside `compute_local_weight_gradients`** (pass N in). Pros: no caller can forget. Cons: the denominator is a property of the objective (target clamps), which learning.py does not know; inspection-only consumers must supply a meaningless constant or an optional default creeps in — a fallback flag by another name. Rejected.
-- **`jnp.mean` inside node `forward_and_weight_grads`.** Pros: locality. Cons: touches every node template, breaks sPC/ePC energy-parity tests, and per-sample is the wrong denominator for token objectives. Rejected.
-- **Per-sample denominator (`batch_size`) everywhere.** Pros: smallest diff (backprop path already does it). Cons: learning rate does not transfer across sequence lengths; fails the LM-token requirement. Rejected.
+- **Divide inside `compute_local_weight_gradients`** (pass N in). Pros: no
+  caller can forget. Cons: the denominator is a property of the objective,
+  which learning.py does not know; inspection-only callers would supply a
+  meaningless constant or an optional default would creep in. Rejected;
+  `pc_weight_gradients` in the trainer gives the same guarantee where the
+  clamps are known.
+- **Divide at each optimizer-feeding call site** via `grad_denominator`
+  alone. Pros: smallest surface. Cons: the contract is enforced by docstring;
+  `train_step_with_history` is already a hand copy of the PC step that
+  diverged on how it reads the batch size. Rejected.
+- **`jnp.mean` inside node `forward_and_weight_grads`.** Pros: locality.
+  Cons: touches every node template and per-sample is the wrong denominator
+  for token objectives. Rejected.
+- **Per-sample denominator (`batch_size`) everywhere.** Pros: smallest diff.
+  Cons: the learning rate does not transfer across sequence lengths. Rejected.
+- **Keep PC `energy` per sample.** Pros: no metric change. Cons: the unified
+  trainer would report `energy` with a different normalization per algorithm
+  for sequence targets, and PC `energy` would no longer be the optimized
+  quantity. Rejected.
+- **Absolute retune of natural-gradient damping.** Pros: no API change. Cons:
+  the regime stays scale-dependent, so any later change of batch size or
+  sequence length re-breaks it silently. Rejected as the default; restored as
+  an explicit opt-in (`damping`, default 0) after calibration showed the
+  relative-only transforms do not train the MNIST demo, so that the demo
+  presets can keep the parent's trajectory and the limitation is documented
+  rather than hidden.
+- **Remove or retune the transformer clip.** Pros: fewer moving parts. Cons:
+  0.8 to 1.0 on a per-token gradient is the standard LM recipe; removing it
+  would itself change dynamics. Rejected in favor of keeping the value and
+  measuring.
 
 ## Changes
 
 **fabricpc/training/trainer.py**
-1. Add public `grad_denominator(structure, clamps, batch_size)` with the docstring above; reuse `_target_node_names`.
-2. `_batch_grads`: compute `denom = grad_denominator(...)` once. PC path: `grads = jax.tree_util.tree_map(lambda g: g / denom, grads)`. Backprop path: objective becomes `graph_energy(..., node_names=target_nodes) / denom` (replacing `/ batch_size`). The `n_predictions` local for the `target_energy` metric collapses into the same computation.
-3. Metrics: PC `"energy"` stays `graph_energy / batch_size` (a per-sample diagnostic, not the gradient scale). Backprop `"energy"` is the objective and moves with it — identical for rank-2 targets, 1/T smaller for sequence targets. Update the normalization comment (lines 327–330), the module-docstring table rows, and `make_train_step`'s `"energy"` description (line 369).
+1. Add `grad_denominator(structure, clamps)` and `pc_weight_gradients(params,
+   state, structure, clamps)` with the docstrings above; reuse
+   `_target_node_names`.
+2. `_batch_grads`: `denom = grad_denominator(structure, clamps)` once. PC
+   path: `grads = pc_weight_gradients(...)`, `energy = graph_energy(state,
+   structure) / denom`. Backprop path: objective `graph_energy(...,
+   node_names=target_nodes) / denom`. The `n_predictions` local collapses into
+   `denom`; `target_energy` divides by it.
+3. Module docstring table rows for sub-step 4 (`/ N` for both), the metrics
+   comment at lines 327–330 (both keys per prediction; `energy` remains
+   algorithm-dependent in node set), and `make_train_step`'s `"energy"`
+   description (line 369: the objective per prediction).
 
-**fabricpc/utils/dashboarding/inference_tracking.py** — `train_step_with_history` (~line 264): apply the same division before `optimizer.update`, importing `grad_denominator` (it already imports `build_clamps` from trainer; no import cycle). Update its docstring.
+**fabricpc/training/__init__.py**: export `grad_denominator` and
+`pc_weight_gradients`.
 
-**fabricpc/core/learning.py** — docstring only: state the contract (returns batch-summed gradients; optimizer-feeding callers divide once by `grad_denominator`) and point to the helper for the microbatching/padding rule.
+**fabricpc/training/metrics.py**: split `_target_items` into a non-raising
+iterator and the raising wrapper the target metrics use. `_internal_energy_fn`
+weight = Σ over target items of `_predictions_per_sample(y)`, or 1 with no
+target key. Update the module docstring's description of `energy`.
 
-**fabricpc/training/natural_gradients.py** — docstring note: the update `g / (fisher + damping)` is not scale-invariant; with gradients N× smaller the Fisher EMA shrinks N²×, so an existing `damping` sits N²× closer to the damping-dominated regime and may need retuning.
+**fabricpc/utils/dashboarding/inference_tracking.py**:
+`train_step_with_history` (lines 161–227) reads B via `_batch_size(batch,
+structure)` from trainer, computes `denom = grad_denominator(structure,
+clamps)`, reports `energy = graph_energy(final_state, structure) / denom`, and
+feeds `pc_weight_gradients(...)` to `optimizer.update`. Docstring: `energy` is
+the objective per prediction.
 
-**Docs** — `docs/user_guides/08_training_and_evaluation.md:28` (objective normalization "per sample" → per prediction); `docs/user_guides/06_custom_nodes.md:322,375` (note the trainer's single global division).
+**fabricpc/core/learning.py**: docstring only. State the contract (returns
+batch-summed gradients; the trainer's `pc_weight_gradients` divides once by
+`grad_denominator`) and point to the helper for the microbatching and padding
+rule.
+
+**fabricpc/training/natural_gradients.py**: the design above. Both state
+tuples gain `count` (int32, incremented with `optax.safe_int32_increment`
+before the bias factor `1 − fisher_decay**count` is formed, so t = 1 on the
+first update); `damping` becomes `relative_damping` (default 0.1) with no
+alias; the zero guard is the `where` form above; `_validate_hparams` checks
+`relative_damping > 0`. The bias correction is written locally rather than
+through `optax.tree_utils.tree_bias_correction`, which first appears in
+optax 0.2.3 while the declared floor is `optax>=0.1.7` (verified: the 0.1.7
+wheel imports and runs `optax.adam` under the venv's JAX 0.10.1). Docstrings
+state the covariance property and that the trainer hands over per-prediction
+mean gradients. `optimizers.py` re-exports unchanged.
+
+**examples/mnist_advanced.py**: `sgd` preset `add_decayed_weights(5e-4)`,
+`sgd(2.0, momentum=0.9)` with the rescale comment. `ngd_diag` and
+`ngd_layerwise` presets are the exact per-prediction analog of the parent's
+constants: `add_decayed_weights(5e-4)`, `relative_damping=0.0`,
+`damping=1e-3 / N**2`, `optax.scale(-scale_old / N)` (F shrinks by N², g by
+N). The comment records the calibration and the measured regime. A
+`--num_epochs` argument (default 10) makes the calibration command
+reproducible.
+
+**examples/transformer_demo.py**: the clip stays at 0.8. The `--lr` default
+becomes mode-dependent (`None` resolved to 3e-5 for `pc`, 1e-4 for
+`backprop`) after the verification below; the energy comment in the training
+loop and the docstring `Results:` block (PC energy now per token) are
+updated.
+
+**Docs**
+- `docs/user_guides/08_training_and_evaluation.md`: table row at line 28 and
+  the Gaussian sentence at line 36 ("per sample" → per prediction, N); the
+  `energy` bullet at line 107 (the objective per prediction, node set still
+  algorithm-dependent); delete the "different normalizations" note at lines
+  115–116.
+- `docs/user_guides/09_experiment_tracking.md:193–194`: comment becomes
+  "energy is the objective per prediction (graph_energy over internal nodes /
+  prediction count)".
+- `docs/user_guides/06_custom_nodes.md:264` and `:358`: add that the trainer
+  divides the summed gradients once by the prediction count
+  (`pc_weight_gradients`).
+- `docs/user_guides/03_how_predictive_coding_works.md:69`: the sentence naming
+  `compute_local_weight_gradients` as the gradient source gains the division
+  step. `examples/mnist_aim_tracking.py:209-211` carried the same stale
+  "per-sample / batch_size" comment as the tracking guide and is updated with
+  it.
+- `CHANGELOG.md`: an `[Unreleased]` entry with a migration table (custom
+  loops, SGD-family rates, the `damping` rename, the `energy` semantics).
+- `docs/user_guides/07_optimizers.md`: new paragraph "Gradient scale" after
+  Optax Basics stating that gradients reaching optax are means per prediction,
+  so learning rates, clipping thresholds, and damping are on the same scale as
+  standard mean-loss training; rewrite the Natural Gradient section for
+  `relative_damping`, the bias-corrected Fisher, and the covariance property.
 
 ## Test updates
 
-- `tests/test_trainer.py:161-169` `test_pc_parity_hand_rolled_reference`: add the same division to the hand-rolled `reference_step` — the only breaking test (Adam trajectory changes with gradient scale). Update the per-prediction comment near line 213.
-- Unaffected: direct `compute_local_weight_gradients` calls with relative/sign assertions (test_fabricpc.py:231, test_mupc.py:1035, test_inference_epc.py:287/422, test_storkey_hopfield.py:223/263); metric-shape tests; loss-decrease tests.
-- New tests (tests/test_trainer.py):
-  1. Backprop objective with a rank-3 target divides by B·T (small sequence graph).
-  2. Cross-algorithm scale parity: 1-step ePC hidden-node weight gradients equal `eta_infer ×` backprop gradients on identical params (the B factor measured in the earlier analysis disappears; pins both the normalization and the ePC/backprop relation).
-  3. Target-free PC graph uses the `batch_size` fallback.
+- `tests/test_trainer.py:161–169` `test_pc_parity_hand_rolled_reference`:
+  `reference_step` uses `pc_weight_gradients`. Comments at lines 213 and 231
+  say "/ prediction count". `test_eval_energy_matches_graph_energy` docstring
+  says `/ N`.
+- Unaffected: direct `compute_local_weight_gradients` calls with shape, sign,
+  or finiteness assertions (test_fabricpc.py:231, test_mupc.py:1038,
+  test_storkey_hopfield.py:181/221); metric-shape tests; loss-decrease tests;
+  Adam-based step tests.
+- `tests/test_optimizers.py`: migrate `damping=` to `relative_damping=`.
+- New tests, `tests/test_trainer.py`:
+  1. Backprop objective with a rank-3 target divides by B·S
+     (`v1_masked_structure` + `make_token_batches`).
+  2. One-step sPC vs backprop on `classification_structure` (single hidden
+     layer, `FeedforwardStateInit`, `infer_steps=1`, identical params):
+     hidden-node weight gradients equal η × backprop gradients to 1e-6
+     relative. Output-node gradients differ by O(η) because
+     `compute_local_weight_gradients` re-evaluates the output prediction at
+     the moved hidden latent: assert relative deviation below 10·η at
+     η = 1e-3 and that it shrinks when η is divided by 10.
+  3. Target-free PC graph: N = B; gradients equal the raw sums / B and
+     `energy` equals `graph_energy / B`.
+  4. `grad_denominator(structure, clamps)` equals B × Σ weights from
+     `_internal_energy_fn` for a sequence batch and a two-target batch (pins
+     train/eval agreement).
+  5. PC `energy` on `v1_masked_structure` equals `graph_energy / (B·S)`.
+- New tests, `tests/test_optimizers.py`:
+  6. Covariance: `update(c·g) == update(g) / c` for both transforms with
+     c = 1e-4 and 1e4, after several steps.
+  7. Bias correction: after one step with constant g, f̂ equals g² exactly, so
+     the update equals `g / (g² + ρ·mean(g²))`.
+  8. All-zero gradient: the update is all zeros and finite.
+- New test file `tests/test_inference_tracking.py`: `train_step_with_history`
+  matches `make_train_step` under `optax.sgd(1.0)` (params within 1e-5,
+  energy equal to `graph_energy / N`), so the hand-copied step cannot drift
+  from the trainer's normalization again.
 
 ## Verification
 
 ```
-pytest tests/test_trainer.py tests/test_inference_epc.py tests/test_mupc.py \
-       tests/test_fabricpc.py tests/test_storkey_hopfield.py tests/test_transformer_nodes.py
+pytest tests/test_trainer.py tests/test_optimizers.py tests/test_mupc.py \
+       tests/test_fabricpc.py tests/test_storkey_hopfield.py \
+       tests/test_transformer_nodes.py tests/test_sharding.py
 ```
-Then re-run the 1-step ePC vs backprop gradient comparison from the preceding analysis: hidden-layer norm ratio must be exactly `eta_infer` (was B·`eta_infer`) and the output layer exactly 1 (was B). Finally a short ResNet-18 demo run per algorithm (`--num_epochs 0.2`) confirming AdamW training curves are unchanged (Adam normalizes a uniform scale; only ε-level effects expected). Demo learning rates stay as tuned; any future SGD ablation tuned before this change needs lr × N.
+
+Then:
+
+1. ResNet-18 demo. The demo is PC-only and its `--num_epochs` is an `int`,
+   so the fractional per-algorithm run first written here cannot execute.
+   Substitute: one default 2-epoch run on the new code, compared with the
+   demo's own `Results:` block (train energy 0.4792, test accuracy 33.71%).
+   AdamW normalizes a uniform gradient scale (decoupled weight decay; only
+   ε-level effects), so the numbers should agree to within the run-to-run
+   variation the docstring already states. The per-algorithm Adam check is
+   item 3, whose demo has `--mode pc|backprop`.
+
+   **Result** (`python examples/resnet18_cifar10_demo.py`, RTX 3090 shared
+   with another job): test accuracy 33.58%, 432 s per epoch, against the
+   docstring's 33.71%. Within the stated variation; the docstring block
+   stands (the current script prints accuracy and time only).
+2. `mnist_advanced.py` calibration. On the parent commit, record 2-epoch test
+   accuracy for `sgd`, `ngd_diag`, `ngd_layerwise`. After the change: `sgd`
+   reproduces its number with the rescaled constants; for each NGD preset
+   sweep the `optax.scale` constant over a decade grid and pick the value
+   matching the parent's 2-epoch accuracy; if none does within one point,
+   adjust `relative_damping` before the constant. Record chosen values and
+   accuracies in the preset comments.
+
+   **Results (RTX 3090, JAX 0.10.1, optax 0.2.8; the demo gains
+   `--num_epochs` so these commands are reproducible; the parent was run from
+   a detached worktree with `num_epochs` edited to 2).**
+
+   Parent commit, `python examples/mnist_advanced.py --optimizer <preset>`:
+
+   | preset | epoch 2 energy / accuracy | epoch 10 energy / accuracy |
+   |---|---|---|
+   | `adamw` | 0.4432 / 20.95% | 0.0127 / 97.27% (new code; the parent's 2-epoch numbers are identical) |
+   | `sgd` (lr 0.01, wd 0.1) | 0.4517 / 10.28% | 0.3245 / 24.78% |
+   | `ngd_diag` (damping 1e-3, scale 3e-4) | 0.5017 / 8.92% | 0.1786 / 25.25% |
+   | `ngd_layerwise` (damping 1e-3, scale 1e-3) | 0.4513 / 10.28% | 0.4514 / 9.74% |
+
+   All three summed-gradient presets sit at chance after 2 epochs, so the
+   2-epoch matching rule above has no target. New code, `sgd` with the exact
+   rescale (lr 2.0, wd 5e-4): epoch 1 energy 0.4811 / 9.58%, epoch 2 0.4517
+   / 10.28%, identical to the parent to the printed digits.
+
+   `ngd_diag` and `ngd_layerwise` with `relative_damping` did not leave
+   chance accuracy at any point of three grids (48 runs), all at 10 epochs
+   unless stated:
+
+   - `optax.scale` ∈ {1e-8, 1e-7, 1e-6, 1e-5, 1e-4, 1e-3} at ρ = 0.1, 2
+     epochs: accuracy 8.9–11.4%; the old constants (3e-4, 1e-3) diverge
+     (energy rising to 1.15 and 3.55).
+   - ρ ∈ {0.1, 1, 10} × scale ∈ {1e-6, 1e-5, 1e-4}: accuracy 9.6–11.4%;
+     energy plateaus at 0.45 (every output near 0.1) except ρ = 10, scale
+     1e-4 for the diagonal transform, energy 0.207 with accuracy 9.74%.
+   - The same with `optax.clip_by_global_norm(1.0)` inserted before
+     `optax.scale`, scale ∈ {0.03, 0.1, 0.3, 1.0}, ρ ∈ {0.1, 1}: accuracy
+     9.6–11.4%, energy 0.45.
+
+   Mechanism, confirmed by logging on the diagonal transform (ρ = 1, scale
+   1e-5): over 250 steps the per-prediction gradient norm falls from 1.29 to
+   0.05 while the update norm stays between 0.04 and 0.28, so the step grows
+   relative to the gradient as the fit improves. Both transforms build F from
+   the squared mean gradient, so g / F ≈ 1 / g: the entries with the largest
+   gradients receive the smallest steps, and the informative directions are
+   suppressed relative to the rest. The covariance property this design pins
+   makes the 1 / g behavior explicit rather than causing it.
+
+   Resolution (maintainer decision): restore an absolute `damping` opt-in
+   and document the limitation. The presets become the exact analog of the
+   parent's constants (`damping = 1e-3 / N²`, `scale_old / N`,
+   `relative_damping = 0`); with the default `relative_damping = 0.1` added,
+   the relative term is about 30× the rescaled absolute term and both
+   presets stay at chance. Exact analog, 10 epochs:
+
+   | preset | new code, epoch 5 / epoch 10 | parent, epoch 5 / epoch 10 |
+   |---|---|---|
+   | `ngd_diag` | 0.2761 / 24.12%, 0.1784 / 23.78% | 0.2632 / 24.05%, 0.1786 / 25.25% |
+   | `ngd_layerwise` | 0.4514 / 9.58%, 0.4514 / 9.74% | 0.4514 / 9.58%, 0.4514 / 9.74% |
+
+   The residual difference for `ngd_diag` is the Fisher EMA's bias
+   correction in the first steps. Regime, measured on `ngd_diag` over the
+   first epoch (fraction of bias-corrected Fisher entries below the absolute
+   damping, and their share of trace(F)): step 1, 96.5% and 0.01%; step 50,
+   97.9% and 0.00%; step 300, 99.7% and 0.00%. Almost every entry is updated
+   as SGD with rate `scale / damping` (60 for `ngd_diag`, 200 for
+   `ngd_layerwise`); the few entries holding the Fisher trace receive the
+   `1 / g` step. The parent presets therefore trained weakly, and
+   `ngd_layerwise` not at all, for the same reason.
+3. `transformer_demo.py` in `--mode pc` and `--mode backprop` at the same
+   short budget on the parent commit and after; record eval perplexity for
+   both. A PC-mode regression is addressed by retuning the demo's `--lr`
+   default, not by changing the clip or the normalization.
+
+   **Results (default budget, 1 epoch = 7841 batches of 128 x 128 tokens,
+   `--lr 1e-4`, RTX 3090 shared with another job).** The parent PC run
+   reproduces the demo docstring exactly.
+
+   | mode | parent: final train energy / test loss / perplexity | new: final train energy / test loss / perplexity |
+   |---|---|---|
+   | backprop | 1.7140 (per token) / 1.8844 / 6.58 | 1.7136 (per token) / 1.8846 / 6.58 |
+   | pc | 352.9587 (per sample = 2.7575 per token) / 2.6988 / 14.86 | 108.0933 (per token) / 4.7353 / 113.90 |
+
+   Backprop is unchanged: its objective moved from `/ B` to `/ (B * S)`, a
+   uniform factor that Adam removes, leaving ε-level differences. PC
+   regressed: the energy per token rose 40x and the perplexity 7.7x. The
+   mechanism is the clip regime named above: on the parent the summed
+   gradient's norm exceeded 0.8 on every step, so `clip_by_global_norm(0.8)`
+   normalized each step's gradient to a fixed norm before Adam; on the new
+   scale the clip is inactive and Adam sees the raw per-token gradients.
+   Energy per token along the two full runs (tqdm postfix, parent divided by
+   128):
+
+   | step | 100 | 1000 | 1500 | 2500 | 3500 | 4000 | 4500 | 5000 | 6500 | 7800 |
+   |---|---|---|---|---|---|---|---|---|---|---|
+   | parent | 3.399 | 2.318 | 2.387 | 2.386 | 2.480 | 2.639 | 2.715 | 2.812 | 2.711 | 2.778 |
+   | new, lr 1e-4 | 3.399 | 2.340 | 2.422 | 2.566 | 3.111 | 10.29 | 53.47 | 181.0 | 719.8 | 720.8 |
+
+   The runs coincide for about 1000 steps, drift apart slowly, and the new
+   run leaves the parent's band after step 3500. At a short budget the two
+   agree: `--num_epochs 0.1` (784 steps) gives parent test loss 3.0282 /
+   perplexity 20.66 (final train energy 337.57 per sample = 2.637 per token)
+   and new 3.0330 / 20.76 (2.636 per token), so the divergence is a
+   late-training instability, not a change in the early dynamics.
+   Short-budget `--lr` sweep on the new code (`--num_epochs 0.1`, test
+   loss / perplexity): 1e-4 gives 3.0330 / 20.76, 3e-5 gives 3.6498 / 38.47,
+   1e-5 gives 4.4815 / 88.37; 1e-4 with the clip removed (diagnostic only)
+   gives 3.1065 / 22.34, so the 0.8 clip still fires on some steps at the
+   per-token scale. Lower rates only slow the early phase; whether they hold
+   the late phase is measured at the full budget below.
+   Full budget on the new code (`--mode pc`, 1 epoch; test loss /
+   perplexity / final train energy per token):
+
+   | `--lr` | test loss | perplexity | final train energy per token | trajectory |
+   |---|---|---|---|---|
+   | 1e-4 (old default) | 4.7353 | 113.90 | 108.09 | diverges after step 3500 |
+   | 3e-5 | 2.6846 | 14.65 | 2.2656 | monotone: 2.72 at step 1000, 2.29 at 5000 |
+   | 1e-5 | 2.9998 | 20.08 | 2.5541 | stable, under-trained |
+   | parent, 1e-4 | 2.6988 | 14.86 | 2.7575 | bounded, 2.3 to 3.2 |
+
+   Resolution: the demo's `--lr` default becomes mode-dependent, 3e-5 for
+   `pc` and 1e-4 for `backprop` (the backprop run at 1e-4 reproduced its
+   number), and the docstring `Results:` block records the 3e-5 run. The
+   clip stays at 0.8. The shared-GPU timings above are not comparable to the
+   docstring's; the perplexities are.
+4. Demo learning rates for Adam and AdamW stay as tuned, with one exception
+   established by item 3: the transformer demo's PC default moves from 1e-4
+   to 3e-5 because the clip no longer normalizes every step. The ResNet
+   (AdamW, item 1) and every MNIST Adam/AdamW preset are unchanged.

--- a/docs/dev_plans_archive/mean_gradient_normalization.md
+++ b/docs/dev_plans_archive/mean_gradient_normalization.md
@@ -317,7 +317,8 @@ updated.
   regimes with the measured MNIST accuracies, and the issue 68 link. The
   Practical Guidance learning-rate bullet gives the per-prediction SGD
   constants and the lr·N, wd/N rule.
-- `CHANGELOG.md`: an `[Unreleased]` entry with a four-row migration table
+- `CHANGELOG.md`: a `[0.5.1] - 2026-09-07` entry (the version bump is in
+  `pyproject.toml`) with a four-row migration table
   (custom loops, SGD-family rates, the `energy` semantics, and saved
   natural-gradient optimizer states, which gain `count` and do not restore
   from 0.5.0) and a "New" list (the three exported functions, the
@@ -421,7 +422,11 @@ Then:
    diagonal transform (ρ = 1, scale 1e-5): over 250 steps the per-prediction
    gradient norm fell from 1.29 to 0.05 while the update norm stayed between
    0.04 and 0.28, so the step grew relative to the gradient as the fit
-   improved.
+   improved. The review reproduced this on a 20-dimensional convex quadratic
+   (300 steps, `fisher_decay = 0.95`, ρ = 0.1), loss at its minimum over the
+   run against loss at step 300: diag at scale 0.1, 0.037 then 0.556;
+   layerwise at scale 0.1, 2.5e-9 then 0.418; layerwise at scale 0.01,
+   2.1e-7 then 0.026; SGD at 0.1 fell monotonically to 3.0e-5.
 
    Exact rescale of the parent presets (`damping = 1e-3 / N²`, `scale / N`,
    N = 200, with the bias correction), energy / accuracy at epoch 5 and 10:
@@ -532,6 +537,23 @@ in the training guide, the eval-metric table row to be corrected, the
 batch-size import in the dashboarding step to be replaced by an export, and
 the CHANGELOG to record the NGD state field. The revision implemented the
 reduced route described under "Natural-gradient transforms: reduced route"
-together with those items. GitHub issue 68
-(https://github.com/trueagi-io/FabricPC/issues/68) was updated with the
-learnings from the NGD tests and the new requirements for the estimator.
+together with those items. Two decisions from the review discussion are
+recorded here because they are not derivable from the code: the multi-head
+prediction count stays the sum over heads (the alternative is listed above),
+and the CHANGELOG carries no text translating pre-normalization `damping`
+values, because no user depends on them and the default changes. GitHub
+issue 68 (https://github.com/trueagi-io/FabricPC/issues/68) was updated with
+the learnings from the NGD tests and the new requirements for the estimator
+(a per-sample Monte-Carlo diagonal Fisher, generic through `NodeBase`); the
+per-sample Fisher design lives there, not in this repository.
+
+Checks the review made that no test covers:
+
+- muPC scaling is multiplicative per edge, so uniform division by N is
+  orthogonal to it.
+- `grad_denominator` on a target-free graph with an injected causal mask
+  reads B from the first clamp, which `build_clamps` inserts before the mask.
+- `optax.safe_int32_increment` exists at the declared optax floor (0.1.7).
+- `scripts/diagnose_deep_mupc.py` and the tests that call
+  `compute_local_weight_gradients` directly only inspect gradients, so no
+  caller is left on the summed scale.

--- a/docs/dev_plans_archive/mean_gradient_normalization.md
+++ b/docs/dev_plans_archive/mean_gradient_normalization.md
@@ -17,7 +17,14 @@ everywhere; division by a global count happens exactly once, in one function.
 
 Because the change moves every gradient to a new scale, it also owns the
 optimizer settings in this repository whose behavior depends on that scale:
-the coupled-L2 SGD preset and the clipping threshold in the transformer demo.
+the coupled-L2 SGD preset, the clipping threshold in the transformer demo, and
+the `damping` default of the two natural-gradient transforms, whose Fisher
+estimate scales with the square of the gradient. Re-choosing that default on
+the new scale exposed a quality gap in the existing transforms: their Fisher
+is the squared mean gradient of the batch, so no damping value gives a
+natural-gradient step. This change documents that gap and ships a
+better-informed default rather than a new estimator; the estimator redesign
+and its requirements are recorded in GitHub issue 68.
 
 ## Symbols
 
@@ -28,6 +35,8 @@ the coupled-L2 SGD preset and the clipping threshold in the transformer demo.
 | N | Prediction count, the single denominator: total clamped-target prediction positions in the batch, Σ over target heads of B·S |
 | η | `eta_infer`, the latent step size in `InferenceSGD` |
 | g | One weight-gradient leaf as handed to optax, a mean per prediction |
+| f | One Fisher leaf in a natural-gradient transform: the exponential moving average (EMA) of g² per entry (`scale_by_natural_gradient_diag`) or of mean(g²) per leaf (`scale_by_natural_gradient_layerwise`) |
+| t | Optimizer step count held in the transform state (`count`), for the EMA bias correction f̂ = f / (1 − fisher_decay^t) |
 
 ## Design
 
@@ -43,8 +52,9 @@ N = B·S. With several target heads N is the sum of their positions (two
 same-shape heads give N = 2B), so adding a head halves the step every shared
 parameter takes at a fixed learning rate. With no clamped target
 (associative-memory graphs) N = B, read from the leading axis of the first
-clamp. Read per sample, N is the weight `metrics._predictions_per_sample`
-assigns in `evaluate()`. Dividing the whole gradient pytree by one scalar
+clamp. Read per sample, N is the weight `metrics._internal_energy_fn` assigns
+in `evaluate()`: the sum of `_predictions_per_sample` over the batch's target
+keys. Dividing the whole gradient pytree by one scalar
 leaves relative layer scaling untouched; it redefines the objective as total
 energy per prediction.
 
@@ -83,8 +93,9 @@ backprop reports `graph_energy` over the target nodes divided by N, which
 equals `target_energy`. `target_energy` is unchanged (target-node energy over
 N). For rank-2 targets every number equals the previous release's. For
 sequence targets `energy` becomes per token, on the same scale as
-`target_energy` and `perplexity`. In `evaluate()`, `internal_energy` weights
-each sample by its target prediction count S (1 when the batch carries no
+`target_energy` and `perplexity`. In `evaluate()`, the default `energy`
+metric (`_internal_energy_fn`) weights each sample by its target prediction
+count, S summed over the batch's target keys (1 when the batch carries no
 target key), so the eval `energy` of a PC model is per prediction as well.
 
 ### Sharding safety
@@ -124,6 +135,47 @@ lr·N·(g_mean + (wd/N)·θ)`. The `mnist_advanced.py` `sgd` preset (B = 200) is
 rescaled exactly to `lr = 2.0`, `wd = 5e-4`, with a comment stating these are
 lr·N and wd/N of the summed-gradient values.
 
+### Natural-gradient transforms: reduced route
+
+Both transforms in natural_gradients.py compute `g / (f + damping)`. Dividing
+g by N divides f by N², so a `damping` tuned on summed gradients sits N²
+higher relative to f on the new scale: at per-prediction gradients of about
+1e-3 per weight, f is about 1e-6 and the parent default `damping = 1e-3`
+dominated every entry. The update has two regimes. Where `damping` dominates
+f the update is `g / damping`, SGD with rate `scale / damping`. Where f
+dominates, f ≈ g² because it is built from the squared *mean* gradient of the
+batch rather than from per-sample gradients, so the update is about `1 / g`:
+the entries with the largest gradients move least, and the step grows
+relative to the gradient as training shrinks it. Neither regime is a
+natural-gradient step, and no damping value produces one; choosing `damping`
+chooses the regime. This is a defect of the existing estimator, present
+before this change; the rescale made it visible.
+
+What ships:
+
+1. Bias-corrected Fisher: f̂ = f / (1 − fisher_decay^t), with t the step
+   count held in a new `count` field of both state tuples. Without it the
+   first steps see f ≈ (1 − fisher_decay)·g² and an update about 20× too
+   large, which the parent's absolute damping largely masked.
+2. `damping` default 1e-8 (`DEFAULT_DAMPING`), the best 10-epoch value in a
+   sweep of `examples/mnist_advanced.py` on the per-prediction scale
+   (Verification, item 2). At that value the damping exceeds 95% of the
+   bias-corrected Fisher entries at step 1 and 99.7% after one epoch, so both
+   transforms act as SGD on almost every parameter.
+3. The two regimes, the estimator defect, the bias correction, and the issue
+   68 link are stated in the module docstring, the optimizers guide, the
+   CHANGELOG, and the demo preset comment. The `ngd_diag` and `ngd_layerwise`
+   presets use the swept constants.
+4. Signatures are unchanged (`fisher_decay=0.95, damping=DEFAULT_DAMPING`);
+   `_validate_hparams` keeps `damping > 0`. The `count` field means optimizer
+   states saved under 0.5.0 with either transform do not restore.
+
+GitHub issue 68 was updated with the learnings from these measurements and
+the requirements for the estimator that would make the transforms
+natural-gradient steps: a diagonal Fisher from per-sample gradients at latents
+drawn from each node's predictive distribution, generic through `NodeBase`
+with no per-node closed forms.
+
 ## Alternatives considered
 
 - **Divide inside `compute_local_weight_gradients`** (pass N in). Pros: no
@@ -153,6 +205,36 @@ lr·N and wd/N of the summed-gradient values.
   0.8 to 1.0 on a per-token gradient is the standard LM recipe; removing it
   would itself change dynamics. Rejected in favor of keeping the value and
   measuring.
+- **Relative damping for the natural-gradient transforms**, `g / (f̂ + ρ·r)`
+  with r = trace(F̂)/dim (the mean of all bias-corrected Fisher entries across
+  the parameter pytree) and ρ a fraction of it, pinned by the covariance
+  property `update(c·g) = update(g) / c`. Built and measured first. Pros: the
+  regime becomes independent of gradient scale, so a later change of batch
+  size or sequence length cannot re-break it. Cons: the squared-mean Fisher
+  gives `g / f̂ ≈ 1 / g`, and relative damping holds that ratio at every
+  scale, so the update grows as the gradient shrinks; 48 MNIST runs stayed at
+  chance (Verification, item 2), the review reproduced the non-convergence on
+  a 20-dimensional convex quadratic, and every preset had opted out through a
+  restored absolute `damping`. Reverted. The design is correct once F is a
+  Fisher and is carried in issue 68.
+- **Exact rescale of the parent natural-gradient presets**
+  (`damping = 1e-3 / N²`, `scale / N`). Pros: reproduces the parent's
+  trajectory (measured: `ngd_diag` 23.78% against the parent's 25.25% at 10
+  epochs, the residual being the bias correction). Cons: keeps a default that
+  acts as SGD on 96.5% of the entries while presenting itself as a
+  natural-gradient step, and no user depends on the old values. Rejected; the
+  default is re-chosen by a sweep on the new scale instead.
+- **Per-sample Monte-Carlo diagonal Fisher** (draw z̃ from each node's energy
+  functional at its prediction `z_mu`, vmap `forward_and_weight_grads` at
+  batch 1, square and sum). Pros: the true Fisher of each node's likelihood;
+  for Gaussian energy with precision π it is π·(∂μ/∂W)², the Gauss-Newton
+  diagonal, bounded below and independent of the residual. Cons: a new
+  `EnergyFunctional.sample` method, a `fisher=True` trainer flag, and a
+  calibration run; too large for this PR. Deferred to issue 68, which holds
+  the design and requirements.
+- **`g / sqrt(F)`.** Pros: bounded step. Cons: that is `optax.scale_by_rms`
+  under another name; the transforms would then be deleted, not kept.
+  Rejected.
 
 ## Changes
 
@@ -164,12 +246,21 @@ lr·N and wd/N of the summed-gradient values.
    path: `grads = pc_weight_gradients(...)`, `energy = graph_energy(state,
    structure) / denom`. Backprop path: objective `graph_energy(...,
    node_names=target_nodes) / denom`. `target_energy` divides by it.
-3. Module docstring table rows for sub-step 4 (`/ N` for both), the metrics
-   comment (both keys per prediction; `energy` remains algorithm-dependent in
-   node set), and `make_train_step`'s `"energy"` description.
+3. Module docstring: the sub-step 4 rows (`/ N` for both), the sub-step 5 PC
+   row (`pc_weight_gradients`, summed gradients / N), and a paragraph under
+   the table defining N; the metrics comment (both keys per prediction;
+   `energy` remains algorithm-dependent in node set); and `make_train_step`'s
+   `"energy"` description.
 
-**fabricpc/training/__init__.py**: export `grad_denominator`,
+**fabricpc/training/__init__.py**: import and export `grad_denominator`,
 `pc_weight_gradients`, `batch_size_of`.
+
+**fabricpc/training/natural_gradients.py**: both state tuples gain an int32
+`count`; `update_fn` divides by the bias-corrected Fisher (`_bias_corrected`,
+factor `1 - fisher_decay**count`); `DEFAULT_DAMPING = 1e-8` replaces the 1e-3
+default in both signatures; the module docstring states the gradient scale,
+the two regimes, the estimator defect, the bias correction, and the issue 68
+link. `_validate_hparams` is unchanged.
 
 **fabricpc/training/metrics.py**: split `_target_items` into a non-raising
 iterator and the raising wrapper the target metrics use. `_internal_energy_fn`
@@ -187,7 +278,11 @@ batch-summed gradients; the trainer's `pc_weight_gradients` divides once by
 `grad_denominator`).
 
 **examples/mnist_advanced.py**: `sgd` preset `add_decayed_weights(5e-4)`,
-`sgd(2.0, momentum=0.9)` with the rescale comment. A `--num_epochs` argument
+`sgd(2.0, momentum=0.9)` with the rescale comment. `ngd_diag` and
+`ngd_layerwise` presets: `add_decayed_weights(5e-4)`, the default-argument
+transform, and `optax.scale(-6e-7)` / `optax.scale(-2e-6)` (scale / damping =
+60 and 200), with a comment recording the regime fractions, the sweep range,
+and the 10-epoch accuracies against `adamw`. A `--num_epochs` argument
 (default 10) makes the runs below reproducible.
 
 **examples/transformer_demo.py**: the clip stays at 0.8. The `--lr` default
@@ -211,12 +306,23 @@ updated.
   `compute_local_weight_gradients` as the gradient source gains the division
   step. `examples/mnist_aim_tracking.py` carried the same stale "per-sample /
   batch_size" comment as the tracking guide and is updated with it.
-- `docs/user_guides/07_optimizers.md`: new paragraph "Gradient scale" after
+- `docs/user_guides/07_optimizers.md`: new section "Gradient Scale" after
   Optax Basics stating that gradients reaching optax are means per prediction,
-  so learning rates and clipping thresholds are on the same scale as standard
-  mean-loss training.
-- `CHANGELOG.md`: an `[Unreleased]` entry with a migration table (custom
-  loops, SGD-family rates, the `energy` semantics).
+  so learning rates, clipping thresholds, Adam epsilon, and the
+  natural-gradient damping are on the same scale as standard mean-loss
+  training. The "Natural Gradient Transforms" section is rewritten: the bias
+  correction, `optax.scale(-lr)` after the transform in both examples (the
+  old examples chained `optax.adam`), the `damping` default 1e-8 with the
+  scale it was chosen on, a "What the update is" paragraph on the two
+  regimes with the measured MNIST accuracies, and the issue 68 link. The
+  Practical Guidance learning-rate bullet gives the per-prediction SGD
+  constants and the lr·N, wd/N rule.
+- `CHANGELOG.md`: an `[Unreleased]` entry with a four-row migration table
+  (custom loops, SGD-family rates, the `energy` semantics, and saved
+  natural-gradient optimizer states, which gain `count` and do not restore
+  from 0.5.0) and a "New" list (the three exported functions, the
+  natural-gradient bias correction and damping default, the eval `energy`
+  weighting, the dashboarding step's parity, the demo changes).
 
 ## Test updates
 
@@ -249,14 +355,31 @@ updated.
   matches `make_train_step` under `optax.sgd(1.0)` (params within 1e-5,
   energy equal to `graph_energy / N`), so the hand-copied step cannot drift
   from the trainer's normalization again.
+- `tests/test_optimizers.py`: `NGD_TRANSFORMS` parametrizes over both
+  transforms; `test_natural_gradients_work_in_train_step` runs the
+  default-argument transforms through `make_train_step`; the validation test
+  adds a negative `damping`. New:
+  1. `test_natural_gradient_first_step_is_bias_corrected`: after one step
+     from a fresh state f̂ equals g² (diag) or mean(g²) per leaf (layerwise),
+     so the update is `g / (f̂ + damping)` and differs from the uncorrected
+     `g / (0.05·f̂ + damping)`; `count == 1`.
+  2. `test_damping_dominated_update_is_sgd`: gradients of order 1e-3 against
+     `damping = 1.0` give `g / damping` on both transforms.
+  3. `test_fisher_dominated_diag_update_is_inverse_gradient`: gradients of
+     order 1 against `damping = 1e-12` give `1 / g` to 1e-4 relative, pinning
+     the documented defect.
 
 ## Verification
 
 ```
-pytest tests/test_trainer.py tests/test_inference_tracking.py tests/test_mupc.py \
-       tests/test_fabricpc.py tests/test_storkey_hopfield.py \
+pytest tests/test_trainer.py tests/test_inference_tracking.py tests/test_optimizers.py \
+       tests/test_mupc.py tests/test_fabricpc.py tests/test_storkey_hopfield.py \
        tests/test_transformer_nodes.py tests/test_sharding.py
 ```
+
+**Result** (CPU, `JAX_PLATFORMS=cpu`, after the `batch_size_of` export fix):
+the listed files give 142 passed, 5 skipped; the full `pytest tests/` run is
+recorded in item 5.
 
 Then:
 
@@ -278,6 +401,57 @@ Then:
    0.3245 / 24.78%. New code with lr 2.0, wd 5e-4: epoch 1 energy 0.4811 /
    9.58%, epoch 2 0.4517 / 10.28%, identical to the parent to the printed
    digits. `adamw` reaches 0.0127 / 97.27% at 10 epochs on both.
+
+   Natural-gradient presets, same machine. Parent commit, energy / accuracy:
+
+   | preset | epoch 2 | epoch 10 |
+   |---|---|---|
+   | `ngd_diag` (damping 1e-3, scale 3e-4) | 0.5017 / 8.92% | 0.1786 / 25.25% |
+   | `ngd_layerwise` (damping 1e-3, scale 1e-3) | 0.4513 / 10.28% | 0.4514 / 9.74% |
+
+   Every parent preset, `sgd` included, sits at chance after 2 epochs.
+
+   Relative damping (the reverted design, `g / (f̂ + ρ·r)`): 48 runs, none
+   left chance accuracy. `optax.scale` ∈ {1e-8, ..., 1e-3} at ρ = 0.1 for 2
+   epochs gave 8.9 to 11.4% (the old constants 3e-4 and 1e-3 diverged, energy
+   rising to 1.15 and 3.55); ρ ∈ {0.1, 1, 10} × scale ∈ {1e-6, 1e-5, 1e-4}
+   for 10 epochs gave 9.6 to 11.4% with energy plateaued at 0.45 (every
+   output near 0.1); the same grid with `clip_by_global_norm(1.0)` before
+   `scale` ∈ {0.03, 0.1, 0.3, 1.0} gave the same. Mechanism, logged on the
+   diagonal transform (ρ = 1, scale 1e-5): over 250 steps the per-prediction
+   gradient norm fell from 1.29 to 0.05 while the update norm stayed between
+   0.04 and 0.28, so the step grew relative to the gradient as the fit
+   improved.
+
+   Exact rescale of the parent presets (`damping = 1e-3 / N²`, `scale / N`,
+   N = 200, with the bias correction), energy / accuracy at epoch 5 and 10:
+   `ngd_diag` 0.2761 / 24.12% and 0.1784 / 23.78% against the parent's
+   0.2632 / 24.05% and 0.1786 / 25.25%; `ngd_layerwise` identical to the
+   parent (0.4514 / 9.58%, 0.4514 / 9.74%). Regime on `ngd_diag`, fraction
+   of bias-corrected Fisher entries below the damping and their share of
+   trace(F): step 1, 96.5% and 0.01%; step 50, 97.9% and 0.00%; step 300,
+   99.7% and 0.00%. The parent presets trained weakly, and `ngd_layerwise`
+   not at all, because almost every entry was already updated as SGD.
+
+   Damping sweep on the shipped code, 68 runs, `damping` and `scale / damping`
+   as the coordinates. Full grid at 2 epochs, both transforms: `damping` ∈
+   {1e-8, 1e-7, 1e-6, 1e-5, 1e-4} × `scale / damping` ∈ {20, 60, 200} (30
+   runs, every one at chance, as the parent's presets were at 2 epochs). Then
+   38 runs at 10 epochs: `damping` ∈ {1e-7, 1e-6, 1e-5, 1e-4} × `scale /
+   damping` ∈ {200, 600, 2000} for both transforms, plus `damping` ∈ {1e-8,
+   2.5e-8, 3e-8, 1e-7} at `scale / damping` 60 to 600. Only the diagonal
+   transform with `damping` ≤ 2.5e-8 and `scale / damping` ≤ 200 leaves
+   chance (12.3 to 16.3%); the layer-wise transform stays at chance in every
+   run; training energy falls in many settings without accuracy following.
+   Chosen: `damping = 1e-8` for both, `scale = 6e-7` for `ngd_diag` (ratio
+   60) and `2e-6` for `ngd_layerwise` (ratio 200). At 10 epochs: `ngd_diag`
+   0.2208 / 16.27%, `ngd_layerwise` 0.4509 / 10.28%, against `adamw`'s
+   0.0127 / 97.27%. At the default the damping exceeds 95.4% of the 242,762
+   bias-corrected Fisher entries at step 1 and 99.7% after one epoch, and the
+   entries above it hold essentially all of trace(F). The `ngd_diag` accuracy
+   is below the parent preset's 25.25%; the default was chosen for the best
+   result available on the new scale, not to reproduce a preset whose
+   damping acted as SGD on 96.5% of the entries.
 3. `transformer_demo.py` in `--mode pc` and `--mode backprop` at the same
    budget on the parent commit and after; record eval perplexity for both. A
    PC-mode regression is addressed by retuning the demo's `--lr` default, not
@@ -338,3 +512,26 @@ Then:
    established by item 3: the transformer demo's PC default moves from 1e-4
    to 3e-5 because the clip no longer normalizes every step. The ResNet
    (AdamW, item 1) and every MNIST Adam/AdamW preset are unchanged.
+5. Full test suite and linters on the final tree.
+
+   **Result** (CPU, `JAX_PLATFORMS=cpu pytest tests/`): 408 passed, 5
+   skipped. `ruff check` and `black --check` on `fabricpc/training/__init__.py`
+   pass.
+
+## Revisions
+
+The first implementation shipped the relative-damping design for the
+natural-gradient transforms (the first Alternatives entry on them above). A
+review of the branch found the prediction-count normalization correct, placed
+where the clamps are known, and pinned by the tests listed above, and found
+the relative-damping default unable to converge: the squared-mean Fisher gives
+a `1 / g` update, and every preset had opted out through a restored absolute
+`damping`. The review also asked for the multi-head convention to be stated
+in the training guide, the eval-metric table row to be corrected, the
+`grad_denominator` docstring to be trimmed to the rule, the private
+batch-size import in the dashboarding step to be replaced by an export, and
+the CHANGELOG to record the NGD state field. The revision implemented the
+reduced route described under "Natural-gradient transforms: reduced route"
+together with those items. GitHub issue 68
+(https://github.com/trueagi-io/FabricPC/issues/68) was updated with the
+learnings from the NGD tests and the new requirements for the estimator.

--- a/docs/dev_plans_archive/mean_gradient_normalization.md
+++ b/docs/dev_plans_archive/mean_gradient_normalization.md
@@ -1,0 +1,57 @@
+# Mean gradient normalization with a global prediction-count denominator
+
+## Context
+
+The PC training path hands the optimizer batch-summed weight gradients (`compute_local_weight_gradients` sums each node's per-sample energy over the batch), while the backprop path divides its objective by `batch_size` (trainer.py:309). The same learning rate, Adam ε, and any future clipping threshold therefore mean different things across `algorithm="pc"` and `"backprop"`, and gradient scale changes with batch size. This change normalizes both paths to mean gradients over a single global denominator that is correct for image minibatches (B samples), timeseries targets (B·T positions), and language-model token objectives (B·S tokens), and is safe under data-parallel sharding. It also builds in the discipline that avoids the Hugging Face gradient-accumulation defect (per-microbatch means averaged over microbatches with unequal token counts overweight short microbatches): gradients stay sums everywhere; division by a global count happens exactly once, at the optimizer boundary.
+
+Symbols: B = batch size; T/S = time/sequence length of a target clamp; N = the global denominator, the total number of independent prediction terms in the batch.
+
+## Design
+
+**Denominator rule.** N = total clamped-target prediction positions, `sum(prod(clamps[name].shape[:-1]) for name in target_nodes)` — the expression already computed as `n_predictions` at trainer.py:320 and matching `evaluate()`'s per-prediction weighting (`metrics._predictions_per_sample`). A rank-2 image target `(B, C)` gives N = B; a rank-3 sequence target `(B, T, V)` gives N = B·T. Target-free PC training (no clamped `in_degree > 0` node, e.g. associative-memory graphs) falls back to N = `batch_size`. Dividing the whole gradient pytree by one scalar leaves relative layer scaling untouched; it redefines the objective as total energy per prediction.
+
+**Placement: sum mechanics, one mean boundary.** `compute_local_weight_gradients` keeps returning batch-summed gradients — sums are associative, so they survive sharding and any future microbatch accumulation unchanged. Each optimizer-feeding call site divides once by N from a new public helper `grad_denominator(structure, clamps, batch_size)` in trainer.py. There are exactly two such call sites: `_batch_grads` (both algorithm branches) and `train_step_with_history` in inference_tracking.py. The five test files that call `compute_local_weight_gradients` directly only inspect gradients and are unaffected.
+
+**Sharding safety.** Data parallelism is `jax.jit` + `NamedSharding` over a `"data"` mesh axis (trainer.py:385, 476): the jitted step traces on global logical shapes, so the static shape product N is already the global count and the batch-summed gradients are globally reduced by XLA. No collective is needed. A future `shard_map`/`pmap` port would see per-shard shapes and must `jax.lax.psum` the count over the data axis — recorded in the helper's docstring, not in code.
+
+**Microbatching (not applicable yet).** The train loop performs one optimizer update per loader batch; no accumulation exists, and no padding/validity masks enter any energy (the only masks are attention masks). Static shape counts are therefore exact today. Per the request, the future rule lands as docstring guidance on `grad_denominator` (referenced from `compute_local_weight_gradients`):
+
+> Gradients arrive batch-summed and are divided once by this global count. If gradient accumulation over microbatches is added, keep that structure: accumulate the unnormalized sums across microbatches and divide once by the count summed over the whole accumulation window — dividing per microbatch and averaging overweights predictions in small microbatches when token counts differ. If padded positions gain a validity mask, replace the static shape product with `jnp.sum(mask)`. Under jit + NamedSharding, trace-time shapes and reductions are global, so this count is already global; a shard_map/pmap port must instead `jax.lax.psum` the per-shard count over the data axis.
+
+## Alternatives considered
+
+- **Divide inside `compute_local_weight_gradients`** (pass N in). Pros: no caller can forget. Cons: the denominator is a property of the objective (target clamps), which learning.py does not know; inspection-only consumers must supply a meaningless constant or an optional default creeps in — a fallback flag by another name. Rejected.
+- **`jnp.mean` inside node `forward_and_weight_grads`.** Pros: locality. Cons: touches every node template, breaks sPC/ePC energy-parity tests, and per-sample is the wrong denominator for token objectives. Rejected.
+- **Per-sample denominator (`batch_size`) everywhere.** Pros: smallest diff (backprop path already does it). Cons: learning rate does not transfer across sequence lengths; fails the LM-token requirement. Rejected.
+
+## Changes
+
+**fabricpc/training/trainer.py**
+1. Add public `grad_denominator(structure, clamps, batch_size)` with the docstring above; reuse `_target_node_names`.
+2. `_batch_grads`: compute `denom = grad_denominator(...)` once. PC path: `grads = jax.tree_util.tree_map(lambda g: g / denom, grads)`. Backprop path: objective becomes `graph_energy(..., node_names=target_nodes) / denom` (replacing `/ batch_size`). The `n_predictions` local for the `target_energy` metric collapses into the same computation.
+3. Metrics: PC `"energy"` stays `graph_energy / batch_size` (a per-sample diagnostic, not the gradient scale). Backprop `"energy"` is the objective and moves with it — identical for rank-2 targets, 1/T smaller for sequence targets. Update the normalization comment (lines 327–330), the module-docstring table rows, and `make_train_step`'s `"energy"` description (line 369).
+
+**fabricpc/utils/dashboarding/inference_tracking.py** — `train_step_with_history` (~line 264): apply the same division before `optimizer.update`, importing `grad_denominator` (it already imports `build_clamps` from trainer; no import cycle). Update its docstring.
+
+**fabricpc/core/learning.py** — docstring only: state the contract (returns batch-summed gradients; optimizer-feeding callers divide once by `grad_denominator`) and point to the helper for the microbatching/padding rule.
+
+**fabricpc/training/natural_gradients.py** — docstring note: the update `g / (fisher + damping)` is not scale-invariant; with gradients N× smaller the Fisher EMA shrinks N²×, so an existing `damping` sits N²× closer to the damping-dominated regime and may need retuning.
+
+**Docs** — `docs/user_guides/08_training_and_evaluation.md:28` (objective normalization "per sample" → per prediction); `docs/user_guides/06_custom_nodes.md:322,375` (note the trainer's single global division).
+
+## Test updates
+
+- `tests/test_trainer.py:161-169` `test_pc_parity_hand_rolled_reference`: add the same division to the hand-rolled `reference_step` — the only breaking test (Adam trajectory changes with gradient scale). Update the per-prediction comment near line 213.
+- Unaffected: direct `compute_local_weight_gradients` calls with relative/sign assertions (test_fabricpc.py:231, test_mupc.py:1035, test_inference_epc.py:287/422, test_storkey_hopfield.py:223/263); metric-shape tests; loss-decrease tests.
+- New tests (tests/test_trainer.py):
+  1. Backprop objective with a rank-3 target divides by B·T (small sequence graph).
+  2. Cross-algorithm scale parity: 1-step ePC hidden-node weight gradients equal `eta_infer ×` backprop gradients on identical params (the B factor measured in the earlier analysis disappears; pins both the normalization and the ePC/backprop relation).
+  3. Target-free PC graph uses the `batch_size` fallback.
+
+## Verification
+
+```
+pytest tests/test_trainer.py tests/test_inference_epc.py tests/test_mupc.py \
+       tests/test_fabricpc.py tests/test_storkey_hopfield.py tests/test_transformer_nodes.py
+```
+Then re-run the 1-step ePC vs backprop gradient comparison from the preceding analysis: hidden-layer norm ratio must be exactly `eta_infer` (was B·`eta_infer`) and the output layer exactly 1 (was B). Finally a short ResNet-18 demo run per algorithm (`--num_epochs 0.2`) confirming AdamW training curves are unchanged (Adam normalizes a uniform scale; only ε-level effects expected). Demo learning rates stay as tuned; any future SGD ablation tuned before this change needs lr × N.

--- a/docs/dev_plans_archive/mean_gradient_normalization.md
+++ b/docs/dev_plans_archive/mean_gradient_normalization.md
@@ -2,24 +2,22 @@
 
 ## Context
 
-The PC training path hands the optimizer batch-summed weight gradients
+The PC training path handed the optimizer batch-summed weight gradients
 (`compute_local_weight_gradients` sums each node's per-sample energy over the
-batch), while the backprop path divides its objective by `batch_size`
-(trainer.py:309). The same learning rate, Adam ε, clipping threshold, or
-natural-gradient damping therefore means different things across
-`algorithm="pc"` and `"backprop"`, and gradient scale changes with batch size
-and sequence length. This change normalizes both paths to mean gradients over
-one global denominator that is correct for image minibatches, timeseries
-targets, and language-model token objectives, is safe under data-parallel
-sharding, and keeps the discipline that avoids the Hugging Face
+batch), while the backprop path divided its objective by `batch_size`. The
+same learning rate, Adam ε, or clipping threshold therefore meant different
+things across `algorithm="pc"` and `"backprop"`, and gradient scale changed
+with batch size and sequence length. This change normalizes both paths to
+mean gradients over one global denominator that is correct for image
+minibatches, timeseries targets, and language-model token objectives, is safe
+under data-parallel sharding, and keeps the discipline that avoids the
 gradient-accumulation defect (per-microbatch means averaged over microbatches
 with unequal token counts overweight short microbatches): gradients stay sums
 everywhere; division by a global count happens exactly once, in one function.
 
 Because the change moves every gradient to a new scale, it also owns the
-optimizer components in this repository whose behavior depends on that scale:
-the natural-gradient transforms, the coupled-L2 SGD preset, and the clipping
-threshold in the transformer demo.
+optimizer settings in this repository whose behavior depends on that scale:
+the coupled-L2 SGD preset and the clipping threshold in the transformer demo.
 
 ## Symbols
 
@@ -27,12 +25,9 @@ threshold in the transformer demo.
 |---|---|
 | B | Batch size, the leading axis of every clamp |
 | S | Prediction positions per sample: the product of a target clamp's non-batch, non-class axes (sequence length for token targets, 1 for classification) |
-| N | Prediction count, the single denominator: total clamped-target prediction positions in the batch, B·S |
+| N | Prediction count, the single denominator: total clamped-target prediction positions in the batch, Σ over target heads of B·S |
 | η | `eta_infer`, the latent step size in `InferenceSGD` |
 | g | One weight-gradient leaf as handed to optax, a mean per prediction |
-| f | The Fisher EMA leaf in a natural-gradient transform, an EMA of g² |
-| r | Damping reference, trace(F)/dim: the mean of all Fisher entries across the parameter pytree |
-| ρ | `relative_damping`: damping as a fraction of r |
 
 ## Design
 
@@ -44,11 +39,14 @@ node is a clamped node with `in_degree > 0` (`_target_node_names`). The
 trailing axis of a target clamp is the class axis: `build_clamps` validates
 every target clamp against `(batch, *node.shape)`, so rank ≥ 2 holds. A rank-2
 image target `(B, C)` gives N = B; a rank-3 token target `(B, S, V)` gives
-N = B·S. The same rule read per sample is N = B × S with S = 1 when the graph
-has no clamped target (associative-memory graphs), which is exactly the weight
-`metrics._predictions_per_sample` assigns in `evaluate()`. Dividing the whole
-gradient pytree by one scalar leaves relative layer scaling untouched; it
-redefines the objective as total energy per prediction.
+N = B·S. With several target heads N is the sum of their positions (two
+same-shape heads give N = 2B), so adding a head halves the step every shared
+parameter takes at a fixed learning rate. With no clamped target
+(associative-memory graphs) N = B, read from the leading axis of the first
+clamp. Read per sample, N is the weight `metrics._predictions_per_sample`
+assigns in `evaluate()`. Dividing the whole gradient pytree by one scalar
+leaves relative layer scaling untouched; it redefines the objective as total
+energy per prediction.
 
 Definition caveat, recorded in the helper docstring: a clamped input node that
 receives feedback edges has `in_degree > 0` and counts as a target. No graph in
@@ -61,9 +59,8 @@ edge-free on the input side).
 are associative, so they survive sharding and any future microbatch
 accumulation unchanged. Two public functions in trainer.py own the mean:
 
-- `grad_denominator(structure, clamps) -> int`: the rule above. B is read from
-  the leading axis of the first clamp; empty `clamps` raises `ValueError`
-  (nothing is clamped, so there is no objective).
+- `grad_denominator(structure, clamps) -> int`: the rule above. Empty
+  `clamps` raises `ValueError` (nothing is clamped, so there is no objective).
 - `pc_weight_gradients(params, state, structure, clamps) -> GraphParams`:
   `compute_local_weight_gradients(...)` with every leaf divided by
   `grad_denominator(structure, clamps)`.
@@ -71,11 +68,12 @@ accumulation unchanged. Two public functions in trainer.py own the mean:
 `_batch_grads` calls `pc_weight_gradients` on the PC path and divides the
 backprop objective by the same `grad_denominator`. `train_step_with_history`
 calls `pc_weight_gradients`. These are the only two optimizer-feeding sites in
-the package; no example rolls its own step. Both functions are exported from
-`fabricpc.training` so custom loops that today call
-`compute_local_weight_gradients` directly have a normalized entry point. The
-trainer, not learning.py, knows the clamps, which is why the division lives
-here.
+the package; no example rolls its own step. Both functions, and
+`batch_size_of(batch, structure)` (the leading-axis size of the first
+task-mapped batch key, which the dashboarding step shares with the trainer),
+are exported from `fabricpc.training` so custom loops have a normalized entry
+point. The trainer, not learning.py, knows the clamps, which is why the
+division lives here.
 
 ### Metrics: `energy` is the objective
 
@@ -83,127 +81,48 @@ here.
 PC reports `graph_energy` over all `in_degree > 0` nodes divided by N;
 backprop reports `graph_energy` over the target nodes divided by N, which
 equals `target_energy`. `target_energy` is unchanged (target-node energy over
-N). For rank-2 targets every number equals today's. For sequence targets
-`energy` becomes per token, on the same scale as `target_energy` and
-`perplexity`. In `evaluate()`, `internal_energy` weights each sample by its
-target prediction count S (1 when the batch carries no target key), so the
-eval `energy` of a PC model is per prediction as well.
+N). For rank-2 targets every number equals the previous release's. For
+sequence targets `energy` becomes per token, on the same scale as
+`target_energy` and `perplexity`. In `evaluate()`, `internal_energy` weights
+each sample by its target prediction count S (1 when the batch carries no
+target key), so the eval `energy` of a PC model is per prediction as well.
 
 ### Sharding safety
 
-Data parallelism is `jax.jit` + `NamedSharding` over a `"data"` mesh axis
-(trainer.py:385, 476). `train` and `make_train_step` place the batch under
-`NamedSharding` before the jitted step, so the step traces on global logical
-shapes: the static shape product N is the global count and the batch-summed
-gradients of the replicated parameters are an XLA all-reduce. No collective is
-needed. A future `shard_map`/`pmap` port would see per-shard shapes and must
-`jax.lax.psum` the count over the data axis. This is recorded in the
-`grad_denominator` docstring.
+Data parallelism is `jax.jit` + `NamedSharding` over a `"data"` mesh axis.
+`train` and `make_train_step` place the batch under `NamedSharding` before the
+jitted step, so the step traces on global logical shapes: the static shape
+product N is the global count and the batch-summed gradients of the
+replicated parameters are an XLA all-reduce. No collective is needed. A future
+`shard_map`/`pmap` port would see per-shard shapes and must `jax.lax.psum` the
+count over the data axis.
 
 ### Microbatching (not applicable yet)
 
 The train loop performs one optimizer update per loader batch; no accumulation
 exists, and no padding or validity masks enter any energy (the only masks are
-attention masks). Static shape counts are exact today. The future rule lands
-as the `grad_denominator` docstring, referenced from
-`compute_local_weight_gradients`:
-
-> Gradients arrive batch-summed and are divided once by this global count. If
-> gradient accumulation over microbatches is added, keep that structure:
-> accumulate the unnormalized sums across microbatches and divide once by the
-> count summed over the whole accumulation window. Dividing per microbatch and
-> averaging overweights predictions in small microbatches when token counts
-> differ. If padded positions gain a validity mask, replace the static shape
-> product with `jnp.sum(mask)`. Under jit + NamedSharding, trace-time shapes
-> and reductions are global, so this count is already global; a
-> shard_map/pmap port must instead `jax.lax.psum` the per-shard count over the
-> data axis.
-
-### Natural-gradient transforms: scale-free damping
-
-Both transforms in natural_gradients.py compute `g / (f + damping)` with f an
-EMA of g². Scaling every gradient by 1/N scales f by 1/N², so a fixed
-`damping` moves N² closer to dominating. At per-prediction gradient magnitudes
-of about 1e-3 per weight, f is about 1e-6 and the current default `damping =
-1e-3` dominates every entry: the transform degenerates to SGD with learning
-rate `scale / damping`. The natural-gradient update is inherently covariant
-(scaling g by c scales `g / f` by 1/c), so no damping rule can make its
-magnitude scale-invariant; what a rule can do is make the regime, which term
-dominates, independent of scale. The transforms adopt:
-
-1. Bias-corrected Fisher: f̂ = f / (1 − fisher_decay^t), with t the step count
-   held in the state. Without this the first steps see f ≈ (1 − decay)·g² and
-   over-large updates, which the absolute damping used to mask.
-2. Damping reference r = trace(F̂)/dim, the mean of all bias-corrected Fisher
-   entries across the pytree. For the layerwise transform each leaf's scalar
-   counts with weight equal to the leaf's size, so both transforms use one
-   definition.
-3. Update `g / (f̂ + ρ·r)`, computed as `g / where(d > 0, d, 1)` with
-   d = f̂ + ρ·r. The denominator is zero only when every gradient entry seen
-   so far, including the current one, is zero (the EMA includes the current
-   g² with weight 1 − fisher_decay > 0), and then g = 0 and the guarded
-   division returns the correct update, 0, without forming 0/0. No absolute
-   constant enters the denominator. An earlier draft added `floor = 1e-12`;
-   measured in float32, that floor breaks the covariance below by about
-   5e-4 relative at c = 1e-4, and at per-prediction gradient magnitudes near
-   1e-6 (f̂ ≈ 1e-12) it halves the update, so it would have re-introduced an
-   absolute scale at the very magnitudes this change produces.
-
-Property pinned by test: `update(c·g) = update(g) / c` exactly (to float32
-rounding, about 2e-7) for any c > 0, and the set of entries where damping
-dominates is the same for g and c·g.
-Signatures become `scale_by_natural_gradient_diag(fisher_decay=0.95,
-relative_damping=0.1, damping=0.0)` and
-`scale_by_natural_gradient_layerwise(...)` with the same arguments. The state
-tuples gain a `count` field.
-
-`damping` was first removed and then restored as an explicit opt-in, default
-0, after the calibration below showed that neither transform trains the MNIST
-demo with relative damping alone. With `damping > 0` the denominator is
-`f̂ + ρ·r + damping`; wherever the constant dominates, the update is
-`g / damping`, SGD with rate `scale / damping`, and the covariance above no
-longer holds. `_validate_hparams` accepts `relative_damping >= 0` and
-`damping >= 0` and rejects both being zero (then `g / f̂ ≈ 1 / g` has no
-bound as gradients shrink). The docstrings record this and the limitation
-paragraph below as properties of the present implementations.
-
-### Limitation of the present transforms
-
-Both transforms build F from the squared *mean* gradient of the batch, not
-from per-sample gradients, so `g / F ≈ 1 / g`: the entries with the largest
-gradients receive the smallest steps, and the step grows relative to the
-gradient as training reduces it (the covariance property states this: smaller
-gradients, larger updates). On `examples/mnist_advanced.py` this leaves both
-transforms at chance accuracy with relative damping alone, at every one of 48
-settings tried (Verification, item 2). The demo presets train, weakly, only
-through an absolute damping that lies above 96.5% of the Fisher entries from
-the first step, so those entries are updated as SGD and only the few
-large-gradient entries receive the natural-gradient step. This is documented
-in the module docstring, the optimizers guide, and the changelog; fixing it
-(a per-sample Fisher, or a square-root normalization as in Adam) is outside
-this change.
+attention masks). Static shape counts are exact today. The rule for a future
+accumulation path is one sentence in the `grad_denominator` docstring: sum
+first, divide once by the window's total count.
 
 ### Clipping thresholds
 
 `optax.clip_by_global_norm` thresholds now sit on the per-prediction scale that
 standard mean-loss training uses. `examples/transformer_demo.py` keeps
-`clip_by_global_norm(0.8)`: today the PC summed-gradient norm over
-B·S = 16384 positions exceeds 0.8 on essentially every step, so the clip acts
+`clip_by_global_norm(0.8)`: before the change the PC summed-gradient norm over
+B·S = 16384 positions exceeded 0.8 on essentially every step, so the clip acted
 as per-step normalization ahead of Adam; after the change it fires on the
-conventional schedule. The verification records perplexity in both modes.
-Outcome: backprop is unchanged; PC at the old `--lr 1e-4` destabilizes after
-about 3500 steps without that per-step normalization, and `--lr 3e-5` holds
-the full epoch at a slightly better perplexity, so the demo's PC default moves
-to 3e-5 (Verification, item 3).
+conventional schedule. Outcome (Verification, item 3): backprop is unchanged;
+PC at the old `--lr 1e-4` destabilizes after about 3500 steps without that
+per-step normalization, and `--lr 3e-5` holds the full epoch at a slightly
+better perplexity, so the demo's PC default moves to 3e-5.
 
 ### SGD with coupled L2
 
 `optax.chain(add_decayed_weights(wd), sgd(lr))` applies `lr·(g_sum + wd·θ) =
 lr·N·(g_mean + (wd/N)·θ)`. The `mnist_advanced.py` `sgd` preset (B = 200) is
 rescaled exactly to `lr = 2.0`, `wd = 5e-4`, with a comment stating these are
-lr·N and wd/N of the summed-gradient values. The two natural-gradient presets
-cannot be rescaled exactly because their damping semantics change; they are
-retuned by the calibration run in Verification.
+lr·N and wd/N of the summed-gradient values.
 
 ## Alternatives considered
 
@@ -215,8 +134,8 @@ retuned by the calibration run in Verification.
   clamps are known.
 - **Divide at each optimizer-feeding call site** via `grad_denominator`
   alone. Pros: smallest surface. Cons: the contract is enforced by docstring;
-  `train_step_with_history` is already a hand copy of the PC step that
-  diverged on how it reads the batch size. Rejected.
+  `train_step_with_history` was already a hand copy of the PC step that
+  diverged on how it read the batch size. Rejected.
 - **`jnp.mean` inside node `forward_and_weight_grads`.** Pros: locality.
   Cons: touches every node template and per-sample is the wrong denominator
   for token objectives. Rejected.
@@ -226,13 +145,10 @@ retuned by the calibration run in Verification.
   trainer would report `energy` with a different normalization per algorithm
   for sequence targets, and PC `energy` would no longer be the optimized
   quantity. Rejected.
-- **Absolute retune of natural-gradient damping.** Pros: no API change. Cons:
-  the regime stays scale-dependent, so any later change of batch size or
-  sequence length re-breaks it silently. Rejected as the default; restored as
-  an explicit opt-in (`damping`, default 0) after calibration showed the
-  relative-only transforms do not train the MNIST demo, so that the demo
-  presets can keep the parent's trajectory and the limitation is documented
-  rather than hidden.
+- **Sum of per-head means for multi-head graphs** (Σ_k L_k / (B·S_k)). Pros:
+  the common multi-task convention. Cons: the PC internal energy of a shared
+  hidden node has no per-head split, so only one global scalar is
+  well-defined. Rejected; the sum-over-heads count is documented instead.
 - **Remove or retune the transformer clip.** Pros: fewer moving parts. Cons:
   0.8 to 1.0 on a per-token gradient is the standard LM recipe; removing it
   would itself change dynamics. Rejected in favor of keeping the value and
@@ -242,20 +158,18 @@ retuned by the calibration run in Verification.
 
 **fabricpc/training/trainer.py**
 1. Add `grad_denominator(structure, clamps)` and `pc_weight_gradients(params,
-   state, structure, clamps)` with the docstrings above; reuse
-   `_target_node_names`.
+   state, structure, clamps)`; reuse `_target_node_names`. Rename the private
+   batch-size helper to `batch_size_of` and export it.
 2. `_batch_grads`: `denom = grad_denominator(structure, clamps)` once. PC
    path: `grads = pc_weight_gradients(...)`, `energy = graph_energy(state,
    structure) / denom`. Backprop path: objective `graph_energy(...,
-   node_names=target_nodes) / denom`. The `n_predictions` local collapses into
-   `denom`; `target_energy` divides by it.
+   node_names=target_nodes) / denom`. `target_energy` divides by it.
 3. Module docstring table rows for sub-step 4 (`/ N` for both), the metrics
-   comment at lines 327–330 (both keys per prediction; `energy` remains
-   algorithm-dependent in node set), and `make_train_step`'s `"energy"`
-   description (line 369: the objective per prediction).
+   comment (both keys per prediction; `energy` remains algorithm-dependent in
+   node set), and `make_train_step`'s `"energy"` description.
 
-**fabricpc/training/__init__.py**: export `grad_denominator` and
-`pc_weight_gradients`.
+**fabricpc/training/__init__.py**: export `grad_denominator`,
+`pc_weight_gradients`, `batch_size_of`.
 
 **fabricpc/training/metrics.py**: split `_target_items` into a non-raising
 iterator and the raising wrapper the target metrics use. `_internal_energy_fn`
@@ -263,37 +177,18 @@ weight = Σ over target items of `_predictions_per_sample(y)`, or 1 with no
 target key. Update the module docstring's description of `energy`.
 
 **fabricpc/utils/dashboarding/inference_tracking.py**:
-`train_step_with_history` (lines 161–227) reads B via `_batch_size(batch,
-structure)` from trainer, computes `denom = grad_denominator(structure,
-clamps)`, reports `energy = graph_energy(final_state, structure) / denom`, and
-feeds `pc_weight_gradients(...)` to `optimizer.update`. Docstring: `energy` is
-the objective per prediction.
+`train_step_with_history` reads B via `batch_size_of(batch, structure)`,
+computes `denom = grad_denominator(structure, clamps)`, reports
+`energy = graph_energy(final_state, structure) / denom`, and feeds
+`pc_weight_gradients(...)` to `optimizer.update`.
 
 **fabricpc/core/learning.py**: docstring only. State the contract (returns
 batch-summed gradients; the trainer's `pc_weight_gradients` divides once by
-`grad_denominator`) and point to the helper for the microbatching and padding
-rule.
-
-**fabricpc/training/natural_gradients.py**: the design above. Both state
-tuples gain `count` (int32, incremented with `optax.safe_int32_increment`
-before the bias factor `1 − fisher_decay**count` is formed, so t = 1 on the
-first update); `damping` becomes `relative_damping` (default 0.1) with no
-alias; the zero guard is the `where` form above; `_validate_hparams` checks
-`relative_damping > 0`. The bias correction is written locally rather than
-through `optax.tree_utils.tree_bias_correction`, which first appears in
-optax 0.2.3 while the declared floor is `optax>=0.1.7` (verified: the 0.1.7
-wheel imports and runs `optax.adam` under the venv's JAX 0.10.1). Docstrings
-state the covariance property and that the trainer hands over per-prediction
-mean gradients. `optimizers.py` re-exports unchanged.
+`grad_denominator`).
 
 **examples/mnist_advanced.py**: `sgd` preset `add_decayed_weights(5e-4)`,
-`sgd(2.0, momentum=0.9)` with the rescale comment. `ngd_diag` and
-`ngd_layerwise` presets are the exact per-prediction analog of the parent's
-constants: `add_decayed_weights(5e-4)`, `relative_damping=0.0`,
-`damping=1e-3 / N**2`, `optax.scale(-scale_old / N)` (F shrinks by N², g by
-N). The comment records the calibration and the measured regime. A
-`--num_epochs` argument (default 10) makes the calibration command
-reproducible.
+`sgd(2.0, momentum=0.9)` with the rescale comment. A `--num_epochs` argument
+(default 10) makes the runs below reproducible.
 
 **examples/transformer_demo.py**: the clip stays at 0.8. The `--lr` default
 becomes mode-dependent (`None` resolved to 3e-5 for `pc`, 1e-4 for
@@ -302,63 +197,54 @@ loop and the docstring `Results:` block (PC energy now per token) are
 updated.
 
 **Docs**
-- `docs/user_guides/08_training_and_evaluation.md`: table row at line 28 and
-  the Gaussian sentence at line 36 ("per sample" → per prediction, N); the
-  `energy` bullet at line 107 (the objective per prediction, node set still
-  algorithm-dependent); delete the "different normalizations" note at lines
-  115–116.
-- `docs/user_guides/09_experiment_tracking.md:193–194`: comment becomes
+- `docs/user_guides/08_training_and_evaluation.md`: objective rows and the
+  Gaussian sentence ("per sample" → per prediction, N); the "Per prediction"
+  paragraph defining N with the multi-head sentence; the `energy` bullet and
+  the eval-metric table row (the objective per prediction, node set still
+  algorithm-dependent); delete the "different normalizations" note.
+- `docs/user_guides/09_experiment_tracking.md`: the energy comment becomes
   "energy is the objective per prediction (graph_energy over internal nodes /
   prediction count)".
-- `docs/user_guides/06_custom_nodes.md:264` and `:358`: add that the trainer
-  divides the summed gradients once by the prediction count
-  (`pc_weight_gradients`).
-- `docs/user_guides/03_how_predictive_coding_works.md:69`: the sentence naming
+- `docs/user_guides/06_custom_nodes.md`: add that the trainer divides the
+  summed gradients once by the prediction count (`pc_weight_gradients`).
+- `docs/user_guides/03_how_predictive_coding_works.md`: the sentence naming
   `compute_local_weight_gradients` as the gradient source gains the division
-  step. `examples/mnist_aim_tracking.py:209-211` carried the same stale
-  "per-sample / batch_size" comment as the tracking guide and is updated with
-  it.
-- `CHANGELOG.md`: an `[Unreleased]` entry with a migration table (custom
-  loops, SGD-family rates, the `damping` rename, the `energy` semantics).
+  step. `examples/mnist_aim_tracking.py` carried the same stale "per-sample /
+  batch_size" comment as the tracking guide and is updated with it.
 - `docs/user_guides/07_optimizers.md`: new paragraph "Gradient scale" after
   Optax Basics stating that gradients reaching optax are means per prediction,
-  so learning rates, clipping thresholds, and damping are on the same scale as
-  standard mean-loss training; rewrite the Natural Gradient section for
-  `relative_damping`, the bias-corrected Fisher, and the covariance property.
+  so learning rates and clipping thresholds are on the same scale as standard
+  mean-loss training.
+- `CHANGELOG.md`: an `[Unreleased]` entry with a migration table (custom
+  loops, SGD-family rates, the `energy` semantics).
 
 ## Test updates
 
-- `tests/test_trainer.py:161–169` `test_pc_parity_hand_rolled_reference`:
-  `reference_step` uses `pc_weight_gradients`. Comments at lines 213 and 231
-  say "/ prediction count". `test_eval_energy_matches_graph_energy` docstring
+- `tests/test_trainer.py` `test_pc_parity_hand_rolled_reference`:
+  `reference_step` uses `pc_weight_gradients`. Reference-loss comments say
+  "/ prediction count". `test_eval_energy_matches_graph_energy` docstring
   says `/ N`.
 - Unaffected: direct `compute_local_weight_gradients` calls with shape, sign,
-  or finiteness assertions (test_fabricpc.py:231, test_mupc.py:1038,
-  test_storkey_hopfield.py:181/221); metric-shape tests; loss-decrease tests;
+  or finiteness assertions (test_fabricpc.py, test_mupc.py,
+  test_storkey_hopfield.py); metric-shape tests; loss-decrease tests;
   Adam-based step tests.
-- `tests/test_optimizers.py`: migrate `damping=` to `relative_damping=`.
 - New tests, `tests/test_trainer.py`:
   1. Backprop objective with a rank-3 target divides by B·S
-     (`v1_masked_structure` + `make_token_batches`).
+     (`v1_masked_structure` + `make_v1_token_batch`).
   2. One-step sPC vs backprop on `classification_structure` (single hidden
      layer, `FeedforwardStateInit`, `infer_steps=1`, identical params):
-     hidden-node weight gradients equal η × backprop gradients to 1e-6
+     hidden-node weight gradients equal η × backprop gradients to 1e-5
      relative. Output-node gradients differ by O(η) because
      `compute_local_weight_gradients` re-evaluates the output prediction at
-     the moved hidden latent: assert relative deviation below 10·η at
-     η = 1e-3 and that it shrinks when η is divided by 10.
+     the moved hidden latent: assert relative deviation below 10·η and that it
+     shrinks as η is divided by 10.
   3. Target-free PC graph: N = B; gradients equal the raw sums / B and
      `energy` equals `graph_energy / B`.
   4. `grad_denominator(structure, clamps)` equals B × Σ weights from
      `_internal_energy_fn` for a sequence batch and a two-target batch (pins
-     train/eval agreement).
+     train/eval agreement and the sum-over-heads convention).
   5. PC `energy` on `v1_masked_structure` equals `graph_energy / (B·S)`.
-- New tests, `tests/test_optimizers.py`:
-  6. Covariance: `update(c·g) == update(g) / c` for both transforms with
-     c = 1e-4 and 1e4, after several steps.
-  7. Bias correction: after one step with constant g, f̂ equals g² exactly, so
-     the update equals `g / (g² + ρ·mean(g²))`.
-  8. All-zero gradient: the update is all zeros and finite.
+  6. `grad_denominator` raises on empty clamps.
 - New test file `tests/test_inference_tracking.py`: `train_step_with_history`
   matches `make_train_step` under `optax.sgd(1.0)` (params within 1e-5,
   energy equal to `graph_energy / N`), so the hand-copied step cannot drift
@@ -367,100 +253,35 @@ updated.
 ## Verification
 
 ```
-pytest tests/test_trainer.py tests/test_optimizers.py tests/test_mupc.py \
+pytest tests/test_trainer.py tests/test_inference_tracking.py tests/test_mupc.py \
        tests/test_fabricpc.py tests/test_storkey_hopfield.py \
        tests/test_transformer_nodes.py tests/test_sharding.py
 ```
 
 Then:
 
-1. ResNet-18 demo. The demo is PC-only and its `--num_epochs` is an `int`,
-   so the fractional per-algorithm run first written here cannot execute.
-   Substitute: one default 2-epoch run on the new code, compared with the
+1. ResNet-18 demo, one default 2-epoch run on the new code, compared with the
    demo's own `Results:` block (train energy 0.4792, test accuracy 33.71%).
    AdamW normalizes a uniform gradient scale (decoupled weight decay; only
    ε-level effects), so the numbers should agree to within the run-to-run
-   variation the docstring already states. The per-algorithm Adam check is
-   item 3, whose demo has `--mode pc|backprop`.
+   variation the docstring already states.
 
    **Result** (`python examples/resnet18_cifar10_demo.py`, RTX 3090 shared
    with another job): test accuracy 33.58%, 432 s per epoch, against the
    docstring's 33.71%. Within the stated variation; the docstring block
-   stands (the current script prints accuracy and time only).
-2. `mnist_advanced.py` calibration. On the parent commit, record 2-epoch test
-   accuracy for `sgd`, `ngd_diag`, `ngd_layerwise`. After the change: `sgd`
-   reproduces its number with the rescaled constants; for each NGD preset
-   sweep the `optax.scale` constant over a decade grid and pick the value
-   matching the parent's 2-epoch accuracy; if none does within one point,
-   adjust `relative_damping` before the constant. Record chosen values and
-   accuracies in the preset comments.
+   stands.
+2. `mnist_advanced.py` `sgd` preset: the exact rescale must reproduce the
+   parent's trajectory.
 
-   **Results (RTX 3090, JAX 0.10.1, optax 0.2.8; the demo gains
-   `--num_epochs` so these commands are reproducible; the parent was run from
-   a detached worktree with `num_epochs` edited to 2).**
-
-   Parent commit, `python examples/mnist_advanced.py --optimizer <preset>`:
-
-   | preset | epoch 2 energy / accuracy | epoch 10 energy / accuracy |
-   |---|---|---|
-   | `adamw` | 0.4432 / 20.95% | 0.0127 / 97.27% (new code; the parent's 2-epoch numbers are identical) |
-   | `sgd` (lr 0.01, wd 0.1) | 0.4517 / 10.28% | 0.3245 / 24.78% |
-   | `ngd_diag` (damping 1e-3, scale 3e-4) | 0.5017 / 8.92% | 0.1786 / 25.25% |
-   | `ngd_layerwise` (damping 1e-3, scale 1e-3) | 0.4513 / 10.28% | 0.4514 / 9.74% |
-
-   All three summed-gradient presets sit at chance after 2 epochs, so the
-   2-epoch matching rule above has no target. New code, `sgd` with the exact
-   rescale (lr 2.0, wd 5e-4): epoch 1 energy 0.4811 / 9.58%, epoch 2 0.4517
-   / 10.28%, identical to the parent to the printed digits.
-
-   `ngd_diag` and `ngd_layerwise` with `relative_damping` did not leave
-   chance accuracy at any point of three grids (48 runs), all at 10 epochs
-   unless stated:
-
-   - `optax.scale` ∈ {1e-8, 1e-7, 1e-6, 1e-5, 1e-4, 1e-3} at ρ = 0.1, 2
-     epochs: accuracy 8.9–11.4%; the old constants (3e-4, 1e-3) diverge
-     (energy rising to 1.15 and 3.55).
-   - ρ ∈ {0.1, 1, 10} × scale ∈ {1e-6, 1e-5, 1e-4}: accuracy 9.6–11.4%;
-     energy plateaus at 0.45 (every output near 0.1) except ρ = 10, scale
-     1e-4 for the diagonal transform, energy 0.207 with accuracy 9.74%.
-   - The same with `optax.clip_by_global_norm(1.0)` inserted before
-     `optax.scale`, scale ∈ {0.03, 0.1, 0.3, 1.0}, ρ ∈ {0.1, 1}: accuracy
-     9.6–11.4%, energy 0.45.
-
-   Mechanism, confirmed by logging on the diagonal transform (ρ = 1, scale
-   1e-5): over 250 steps the per-prediction gradient norm falls from 1.29 to
-   0.05 while the update norm stays between 0.04 and 0.28, so the step grows
-   relative to the gradient as the fit improves. Both transforms build F from
-   the squared mean gradient, so g / F ≈ 1 / g: the entries with the largest
-   gradients receive the smallest steps, and the informative directions are
-   suppressed relative to the rest. The covariance property this design pins
-   makes the 1 / g behavior explicit rather than causing it.
-
-   Resolution (maintainer decision): restore an absolute `damping` opt-in
-   and document the limitation. The presets become the exact analog of the
-   parent's constants (`damping = 1e-3 / N²`, `scale_old / N`,
-   `relative_damping = 0`); with the default `relative_damping = 0.1` added,
-   the relative term is about 30× the rescaled absolute term and both
-   presets stay at chance. Exact analog, 10 epochs:
-
-   | preset | new code, epoch 5 / epoch 10 | parent, epoch 5 / epoch 10 |
-   |---|---|---|
-   | `ngd_diag` | 0.2761 / 24.12%, 0.1784 / 23.78% | 0.2632 / 24.05%, 0.1786 / 25.25% |
-   | `ngd_layerwise` | 0.4514 / 9.58%, 0.4514 / 9.74% | 0.4514 / 9.58%, 0.4514 / 9.74% |
-
-   The residual difference for `ngd_diag` is the Fisher EMA's bias
-   correction in the first steps. Regime, measured on `ngd_diag` over the
-   first epoch (fraction of bias-corrected Fisher entries below the absolute
-   damping, and their share of trace(F)): step 1, 96.5% and 0.01%; step 50,
-   97.9% and 0.00%; step 300, 99.7% and 0.00%. Almost every entry is updated
-   as SGD with rate `scale / damping` (60 for `ngd_diag`, 200 for
-   `ngd_layerwise`); the few entries holding the Fisher trace receive the
-   `1 / g` step. The parent presets therefore trained weakly, and
-   `ngd_layerwise` not at all, for the same reason.
+   **Result (RTX 3090, JAX 0.10.1, optax 0.2.8).** Parent commit, `sgd`
+   (lr 0.01, wd 0.1): epoch 2 energy 0.4517 / accuracy 10.28%, epoch 10
+   0.3245 / 24.78%. New code with lr 2.0, wd 5e-4: epoch 1 energy 0.4811 /
+   9.58%, epoch 2 0.4517 / 10.28%, identical to the parent to the printed
+   digits. `adamw` reaches 0.0127 / 97.27% at 10 epochs on both.
 3. `transformer_demo.py` in `--mode pc` and `--mode backprop` at the same
-   short budget on the parent commit and after; record eval perplexity for
-   both. A PC-mode regression is addressed by retuning the demo's `--lr`
-   default, not by changing the clip or the normalization.
+   budget on the parent commit and after; record eval perplexity for both. A
+   PC-mode regression is addressed by retuning the demo's `--lr` default, not
+   by changing the clip or the normalization.
 
    **Results (default budget, 1 epoch = 7841 batches of 128 x 128 tokens,
    `--lr 1e-4`, RTX 3090 shared with another job).** The parent PC run

--- a/docs/user_guides/03_how_predictive_coding_works.md
+++ b/docs/user_guides/03_how_predictive_coding_works.md
@@ -66,7 +66,7 @@ The **learning loop** updates weights using gradients computed from the converge
 dE/dW ~ error * input_activity
 ```
 
-In FabricPC, local gradients are computed by `compute_local_weight_gradients`, then an Optax optimizer (e.g., Adam, SGD) applies the updates:
+In FabricPC, local gradients are computed by `compute_local_weight_gradients` (batch-summed), divided once by the batch's prediction count in the trainer's `pc_weight_gradients`, and then an Optax optimizer (e.g., Adam, SGD) applies the updates:
 
 ```python
 import optax

--- a/docs/user_guides/06_custom_nodes.md
+++ b/docs/user_guides/06_custom_nodes.md
@@ -261,7 +261,7 @@ Within that constraint, every `forward()` must perform these five steps in order
 2. **Compute the error**: `error = state.z_latent - z_mu`. The energy functionals assume this sign (latent minus prediction).
 3. **Write the fields back**: `state = state._replace(z_mu=..., error=...)`. `NodeState` is a fixed-schema NamedTuple (`z_latent, z_mu, error, energy, latent_grad`); no other fields exist or may be added.
 4. **Populate energy**: `node_class = node_info.node_class; state = node_class.energy_functional(state, node_info)`. This sets `state.energy` from `energy(z_latent, z_mu)`, so `z_mu` must already be set. Extra energy terms (for example the Hopfield attractor term in `StorkeyHopfield`) are added by replacing `state.energy` after this call.
-5. **Return**: the updated `NodeState`. The `energy` field stays per-sample (shape `(batch,)`); summation over the batch dimension is owned by `forward_and_latent_grads()`/`forward_and_weight_grads()`, which need the resulting scalar for autodiff.
+5. **Return**: the updated `NodeState`. The `energy` field stays per-sample (shape `(batch,)`); summation over the batch dimension is owned by `forward_and_latent_grads()`/`forward_and_weight_grads()`, which need the resulting scalar for autodiff. The weight gradients therefore leave the node batch-summed; the trainer's `pc_weight_gradients` divides them once by the prediction count (`grad_denominator`) before they reach the optimizer.
 
 The steps *between* predicting `z_mu` and writing it back are free: input aggregation, weights and biases, the choice of activation, and any internal sub-structure are all node-specific.
 
@@ -355,7 +355,7 @@ The mixin provides:
 
 1. **In-degree-0 nodes are handled specially**, without calling `forward()`: `z_mu <- z_latent` (cast to `z_mu`'s dtype); error and all gradients are zero; energy is `E(z_latent, z_latent)` from the node's energy functional.
 2. **Every node with in-degree > 0 goes through `forward()`**. For unclamped out-degree-0 nodes the forward's `z_mu` is kept and written into `z_latent` (outputs track predictions in evaluation mode); error, energy, and all gradients are zeroed.
-3. **The per-sample `state.energy` (shape `(batch,)`) is summed over the batch dimension** to a scalar.
+3. **The per-sample `state.energy` (shape `(batch,)`) is summed over the batch dimension** to a scalar. The resulting weight gradients are batch sums; `fabricpc.training.pc_weight_gradients` divides them once by the prediction count so the optimizer sees means per prediction.
 4. **`jax.value_and_grad` differentiates that scalar** w.r.t. the input tensors and `z_latent`.
 
 It returns `(NodeState, input_grads, self_grad)`: the updated state, gradients w.r.t. each input edge (dE/d_input, unscaled), and this node's dE/dz_latent contribution (unscaled). muPC scaling and accumulation into `state.latent_grad` are handled by the callsite (the inference loop).

--- a/docs/user_guides/07_optimizers.md
+++ b/docs/user_guides/07_optimizers.md
@@ -36,6 +36,20 @@ opt_state = optimizer.init(params)
 params, opt_state, metrics, _ = train_step(params, opt_state, batch, rng_key)
 ```
 
+## Gradient Scale
+
+The gradients that reach Optax are means per prediction, under both
+`algorithm="pc"` and `"backprop"`. The trainer divides the batch-summed
+gradients once by the prediction count N, the number of clamped-target
+prediction positions in the batch (`batch` for classification, `batch *
+seq_len` for token targets). Learning rates, clipping thresholds, Adam
+epsilon, and the natural-gradient damping below therefore sit on the same
+scale as standard mean-loss training, and they transfer across batch sizes and
+sequence lengths. A custom loop that builds its own step gets the same scale
+from `fabricpc.training.pc_weight_gradients(params, state, structure, clamps)`,
+or from `fabricpc.training.grad_denominator(structure, clamps)` for the count
+itself.
+
 ## Chaining Transforms
 
 Optax transforms compose via `optax.chain()`:
@@ -64,7 +78,13 @@ optimizer = optax.adam(schedule)
 
 ## Natural Gradient Transforms
 
-FabricPC provides two natural gradient transforms in `fabricpc.training.natural_gradients`:
+FabricPC provides two natural gradient transforms in `fabricpc.training.natural_gradients`.
+Both divide the gradient by an online diagonal Fisher estimate F, an
+exponential moving average (EMA) of the squared gradient, bias-corrected for
+the EMA's zero start (`F / (1 - fisher_decay**t)` after `t` steps, as Adam
+corrects its second moment). Follow them with `optax.scale(-lr)` to apply a
+step size; the presets in `examples/mnist_advanced.py` show calibrated
+constants.
 
 **Diagonal Fisher preconditioning**:
 
@@ -72,12 +92,12 @@ FabricPC provides two natural gradient transforms in `fabricpc.training.natural_
 from fabricpc.training.natural_gradients import scale_by_natural_gradient_diag
 
 optimizer = optax.chain(
-    scale_by_natural_gradient_diag(fisher_decay=0.95, damping=1e-3),
-    optax.adam(1e-3),
+    scale_by_natural_gradient_diag(fisher_decay=0.95, relative_damping=0.1),
+    optax.scale(-1e-3),
 )
 ```
 
-Uses an EMA diagonal Fisher approximation. More expressive but higher memory.
+One Fisher entry per parameter. More expressive but higher memory.
 
 **Layer-wise Fisher preconditioning**:
 
@@ -85,20 +105,59 @@ Uses an EMA diagonal Fisher approximation. More expressive but higher memory.
 from fabricpc.training.natural_gradients import scale_by_natural_gradient_layerwise
 
 optimizer = optax.chain(
-    scale_by_natural_gradient_layerwise(fisher_decay=0.95, damping=1e-3),
-    optax.adam(1e-3),
+    scale_by_natural_gradient_layerwise(fisher_decay=0.95, relative_damping=0.1),
+    optax.scale(-1e-3),
 )
 ```
 
-One scalar Fisher estimate per parameter tensor. Cheaper and more stable for large tensors.
+One scalar Fisher estimate per parameter tensor (the EMA of the tensor's mean
+squared gradient). Cheaper and more stable for large tensors.
 
 Parameters for both:
-- `fisher_decay` — EMA decay for Fisher estimate, in [0, 1). Default: 0.95
-- `damping` — Positive damping added to the Fisher. Default: 1e-3
+- `fisher_decay` — EMA decay for the Fisher estimate, in [0, 1). Default: 0.95
+- `relative_damping` — damping as a fraction of the mean Fisher entry, >= 0.
+  Default: 0.1
+- `damping` — absolute damping added to the denominator, >= 0. Default: 0
+  (off). At least one of the two damping terms must be positive.
+
+**Why the damping is relative.** The update `g / F` is covariant: scaling
+every gradient by a constant c scales F by c² and the update by 1/c. The
+damping reference is r = trace(F) / dim, the mean bias-corrected Fisher entry
+over the whole parameter pytree (for the layer-wise transform each tensor's
+scalar counts with weight equal to the tensor's size, so both transforms use
+the same r), and the update is `g / (F + relative_damping * r)`. Both
+denominator terms scale by c², so the update still scales by exactly 1/c and
+the set of parameters where damping dominates the Fisher does not depend on
+the gradient scale. An absolute damping constant would pin that regime to one
+gradient scale: with gradients N times smaller, F shrinks N² times and the
+constant silently takes over, turning the transform into plain SGD. With
+`damping = 0` no constant is added to the denominator; if every gradient seen
+so far is zero the update is zero.
+
+**Limitations of the present implementations.** F is the squared *mean*
+gradient of the batch, not a per-sample Fisher, so `g / F` is about `1 / g`:
+the entries with the largest gradients get the smallest steps, and the step
+grows relative to the gradient as training shrinks it. On the MNIST demo
+(`examples/mnist_advanced.py`, a four-layer sigmoid MLP) neither transform left
+chance accuracy in 10 epochs with relative damping alone, at any of 48 tried
+combinations of `optax.scale`, `relative_damping`, and a global-norm clip,
+while `optax.adamw` reaches 97% on the same graph. The demo's `ngd_diag` and
+`ngd_layerwise` presets use `relative_damping=0` with an absolute `damping`
+that, measured, lies above 96.5% of the Fisher entries from the first step:
+those entries are updated as SGD with rate `scale / damping`, and only the few
+large-gradient entries receive the natural-gradient step. Even so `ngd_diag`
+reaches 24% at 10 epochs and `ngd_layerwise` stays at chance. Use these
+transforms as research baselines, not as tuned optimizers. The measurements
+are recorded in `docs/dev_plans_archive/mean_gradient_normalization.md`.
 
 ## Practical Guidance
 
 - **Default**: `optax.adamw(1e-3, weight_decay=0.1)` is a good starting point
 - **Weight decay**: 0.001–0.1 depending on model size
-- **Learning rate**: 1e-3 for Adam/AdamW, 0.01–0.1 for SGD with momentum
+- **Learning rate**: 1e-3 for Adam/AdamW. SGD rates depend on the gradient
+  scale: on per-prediction PC gradients the MNIST demo's `sgd` preset uses
+  `optax.sgd(2.0, momentum=0.9)` with `add_decayed_weights(5e-4)`. A rate
+  tuned before the per-prediction normalization (on batch-summed gradients)
+  is multiplied by the prediction count N, and a coupled weight decay divided
+  by N.
 - Natural gradient transforms are experimental; useful for research comparisons

--- a/docs/user_guides/07_optimizers.md
+++ b/docs/user_guides/07_optimizers.md
@@ -78,13 +78,13 @@ optimizer = optax.adam(schedule)
 
 ## Natural Gradient Transforms
 
-FabricPC provides two natural gradient transforms in `fabricpc.training.natural_gradients`.
-Both divide the gradient by an online diagonal Fisher estimate F, an
-exponential moving average (EMA) of the squared gradient, bias-corrected for
-the EMA's zero start (`F / (1 - fisher_decay**t)` after `t` steps, as Adam
-corrects its second moment). Follow them with `optax.scale(-lr)` to apply a
-step size; the presets in `examples/mnist_advanced.py` show calibrated
-constants.
+FabricPC provides two natural-gradient-style transforms in
+`fabricpc.training.natural_gradients`. Both divide the gradient by an online
+diagonal Fisher estimate F, an exponential moving average (EMA) of the squared
+gradient, bias-corrected for the EMA's zero start (`F / (1 - fisher_decay**t)`
+after `t` steps, as Adam corrects its second moment). Follow them with
+`optax.scale(-lr)` to apply a step size; the presets in
+`examples/mnist_advanced.py` carry constants swept on the MNIST demo.
 
 **Diagonal Fisher preconditioning**:
 
@@ -92,7 +92,7 @@ constants.
 from fabricpc.training.natural_gradients import scale_by_natural_gradient_diag
 
 optimizer = optax.chain(
-    scale_by_natural_gradient_diag(fisher_decay=0.95, relative_damping=0.1),
+    scale_by_natural_gradient_diag(fisher_decay=0.95, damping=1e-8),
     optax.scale(-1e-3),
 )
 ```
@@ -105,50 +105,36 @@ One Fisher entry per parameter. More expressive but higher memory.
 from fabricpc.training.natural_gradients import scale_by_natural_gradient_layerwise
 
 optimizer = optax.chain(
-    scale_by_natural_gradient_layerwise(fisher_decay=0.95, relative_damping=0.1),
+    scale_by_natural_gradient_layerwise(fisher_decay=0.95, damping=1e-8),
     optax.scale(-1e-3),
 )
 ```
 
 One scalar Fisher estimate per parameter tensor (the EMA of the tensor's mean
-squared gradient). Cheaper and more stable for large tensors.
+squared gradient). Cheaper for large tensors.
 
 Parameters for both:
 - `fisher_decay` — EMA decay for the Fisher estimate, in [0, 1). Default: 0.95
-- `relative_damping` — damping as a fraction of the mean Fisher entry, >= 0.
-  Default: 0.1
-- `damping` — absolute damping added to the denominator, >= 0. Default: 0
-  (off). At least one of the two damping terms must be positive.
+- `damping` — positive constant added to the Fisher. Default: 1e-8,
+  chosen on the MNIST demo at the per-prediction gradient scale, where
+  gradients of about 1e-3 per weight give Fisher entries of about 1e-6.
 
-**Why the damping is relative.** The update `g / F` is covariant: scaling
-every gradient by a constant c scales F by c² and the update by 1/c. The
-damping reference is r = trace(F) / dim, the mean bias-corrected Fisher entry
-over the whole parameter pytree (for the layer-wise transform each tensor's
-scalar counts with weight equal to the tensor's size, so both transforms use
-the same r), and the update is `g / (F + relative_damping * r)`. Both
-denominator terms scale by c², so the update still scales by exactly 1/c and
-the set of parameters where damping dominates the Fisher does not depend on
-the gradient scale. An absolute damping constant would pin that regime to one
-gradient scale: with gradients N times smaller, F shrinks N² times and the
-constant silently takes over, turning the transform into plain SGD. With
-`damping = 0` no constant is added to the denominator; if every gradient seen
-so far is zero the update is zero.
-
-**Limitations of the present implementations.** F is the squared *mean*
-gradient of the batch, not a per-sample Fisher, so `g / F` is about `1 / g`:
-the entries with the largest gradients get the smallest steps, and the step
-grows relative to the gradient as training shrinks it. On the MNIST demo
-(`examples/mnist_advanced.py`, a four-layer sigmoid MLP) neither transform left
-chance accuracy in 10 epochs with relative damping alone, at any of 48 tried
-combinations of `optax.scale`, `relative_damping`, and a global-norm clip,
-while `optax.adamw` reaches 97% on the same graph. The demo's `ngd_diag` and
-`ngd_layerwise` presets use `relative_damping=0` with an absolute `damping`
-that, measured, lies above 96.5% of the Fisher entries from the first step:
-those entries are updated as SGD with rate `scale / damping`, and only the few
-large-gradient entries receive the natural-gradient step. Even so `ngd_diag`
-reaches 24% at 10 epochs and `ngd_layerwise` stays at chance. Use these
-transforms as research baselines, not as tuned optimizers. The measurements
-are recorded in `docs/dev_plans_archive/mean_gradient_normalization.md`.
+**What the update is.** With `f` the bias-corrected Fisher entry, the update is
+`g / (f + damping)`. Where `damping` dominates `f`, the update is
+`g / damping`: SGD with learning rate `scale / damping`. Where `f` dominates, `f` is
+about `g²`, because it is built from the squared mean gradient of the batch
+rather than from per-sample gradients, so the update is about `1 / g`: the
+entries with the largest gradients move least, and the step grows relative to
+the gradient as training shrinks it. Neither regime is a natural-gradient step,
+and no damping value produces one: a smaller value moves more entries into the
+`1 / g` regime, a larger value into SGD. At the default the damping exceeds 95%
+of the Fisher entries from the first step of the MNIST demo, so both transforms
+act as SGD on almost every parameter; `ngd_diag` reaches 16% and
+`ngd_layerwise` stays at chance (10%) at 10 epochs, against 97% for
+`optax.adamw`. Treat them as research baselines. The estimator redesign, a
+Fisher from per-sample gradients at latents sampled from each node's predictive
+distribution, is tracked in [issue 68](https://github.com/trueagi-
+io/FabricPC/issues/68).
 
 ## Practical Guidance
 

--- a/docs/user_guides/08_training_and_evaluation.md
+++ b/docs/user_guides/08_training_and_evaluation.md
@@ -38,7 +38,10 @@ output node's energy functional in the graph definition selects the loss.**
 "Per prediction" means divided by N, the prediction count: the total number
 of clamped-target prediction positions in the batch (`batch` for
 classification, `batch * seq_len` for token targets; `batch` when the graph
-has no clamped target). Both algorithms divide their objective and their
+has no clamped target). With several clamped target heads N is the sum of
+their prediction positions (two same-shape heads give N = 2 * batch), so
+adding a head halves the step every shared parameter takes at a fixed
+learning rate. Both algorithms divide their objective and their
 gradients by the same N, so a learning rate, clipping threshold, or Adam
 epsilon means the same under either algorithm and across batch sizes and
 sequence lengths. `fabricpc.training.grad_denominator(structure, clamps)`
@@ -184,7 +187,7 @@ energy framing:
 | `accuracy` | always | `argmax(z_mu, -1)` compared to `argmax(y, -1)` for one-hot targets (same rank as `z_mu`), or directly to integer class labels of lower rank; per prediction (argmax-based: meaningful for class-like targets, not continuous ones) |
 | `cross_entropy` | target functional is `CrossEntropyEnergy` | identical to `target_energy` in that case; the conventional name |
 | `perplexity` | target functional is `CrossEntropyEnergy` | `exp(cross_entropy)` |
-| `energy` | `algorithm="pc"` | per-sample energy over internal nodes — the PC training objective's definition |
+| `energy` | `algorithm="pc"` | internal energy per prediction, the PC training objective's scale |
 
 A graph with no target task key raises under the defaults; pass an explicit
 metrics dict to evaluate such a graph.

--- a/docs/user_guides/08_training_and_evaluation.md
+++ b/docs/user_guides/08_training_and_evaluation.md
@@ -25,7 +25,7 @@ inside the step:
 | sub-step | PC | backprop |
 |---|---|---|
 | produce state | initialize, then settle the latents via `run_inference` | single feedforward pass (`FeedforwardStateInit`), no inference |
-| objective | energy summed over all internal (`in_degree > 0`) nodes, per sample | energy of the clamped target nodes, per sample |
+| objective | energy summed over all internal (`in_degree > 0`) nodes, per prediction | energy of the clamped target nodes, per prediction |
 | gradients | local per-node Hebbian gradients | `jax.value_and_grad` through the forward pass |
 
 The backprop objective is the clamped target node's energy — the negative log
@@ -33,7 +33,17 @@ probability the output node's energy functional assigns to the clamped target
 given the feedforward prediction. There is no `loss_type` option: **the
 output node's energy functional in the graph definition selects the loss.**
 `CrossEntropyEnergy()` on the output gives cross-entropy training;
-`GaussianEnergy(precision=p)` gives `0.5 * p * ||y - mu||^2` per sample.
+`GaussianEnergy(precision=p)` gives `0.5 * p * ||y - mu||^2` per prediction.
+
+"Per prediction" means divided by N, the prediction count: the total number
+of clamped-target prediction positions in the batch (`batch` for
+classification, `batch * seq_len` for token targets; `batch` when the graph
+has no clamped target). Both algorithms divide their objective and their
+gradients by the same N, so a learning rate, clipping threshold, or Adam
+epsilon means the same under either algorithm and across batch sizes and
+sequence lengths. `fabricpc.training.grad_denominator(structure, clamps)`
+returns N, and `fabricpc.training.pc_weight_gradients` is the PC gradient
+already divided by it, for custom loops.
 
 Integer or bool targets are one-hot encoded automatically from their dtype
 (with the class count taken from the target node's last shape axis), so token
@@ -104,16 +114,14 @@ Each step produces two device scalars, materialized to floats at epoch
 boundaries (or per batch when `verbose=True` or an `iter_callback` is
 supplied — both force a per-batch device sync):
 
-- `energy` — the per-sample objective the gradients descend. This is
-  **algorithm-dependent** (all internal nodes for PC, target nodes only for
-  backprop), so comparing it across algorithms is invalid.
+- `energy` — the objective the gradients descend, per prediction. Its node
+  set is **algorithm-dependent** (all internal nodes for PC, target nodes
+  only for backprop), so comparing it across algorithms compares different
+  node sets; under backprop it equals `target_energy`.
 - `target_energy` — the target-node energy divided by the number of
   predictions (`batch * seq_len` for sequences, `batch` for classification).
   Under `CrossEntropyEnergy` this is the teacher-forced per-token
   cross-entropy, so `exp(target_energy)` is the training perplexity.
-
-Note the two keys use different normalizations (per sample vs per
-prediction).
 
 ## Callbacks
 

--- a/docs/user_guides/09_experiment_tracking.md
+++ b/docs/user_guides/09_experiment_tracking.md
@@ -190,8 +190,8 @@ for epoch in range(num_epochs):
             stacked_history, collect_every=collect_every
         )
 
-        # energy is already the per-sample objective (graph_energy over
-        # internal nodes / batch size) — no further normalization.
+        # energy is the objective per prediction (graph_energy over
+        # internal nodes / prediction count) — no further normalization.
         tracker.track_batch_energy(float(energy), epoch, batch_idx)
         tracker.track_batch_energy_per_node(final_state, structure, epoch, batch_idx)
 

--- a/examples/mnist_advanced.py
+++ b/examples/mnist_advanced.py
@@ -105,34 +105,24 @@ OPTIMIZER_PRESETS = {
     "sgd": lambda: optax.chain(
         optax.add_decayed_weights(5e-4), optax.sgd(2.0, momentum=0.9)
     ),
-    # Natural-gradient presets: the exact per-prediction analog of the former
-    # summed-gradient constants (damping 1e-3, scale 3e-4 and 1e-3). F shrinks
-    # by N**2 and g by N, so damping / N**2 and scale / N give the same
-    # trajectory up to the Fisher EMA's new bias correction in the first steps
-    # (10 epochs, RTX 3090: ngd_diag 23.78% vs 25.25% on the parent commit,
-    # ngd_layerwise 9.74% on both). relative_damping is 0 here because the
-    # default 0.1 adds a term about 30x this absolute damping and changes the
-    # regime (both presets then stay at chance). Measured regime for ngd_diag:
-    # from the first step 96.5% of Fisher entries lie below the damping and are
-    # updated as SGD with rate scale / damping = 60; the remaining entries
-    # (0.3% by step 300) hold essentially all of trace(F) and get the 1 / g
-    # natural-gradient step. With relative damping alone neither transform
-    # left chance accuracy on this demo in 10 epochs at any of 48 settings.
-    # See fabricpc.training.natural_gradients and
-    # docs/dev_plans_archive/mean_gradient_normalization.md.
+    # Natural-gradient presets. The transforms' Fisher is the squared mean
+    # gradient (see fabricpc.training.natural_gradients): where the damping
+    # dominates it the update is SGD with rate scale / damping, elsewhere about
+    # 1 / g. At the default damping (1e-8) 95% of the Fisher entries sit below
+    # it at step 1 and 99.7% after one epoch, so these presets run as SGD with
+    # rate 60 (diag) and 200 (layerwise) on almost every weight. Swept on this
+    # graph over damping 1e-8..1e-4 and scale / damping 20..2000 at 10 epochs:
+    # ngd_diag 16.27%, ngd_layerwise 10.28% (chance) (adamw 97%);
+    # no setting did better. Issue 68 tracks the estimator fix.
     "ngd_diag": lambda: optax.chain(
         optax.add_decayed_weights(5e-4),
-        scale_by_natural_gradient_diag(
-            fisher_decay=0.95, relative_damping=0.0, damping=1e-3 / batch_size**2
-        ),
-        optax.scale(-0.0003 / batch_size),
+        scale_by_natural_gradient_diag(),
+        optax.scale(-6e-7),
     ),
     "ngd_layerwise": lambda: optax.chain(
         optax.add_decayed_weights(5e-4),
-        scale_by_natural_gradient_layerwise(
-            fisher_decay=0.95, relative_damping=0.0, damping=1e-3 / batch_size**2
-        ),
-        optax.scale(-0.001 / batch_size),
+        scale_by_natural_gradient_layerwise(),
+        optax.scale(-2e-6),
     ),
 }
 

--- a/examples/mnist_advanced.py
+++ b/examples/mnist_advanced.py
@@ -11,6 +11,7 @@ Architecture::
 
 Usage:
     PYTHONPATH=. python examples/mnist_advanced.py --optimizer adamw
+    PYTHONPATH=. python examples/mnist_advanced.py --optimizer sgd --num_epochs 2
     FABRICPC_OPTIMIZER=ngd_diag PYTHONPATH=. python examples/mnist_advanced.py
 """
 
@@ -96,18 +97,42 @@ num_epochs = 10
 OPTIMIZER_PRESETS = {
     "adam": lambda: optax.chain(optax.adam(0.001)),
     "adamw": lambda: optax.adamw(0.001, weight_decay=0.1),
+    # The trainer hands optax mean gradients per prediction (summed gradients
+    # / N, N = batch_size = 200 here). Coupled L2 with SGD applies
+    # lr * (g + wd * theta); the former summed-gradient constants lr = 0.01,
+    # wd = 0.1 rescale exactly to lr * N = 2.0 and wd / N = 5e-4, and the
+    # momentum trace is linear, so the trajectory is unchanged.
     "sgd": lambda: optax.chain(
-        optax.add_decayed_weights(0.1), optax.sgd(0.01, momentum=0.9)
+        optax.add_decayed_weights(5e-4), optax.sgd(2.0, momentum=0.9)
     ),
+    # Natural-gradient presets: the exact per-prediction analog of the former
+    # summed-gradient constants (damping 1e-3, scale 3e-4 and 1e-3). F shrinks
+    # by N**2 and g by N, so damping / N**2 and scale / N give the same
+    # trajectory up to the Fisher EMA's new bias correction in the first steps
+    # (10 epochs, RTX 3090: ngd_diag 23.78% vs 25.25% on the parent commit,
+    # ngd_layerwise 9.74% on both). relative_damping is 0 here because the
+    # default 0.1 adds a term about 30x this absolute damping and changes the
+    # regime (both presets then stay at chance). Measured regime for ngd_diag:
+    # from the first step 96.5% of Fisher entries lie below the damping and are
+    # updated as SGD with rate scale / damping = 60; the remaining entries
+    # (0.3% by step 300) hold essentially all of trace(F) and get the 1 / g
+    # natural-gradient step. With relative damping alone neither transform
+    # left chance accuracy on this demo in 10 epochs at any of 48 settings.
+    # See fabricpc.training.natural_gradients and
+    # docs/dev_plans_archive/mean_gradient_normalization.md.
     "ngd_diag": lambda: optax.chain(
-        optax.add_decayed_weights(0.1),
-        scale_by_natural_gradient_diag(fisher_decay=0.95, damping=1e-3),
-        optax.scale(-0.0003),
+        optax.add_decayed_weights(5e-4),
+        scale_by_natural_gradient_diag(
+            fisher_decay=0.95, relative_damping=0.0, damping=1e-3 / batch_size**2
+        ),
+        optax.scale(-0.0003 / batch_size),
     ),
     "ngd_layerwise": lambda: optax.chain(
-        optax.add_decayed_weights(0.1),
-        scale_by_natural_gradient_layerwise(fisher_decay=0.95, damping=1e-3),
-        optax.scale(-0.001),
+        optax.add_decayed_weights(5e-4),
+        scale_by_natural_gradient_layerwise(
+            fisher_decay=0.95, relative_damping=0.0, damping=1e-3 / batch_size**2
+        ),
+        optax.scale(-0.001 / batch_size),
     ),
 }
 
@@ -124,6 +149,12 @@ def parse_args() -> argparse.Namespace:
             f"Choices: {', '.join(OPTIMIZER_PRESETS.keys())}. "
             "CLI flag overrides FABRICPC_OPTIMIZER."
         ),
+    )
+    parser.add_argument(
+        "--num_epochs",
+        type=int,
+        default=num_epochs,
+        help=f"Training epochs (default: {num_epochs})",
     )
     args = parser.parse_args()
     if args.optimizer.lower() not in OPTIMIZER_PRESETS:
@@ -146,6 +177,7 @@ def get_optimizer(name: str) -> optax.GradientTransformation:
 if __name__ == "__main__":
     args = parse_args()
     optimizer = get_optimizer(args.optimizer)
+    num_epochs = args.num_epochs
 
     master_rng_key = jax.random.PRNGKey(42)
     graph_key, train_key, eval_key = jax.random.split(master_rng_key, 3)

--- a/examples/mnist_aim_tracking.py
+++ b/examples/mnist_aim_tracking.py
@@ -206,9 +206,9 @@ for epoch in range(num_epochs):
             stacked_history, collect_every=INFERENCE_COLLECT_EVERY
         )
 
-        # train_step_with_history returns the per-sample internal energy
-        # (graph_energy over in_degree>0 nodes / batch_size) — no further
-        # normalization needed.
+        # train_step_with_history returns the training objective per
+        # prediction (graph_energy over in_degree>0 nodes / prediction count,
+        # = batch_size for MNIST) — no further normalization needed.
         normalized_energy = float(energy)
         epoch_energies.append(normalized_energy)
 

--- a/examples/transformer_demo.py
+++ b/examples/transformer_demo.py
@@ -20,16 +20,16 @@ Usage:
     python examples/transformer_demo.py --mode backprop --lr 1e-3 --num_epochs 3
     python examples/transformer_demo.py --mode pc --num_blocks 2
 
-Results: PC training (cuda13, rtx3090, jax 0.10.2, can vary a few points in perplexity in different jax versions / hardware due to sensitivity to floating point rounding)
-Final train energy: 352.9587
-Test loss: 2.6988, Perplexity: 14.86
+Results: PC training (cuda13, rtx3090, jax 0.10.1, can vary a few points in perplexity in different jax versions / hardware due to sensitivity to floating point rounding)
+Final train energy: 2.2656 (internal energy per token)
+Test loss: 2.6846, Perplexity: 14.65
 Prompt: 'ROMEO: '
 ----------------------------------------
-ROMEO: hooofo!eoooraoathe o
+ROMEO: hirifo!Borerenoooroo
 ----------------------------------------
 
-Backprop Training
-Test loss: 1.8867, Perplexity: 6.60
+Backprop Training (python examples/transformer_demo.py --mode backprop)
+Test loss: 1.8846, Perplexity: 6.58
 Prompt: 'ROMEO: '
 ----------------------------------------
 ROMEO: his.fe!
@@ -133,9 +133,22 @@ def parse_args():
     parser.add_argument(
         "--eta_infer", type=float, default=0.1, help="PC inference step size"
     )
-    parser.add_argument("--lr", type=float, default=1e-4, help="Learning rate")
+    parser.add_argument(
+        "--lr",
+        type=float,
+        default=None,
+        help="Peak learning rate (default: 3e-5 for pc, 1e-4 for backprop)",
+    )
     parser.add_argument("--seed", type=int, default=42, help="Random seed")
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.lr is None:
+        # Gradients are means per token, so the 0.8 clip no longer normalizes
+        # every PC step as it did on batch-summed gradients; at 1e-4 the PC
+        # run destabilized after ~3500 steps, and 3e-5 holds the full epoch
+        # (perplexity 14.65 vs 14.86 before the normalization). Backprop is
+        # unaffected by the rescale and keeps 1e-4.
+        args.lr = 3e-5 if args.mode == "pc" else 1e-4
+    return args
 
 
 # --- Model Configuration ---
@@ -523,9 +536,10 @@ def main(args=None):
                 params, opt_state, metrics, final_state = train_step(
                     params, opt_state, batch, batch_keys[batch_idx]
                 )
-                # PC tracks the settling objective (per-sample internal
-                # energy); backprop tracks the per-token cross-entropy
-                # (target_energy under CrossEntropyEnergy).
+                # PC tracks the settling objective (internal energy per
+                # token); backprop tracks the per-token cross-entropy
+                # (target_energy under CrossEntropyEnergy). Both are means
+                # over the batch's B * seq_len prediction positions.
                 loss_val = float(
                     metrics["energy"] if use_pc else metrics["target_energy"]
                 )

--- a/examples/transformer_v2_demo.py
+++ b/examples/transformer_v2_demo.py
@@ -24,27 +24,23 @@ Usage:
     PYTHONPATH=. python examples/transformer_v2_demo.py --mode pc --depth 6 --num_epochs 10
 
 
-Results (pre-0.5 trainer, default call, cuda12, rtx3090, jax 0.8.1, can vary
+Results (default call, cuda12, rtx3090, jax 0.10.1, can vary
 a few points in perplexity in different jax versions / hardware due to
-sensitivity to floating point rounding). The 0.5 unified trainer prints
-`Epoch i/N — energy: ..., target_energy: ...` per epoch, changes the
-per-epoch energy normalization, and fixes the transformer eval numerics
-(double softmax, external SSE term — see the 0.5.0 CHANGELOG), so these
-numbers are a historical baseline until re-measured under 0.5:
+sensitivity to floating point rounding).
 Model parameters: 108,353
 Vocab Size: 65
-Train Epoch 1/5, Energy: 274.3637, Loss: 2.1401, Perplexity: 8.50
-Train Epoch 2/5, Energy: 260.0219, Loss: 2.0280, Perplexity: 7.60
-Train Epoch 3/5, Energy: 250.6280, Loss: 1.9546, Perplexity: 7.06
-Train Epoch 4/5, Energy: 244.7030, Loss: 1.9089, Perplexity: 6.75
-Train Epoch 5/5, Energy: 242.0046, Loss: 1.8878, Perplexity: 6.61
-Training completed in 8772.4s
-Evaluation completed in 55.2s
-Test Accuracy:   35.92%
-Test CE Loss:    2.2108
-Test Perplexity: 9.12
+Epoch 1/5 — energy: 2.1198, target_energy: 2.1165
+Epoch 2/5 — energy: 1.9861, target_energy: 1.9826
+Epoch 3/5 — energy: 2.0056, target_energy: 2.0024
+Epoch 4/5 — energy: 1.9770, target_energy: 1.9741
+Epoch 5/5 — energy: 1.9691, target_energy: 1.9663
+Training completed in 8730.8s
+Evaluation completed in 43.7s
+Test Accuracy:   33.43%
+Test CE Loss:    2.3383
+Test Perplexity: 10.36
 --- Generating ---
-ROMEO: whou sarone the bro beariers thas tray sucas a st my lo the to ate.
+ROMEO: marencan net s ieat aceaimes thall dathak: Tha blag an wince'd ate.
 """
 
 import argparse

--- a/fabricpc/core/learning.py
+++ b/fabricpc/core/learning.py
@@ -15,13 +15,22 @@ def compute_local_weight_gradients(
     muPC scaling is applied here (pre-scale inputs, post-scale weight
     gradients), keeping node methods (forward_and_weight_grads) scaling-unaware.
 
+    The returned gradients are batch-summed: each node's
+    ``forward_and_weight_grads`` differentiates the sum of its per-sample
+    energies over the batch. Sums are associative, so they survive data
+    sharding and gradient accumulation unchanged. The trainer's
+    ``fabricpc.training.pc_weight_gradients`` divides them once by the
+    prediction count ``fabricpc.training.grad_denominator``, whose docstring
+    carries the rule for microbatching and padded positions. Optimizer-facing
+    callers use that function; this one serves inspection and composition.
+
     Args:
         params: Current model parameters
         final_state: Converged state after inference
         structure: Graph structure
 
     Returns:
-        GraphParams containing gradients for the parameters
+        GraphParams containing batch-summed gradients for the parameters
     """
     gradients = {}
 

--- a/fabricpc/training/__init__.py
+++ b/fabricpc/training/__init__.py
@@ -18,7 +18,9 @@ from fabricpc.training.trainer import (
     convert_batch,
     create_causal_mask,
     evaluate,
+    grad_denominator,
     make_train_step,
+    pc_weight_gradients,
     train,
 )
 
@@ -30,6 +32,8 @@ __all__ = [
     "build_clamps",
     "convert_batch",
     "create_causal_mask",
+    "grad_denominator",
+    "pc_weight_gradients",
     "TrainResult",
     "EpochContext",
     "EvalMetric",

--- a/fabricpc/training/__init__.py
+++ b/fabricpc/training/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     "evaluate",
     "make_train_step",
     "generate",
+    "batch_size_of",
     "build_clamps",
     "convert_batch",
     "create_causal_mask",

--- a/fabricpc/training/__init__.py
+++ b/fabricpc/training/__init__.py
@@ -14,6 +14,7 @@ from fabricpc.training.metrics import EvalMetric
 from fabricpc.training.trainer import (
     EpochContext,
     TrainResult,
+    batch_size_of,
     build_clamps,
     convert_batch,
     create_causal_mask,

--- a/fabricpc/training/metrics.py
+++ b/fabricpc/training/metrics.py
@@ -16,7 +16,10 @@ A metric separates three concerns:
 
 ``default_metrics(structure, algorithm)`` derives the default metric set
 from the graph: the target node's own energy functional selects the loss and
-therefore the default eval metrics.
+therefore the default eval metrics. Every built-in metric weights a sample by
+its prediction positions (sequence length for token targets, 1 for
+classification), the same count the trainer divides by, so eval and training
+values share one per-prediction scale.
 """
 
 from typing import Any, Callable, Dict, List, NamedTuple, Tuple
@@ -61,20 +64,29 @@ def as_eval_metric(metric: Any) -> EvalMetric:
 # ---------------------------------------------------------------------------
 
 
-def _target_items(
+def _iter_target_items(
     structure: GraphStructure, batch: Dict[str, jnp.ndarray]
 ) -> List[Tuple[str, str]]:
-    """``(task_key, node_name)`` pairs for batch keys mapped to target nodes.
+    """``(task_key, node_name)`` pairs for batch keys mapped to target nodes;
+    empty when the batch carries no target key.
 
     A task key is a target iff its mapped node has ``in_degree > 0`` (source
     nodes carry inputs, not predictions).
     """
-    items = [
+    return [
         (key, structure.task_map[key])
         for key in batch
         if key in structure.task_map
         and structure.nodes[structure.task_map[key]].node_info.in_degree > 0
     ]
+
+
+def _target_items(
+    structure: GraphStructure, batch: Dict[str, jnp.ndarray]
+) -> List[Tuple[str, str]]:
+    """:func:`_iter_target_items`, raising when the batch has no target key:
+    the target metrics are undefined without one."""
+    items = _iter_target_items(structure, batch)
     if not items:
         raise ValueError(
             "No target task key: no batch key maps to an in_degree>0 node, so "
@@ -182,7 +194,10 @@ def _accuracy_fn(state, batch, structure):
 
 def _internal_energy_fn(state, batch, structure):
     """Per-sample energy summed over internal (``in_degree > 0``) nodes — the
-    same node set as the PC training objective; weight = 1 per sample.
+    same node set as the PC training objective; weight = prediction positions
+    per sample, summed over the batch's target keys (1 when the batch carries
+    no target key). The weights total the trainer's ``grad_denominator``, so
+    the eval ``energy`` is per prediction on the training objective's scale.
 
     Summation order matches :func:`fabricpc.core.energy.graph_energy`:
     ``structure.node_order`` first, then nodes the topological sort omitted
@@ -198,7 +213,12 @@ def _internal_energy_fn(state, batch, structure):
     value = jnp.zeros((state.batch_size,))
     for name in ordered:
         value = value + state.nodes[name].energy
-    return value, jnp.ones_like(value)
+    predictions = 0.0
+    for key, node_name in _iter_target_items(structure, batch):
+        y = _as_one_hot(batch[key], structure.nodes[node_name].node_info.shape[-1])
+        predictions += _predictions_per_sample(y)
+    weight = jnp.full_like(value, predictions if predictions > 0 else 1.0)
+    return value, weight
 
 
 # ---------------------------------------------------------------------------
@@ -217,7 +237,8 @@ def default_metrics(structure: GraphStructure, algorithm: str) -> Dict[str, Eval
 
     ``target_energy`` and ``accuracy`` always; ``cross_entropy`` and
     ``perplexity`` when a target node's energy functional is
-    ``CrossEntropyEnergy``; ``energy`` (per-sample internal energy) for PC.
+    ``CrossEntropyEnergy``; ``energy`` (internal energy per prediction, the
+    PC training objective's scale) for PC.
     Raises ``ValueError`` on a graph with no target task key — pass an
     explicit metrics dict to evaluate such a graph.
     """

--- a/fabricpc/training/metrics.py
+++ b/fabricpc/training/metrics.py
@@ -19,7 +19,7 @@ from the graph: the target node's own energy functional selects the loss and
 therefore the default eval metrics. Every built-in metric weights a sample by
 its prediction positions (sequence length for token targets, 1 for
 classification), the same count the trainer divides by, so eval and training
-values share one per-prediction scale.
+values share the same per-prediction scale.
 """
 
 from typing import Any, Callable, Dict, List, NamedTuple, Tuple

--- a/fabricpc/training/natural_gradients.py
+++ b/fabricpc/training/natural_gradients.py
@@ -1,61 +1,47 @@
 """Natural-gradient-style optimizer transforms for predictive coding training.
 
-Both transforms precondition the gradient with an online diagonal Fisher
-approximation, an exponential moving average (EMA) of the squared gradient,
-and compose with Optax chains, typically followed by ``optax.scale(-lr)``.
+Both transforms divide the gradient by an online diagonal Fisher estimate, an
+exponential moving average (EMA) of the squared gradient, and compose with
+Optax chains, typically followed by ``optax.scale(-lr)``. They are research
+baselines, not tuned optimizers; see the regimes below and
+https://github.com/trueagi-io/FabricPC/issues/68.
 
 Gradient scale. The trainer hands Optax mean gradients per prediction
 (``fabricpc.training.pc_weight_gradients`` divides the batch-summed gradients
-once by the prediction count), so the gradients reaching these transforms sit
-on the scale of standard mean-loss training.
+once by the prediction count), so ``damping`` is compared against Fisher
+entries on that scale: per-prediction gradients of g per weight give
+Fisher entries of g**2.
 
-Covariance. The natural-gradient update ``g / f`` is covariant: scaling every
-gradient by ``c`` scales ``f`` by ``c**2`` and the update by ``1/c``. Damping
-is therefore expressed relative to the Fisher itself. The damping reference is
-``r = trace(F) / dim``, the mean bias-corrected Fisher entry over the whole
-parameter pytree, and the update is
-``g / (f + relative_damping * r + damping)``. With ``damping = 0`` (the
-default) both denominator terms scale by ``c**2``, so the update scales by
-exactly ``1/c`` and the set of entries where damping dominates the Fisher does
-not depend on the gradient scale. No constant is added in that case: a zero
-denominator occurs only when every gradient seen so far is zero, and then the
-update is zero.
-
-Absolute damping. ``damping > 0`` adds a constant to the denominator. It
-breaks the covariance above and ties the transform to one gradient scale:
-wherever ``damping`` dominates ``f + relative_damping * r``, the update is
-``g / damping``, plain SGD with learning rate ``scale / damping``. It exists
-as an explicit opt-in because of the limitation below.
+Regimes. The update is ``g / (f + damping)``, with ``f`` the bias-corrected
+EMA of ``g**2``. Where ``damping`` dominates ``f`` the update is
+``g / damping``: plain SGD with learning rate ``scale / damping``. Where ``f``
+dominates, ``f`` is about ``g**2`` because it is built from the squared *mean*
+gradient of the batch rather than from per-sample gradients, so the update is
+about ``1 / g``: the entries with the largest gradients move least, and the
+step grows relative to the gradient as training shrinks it. Neither regime is
+a natural-gradient step, and no damping value produces one: a smaller value
+moves more entries into the ``1 / g`` regime, a larger one into SGD. The
+default ``damping`` is the value that trained best on
+``examples/mnist_advanced.py``; at that value the damping term exceeds almost
+every Fisher entry from the first step (measured fraction in the demo's preset
+comment), so the transforms act as SGD on almost every parameter. Choosing
+``damping`` chooses the regime. The defect is the estimator: a Fisher needs
+per-sample gradients at latents drawn from each node's predictive
+distribution, not the squared batch mean. That design is specified in issue 68.
 
 Bias correction. The EMA starts at zero, so after ``t`` steps it holds only
 ``1 - fisher_decay**t`` of a stationary ``g**2``. Both transforms divide by
 that factor (``t`` is the step count held in the state), so the first steps
 are not over-scaled.
-
-Limitations of the present implementations. ``F`` is built from the squared
-*mean* gradient of the batch, not from per-sample gradients, so ``g / F`` is
-about ``1 / g``: the entries with the largest gradients receive the smallest
-steps, and the step size grows relative to the gradient as training reduces
-it. On ``examples/mnist_advanced.py`` (a four-layer sigmoid MLP) neither
-transform left chance accuracy in 10 epochs with relative damping alone, at
-any of 48 combinations of ``optax.scale``, ``relative_damping``, and a global
-norm clip, while ``optax.adamw`` reaches 97% on the same graph. The demo
-presets that do train (weakly: 24% at 10 epochs) use ``relative_damping = 0``
-with an absolute ``damping`` that, measured on the diagonal transform, lies
-above 96.5% of the Fisher entries from the first step and above 99.7% by
-step 300: those entries are updated as SGD with rate ``scale / damping``,
-while the few large-gradient entries that hold the Fisher trace receive the
-``1 / g`` step. Treat these transforms as research baselines, not as tuned
-optimizers; the measurements are recorded in
-``docs/dev_plans_archive/mean_gradient_normalization.md``.
 """
 
-import operator
 from typing import Any, NamedTuple
 
 import jax
 import jax.numpy as jnp
 import optax
+
+DEFAULT_DAMPING = 1e-8
 
 
 class DiagonalNaturalGradientState(NamedTuple):
@@ -83,31 +69,24 @@ class LayerwiseNaturalGradientState(NamedTuple):
 
 def scale_by_natural_gradient_diag(
     fisher_decay: float = 0.95,
-    relative_damping: float = 0.1,
-    damping: float = 0.0,
+    damping: float = DEFAULT_DAMPING,
 ) -> optax.GradientTransformation:
     """Precondition updates with a bias-corrected EMA diagonal Fisher.
 
-    Each entry is divided by ``f + relative_damping * r + damping``, where
-    ``f`` is the bias-corrected EMA of ``g**2`` for that entry and ``r`` is
-    the mean of ``f`` over the whole parameter pytree. With ``damping = 0``,
-    scaling the gradients by ``c`` scales the update by ``1/c``.
+    Each entry is divided by ``f + damping``, where ``f`` is the
+    bias-corrected EMA of ``g**2`` for that entry.
 
     Args:
         fisher_decay: EMA decay for the Fisher estimate in [0, 1).
-        relative_damping: Damping as a fraction of the mean Fisher entry,
-            >= 0. Entries whose Fisher is well below ``relative_damping * r``
-            are updated as by SGD with step ``1 / (relative_damping * r)``.
-        damping: Absolute damping added to the denominator, >= 0. Where it
-            dominates, the update is ``g / damping`` (SGD with rate
-            ``scale / damping``); it ties the transform to one gradient
-            scale. At least one of ``relative_damping`` and ``damping`` must
-            be positive.
+        damping: Positive constant added to every Fisher entry. Where it
+            dominates ``f`` the update is ``g / damping``, SGD with rate
+            ``scale / damping``; where ``f`` dominates the update is about
+            ``1 / g``. See the module docstring.
 
     Returns:
         Optax gradient transformation.
     """
-    _validate_hparams(fisher_decay, relative_damping, damping)
+    _validate_hparams(fisher_decay, damping)
     one_minus_decay = 1.0 - fisher_decay
 
     def init_fn(params):
@@ -125,14 +104,8 @@ def scale_by_natural_gradient_diag(
             updates,
         )
         fisher_hat = _bias_corrected(fisher_diag, fisher_decay, count)
-        leaf_traces = jax.tree_util.tree_map(jnp.sum, fisher_hat)
-        total_damping = (
-            relative_damping * _mean_fisher_entry(leaf_traces, updates) + damping
-        )
         preconditioned_updates = jax.tree_util.tree_map(
-            lambda g, f: _divide_guarded(g, f + total_damping.astype(f.dtype)),
-            updates,
-            fisher_hat,
+            lambda g, f: g / (f + damping), updates, fisher_hat
         )
         return preconditioned_updates, DiagonalNaturalGradientState(
             count=count, fisher_diag=fisher_diag
@@ -143,30 +116,23 @@ def scale_by_natural_gradient_diag(
 
 def scale_by_natural_gradient_layerwise(
     fisher_decay: float = 0.95,
-    relative_damping: float = 0.1,
-    damping: float = 0.0,
+    damping: float = DEFAULT_DAMPING,
 ) -> optax.GradientTransformation:
     """Precondition each tensor by one bias-corrected scalar Fisher per leaf.
 
     A cheap layer-wise approximation: each leaf's scalar is the EMA of
-    ``mean(g**2)`` over the leaf. The leaf is divided by
-    ``f + relative_damping * r + damping`` with ``r`` the mean Fisher entry
-    over the whole pytree, where each leaf's scalar counts with weight equal
-    to the leaf's size (the same ``trace(F) / dim`` the diagonal transform
-    uses). With ``damping = 0``, scaling the gradients by ``c`` scales the
-    update by ``1/c``.
+    ``mean(g**2)`` over the leaf, and the leaf is divided by
+    ``f + damping``.
 
     Args:
         fisher_decay: EMA decay for the Fisher estimate in [0, 1).
-        relative_damping: Damping as a fraction of the mean Fisher entry, >= 0.
-        damping: Absolute damping added to the denominator, >= 0; where it
-            dominates, the update is ``g / damping``. At least one of
-            ``relative_damping`` and ``damping`` must be positive.
+        damping: Positive constant added to each leaf's Fisher scalar. The
+            regimes are those of :func:`scale_by_natural_gradient_diag`.
 
     Returns:
         Optax gradient transformation.
     """
-    _validate_hparams(fisher_decay, relative_damping, damping)
+    _validate_hparams(fisher_decay, damping)
     one_minus_decay = 1.0 - fisher_decay
 
     def init_fn(params):
@@ -186,17 +152,8 @@ def scale_by_natural_gradient_layerwise(
             updates,
         )
         fisher_hat = _bias_corrected(fisher_scalar, fisher_decay, count)
-        # Each leaf scalar stands for g.size Fisher entries.
-        leaf_traces = jax.tree_util.tree_map(
-            lambda f, g: f * g.size, fisher_hat, updates
-        )
-        total_damping = (
-            relative_damping * _mean_fisher_entry(leaf_traces, updates) + damping
-        )
         preconditioned_updates = jax.tree_util.tree_map(
-            lambda g, f: _divide_guarded(g, f + total_damping.astype(f.dtype)),
-            updates,
-            fisher_hat,
+            lambda g, f: g / (f + damping), updates, fisher_hat
         )
         return preconditioned_updates, LayerwiseNaturalGradientState(
             count=count, fisher_scalar=fisher_scalar
@@ -216,41 +173,9 @@ def _bias_corrected(fisher, fisher_decay: float, count: jax.Array):
     return jax.tree_util.tree_map(lambda f: f / factor.astype(f.dtype), fisher)
 
 
-def _mean_fisher_entry(leaf_traces, updates):
-    """``trace(F) / dim``: the mean Fisher entry over the whole pytree.
-
-    ``leaf_traces`` holds one scalar per leaf, the sum of that leaf's Fisher
-    entries. ``dim`` is the static parameter count read from ``updates``.
-    """
-    trace = jax.tree_util.tree_reduce(operator.add, leaf_traces)
-    dim = sum(g.size for g in jax.tree_util.tree_leaves(updates))
-    return trace / dim
-
-
-def _divide_guarded(g, denominator):
-    """``g / denominator`` with a zero denominator mapped to a zero update.
-
-    With ``damping = 0``, ``f + relative_damping * r`` is zero only when
-    every Fisher entry in the pytree is zero, which requires every gradient
-    seen so far, including this step's, to be zero. Then ``g`` is zero too,
-    and dividing by 1 instead gives the correct update without forming
-    ``0 / 0`` and without adding any constant to the denominator.
-    """
-    return g / jnp.where(denominator > 0, denominator, 1.0)
-
-
-def _validate_hparams(
-    fisher_decay: float, relative_damping: float, damping: float
-) -> None:
+def _validate_hparams(fisher_decay: float, damping: float) -> None:
     """Validate natural-gradient hyperparameters."""
     if not 0.0 <= fisher_decay < 1.0:
         raise ValueError(f"fisher_decay must be in [0, 1). got {fisher_decay}")
-    if relative_damping < 0.0:
-        raise ValueError(f"relative_damping must be >= 0. got {relative_damping}")
-    if damping < 0.0:
-        raise ValueError(f"damping must be >= 0. got {damping}")
-    if relative_damping == 0.0 and damping == 0.0:
-        raise ValueError(
-            "relative_damping and damping are both 0: at least one must be > 0, "
-            "or the update g / F has no bound as gradients shrink."
-        )
+    if damping <= 0.0:
+        raise ValueError(f"damping must be > 0. got {damping}")

--- a/fabricpc/training/natural_gradients.py
+++ b/fabricpc/training/natural_gradients.py
@@ -1,10 +1,56 @@
-"""
-Natural-gradient-style optimizer transforms for predictive coding training.
+"""Natural-gradient-style optimizer transforms for predictive coding training.
 
-These transforms use online Fisher information approximations and can be
-composed with Optax chains.
+Both transforms precondition the gradient with an online diagonal Fisher
+approximation, an exponential moving average (EMA) of the squared gradient,
+and compose with Optax chains, typically followed by ``optax.scale(-lr)``.
+
+Gradient scale. The trainer hands Optax mean gradients per prediction
+(``fabricpc.training.pc_weight_gradients`` divides the batch-summed gradients
+once by the prediction count), so the gradients reaching these transforms sit
+on the scale of standard mean-loss training.
+
+Covariance. The natural-gradient update ``g / f`` is covariant: scaling every
+gradient by ``c`` scales ``f`` by ``c**2`` and the update by ``1/c``. Damping
+is therefore expressed relative to the Fisher itself. The damping reference is
+``r = trace(F) / dim``, the mean bias-corrected Fisher entry over the whole
+parameter pytree, and the update is
+``g / (f + relative_damping * r + damping)``. With ``damping = 0`` (the
+default) both denominator terms scale by ``c**2``, so the update scales by
+exactly ``1/c`` and the set of entries where damping dominates the Fisher does
+not depend on the gradient scale. No constant is added in that case: a zero
+denominator occurs only when every gradient seen so far is zero, and then the
+update is zero.
+
+Absolute damping. ``damping > 0`` adds a constant to the denominator. It
+breaks the covariance above and ties the transform to one gradient scale:
+wherever ``damping`` dominates ``f + relative_damping * r``, the update is
+``g / damping``, plain SGD with learning rate ``scale / damping``. It exists
+as an explicit opt-in because of the limitation below.
+
+Bias correction. The EMA starts at zero, so after ``t`` steps it holds only
+``1 - fisher_decay**t`` of a stationary ``g**2``. Both transforms divide by
+that factor (``t`` is the step count held in the state), so the first steps
+are not over-scaled.
+
+Limitations of the present implementations. ``F`` is built from the squared
+*mean* gradient of the batch, not from per-sample gradients, so ``g / F`` is
+about ``1 / g``: the entries with the largest gradients receive the smallest
+steps, and the step size grows relative to the gradient as training reduces
+it. On ``examples/mnist_advanced.py`` (a four-layer sigmoid MLP) neither
+transform left chance accuracy in 10 epochs with relative damping alone, at
+any of 48 combinations of ``optax.scale``, ``relative_damping``, and a global
+norm clip, while ``optax.adamw`` reaches 97% on the same graph. The demo
+presets that do train (weakly: 24% at 10 epochs) use ``relative_damping = 0``
+with an absolute ``damping`` that, measured on the diagonal transform, lies
+above 96.5% of the Fisher entries from the first step and above 99.7% by
+step 300: those entries are updated as SGD with rate ``scale / damping``,
+while the few large-gradient entries that hold the Fisher trace receive the
+``1 / g`` step. Treat these transforms as research baselines, not as tuned
+optimizers; the measurements are recorded in
+``docs/dev_plans_archive/mean_gradient_normalization.md``.
 """
 
+import operator
 from typing import Any, NamedTuple
 
 import jax
@@ -13,52 +59,83 @@ import optax
 
 
 class DiagonalNaturalGradientState(NamedTuple):
-    """State for diagonal natural-gradient preconditioning."""
+    """State for diagonal natural-gradient preconditioning.
 
+    ``count`` is the int32 number of updates applied so far; ``fisher_diag``
+    is the uncorrected EMA of ``g**2`` with the parameters' structure.
+    """
+
+    count: jax.Array
     fisher_diag: Any
 
 
 class LayerwiseNaturalGradientState(NamedTuple):
-    """State for layer-wise natural-gradient preconditioning."""
+    """State for layer-wise natural-gradient preconditioning.
 
+    ``count`` is the int32 number of updates applied so far;
+    ``fisher_scalar`` holds one scalar per leaf, the uncorrected EMA of
+    ``mean(g**2)`` over that leaf.
+    """
+
+    count: jax.Array
     fisher_scalar: Any
 
 
 def scale_by_natural_gradient_diag(
     fisher_decay: float = 0.95,
-    damping: float = 1e-3,
+    relative_damping: float = 0.1,
+    damping: float = 0.0,
 ) -> optax.GradientTransformation:
-    """
-    Precondition updates with an EMA diagonal Fisher approximation.
+    """Precondition updates with a bias-corrected EMA diagonal Fisher.
+
+    Each entry is divided by ``f + relative_damping * r + damping``, where
+    ``f`` is the bias-corrected EMA of ``g**2`` for that entry and ``r`` is
+    the mean of ``f`` over the whole parameter pytree. With ``damping = 0``,
+    scaling the gradients by ``c`` scales the update by ``1/c``.
 
     Args:
         fisher_decay: EMA decay for the Fisher estimate in [0, 1).
-        damping: Positive damping added to the Fisher diagonal.
+        relative_damping: Damping as a fraction of the mean Fisher entry,
+            >= 0. Entries whose Fisher is well below ``relative_damping * r``
+            are updated as by SGD with step ``1 / (relative_damping * r)``.
+        damping: Absolute damping added to the denominator, >= 0. Where it
+            dominates, the update is ``g / damping`` (SGD with rate
+            ``scale / damping``); it ties the transform to one gradient
+            scale. At least one of ``relative_damping`` and ``damping`` must
+            be positive.
 
     Returns:
         Optax gradient transformation.
     """
-    _validate_hparams(fisher_decay, damping)
+    _validate_hparams(fisher_decay, relative_damping, damping)
     one_minus_decay = 1.0 - fisher_decay
 
     def init_fn(params):
-        fisher_diag = jax.tree_util.tree_map(lambda p: jnp.zeros_like(p), params)
-        return DiagonalNaturalGradientState(fisher_diag=fisher_diag)
+        return DiagonalNaturalGradientState(
+            count=jnp.zeros((), dtype=jnp.int32),
+            fisher_diag=jax.tree_util.tree_map(jnp.zeros_like, params),
+        )
 
     def update_fn(updates, state, params=None):
         del params
+        count = optax.safe_int32_increment(state.count)
         fisher_diag = jax.tree_util.tree_map(
             lambda f, g: fisher_decay * f + one_minus_decay * jnp.square(g),
             state.fisher_diag,
             updates,
         )
+        fisher_hat = _bias_corrected(fisher_diag, fisher_decay, count)
+        leaf_traces = jax.tree_util.tree_map(jnp.sum, fisher_hat)
+        total_damping = (
+            relative_damping * _mean_fisher_entry(leaf_traces, updates) + damping
+        )
         preconditioned_updates = jax.tree_util.tree_map(
-            lambda g, f: g / (f + damping),
+            lambda g, f: _divide_guarded(g, f + total_damping.astype(f.dtype)),
             updates,
-            fisher_diag,
+            fisher_hat,
         )
         return preconditioned_updates, DiagonalNaturalGradientState(
-            fisher_diag=fisher_diag
+            count=count, fisher_diag=fisher_diag
         )
 
     return optax.GradientTransformation(init_fn, update_fn)
@@ -66,52 +143,114 @@ def scale_by_natural_gradient_diag(
 
 def scale_by_natural_gradient_layerwise(
     fisher_decay: float = 0.95,
-    damping: float = 1e-3,
+    relative_damping: float = 0.1,
+    damping: float = 0.0,
 ) -> optax.GradientTransformation:
-    """
-    Precondition each tensor by one scalar Fisher estimate per leaf.
+    """Precondition each tensor by one bias-corrected scalar Fisher per leaf.
 
-    This is a cheap layer-wise approximation. It is less expressive than a full
-    diagonal preconditioner but can be more stable for large tensors.
+    A cheap layer-wise approximation: each leaf's scalar is the EMA of
+    ``mean(g**2)`` over the leaf. The leaf is divided by
+    ``f + relative_damping * r + damping`` with ``r`` the mean Fisher entry
+    over the whole pytree, where each leaf's scalar counts with weight equal
+    to the leaf's size (the same ``trace(F) / dim`` the diagonal transform
+    uses). With ``damping = 0``, scaling the gradients by ``c`` scales the
+    update by ``1/c``.
 
     Args:
         fisher_decay: EMA decay for the Fisher estimate in [0, 1).
-        damping: Positive damping added to each layer Fisher scalar.
+        relative_damping: Damping as a fraction of the mean Fisher entry, >= 0.
+        damping: Absolute damping added to the denominator, >= 0; where it
+            dominates, the update is ``g / damping``. At least one of
+            ``relative_damping`` and ``damping`` must be positive.
 
     Returns:
         Optax gradient transformation.
     """
-    _validate_hparams(fisher_decay, damping)
+    _validate_hparams(fisher_decay, relative_damping, damping)
     one_minus_decay = 1.0 - fisher_decay
 
     def init_fn(params):
-        fisher_scalar = jax.tree_util.tree_map(
-            lambda p: jnp.zeros((), dtype=p.dtype), params
+        return LayerwiseNaturalGradientState(
+            count=jnp.zeros((), dtype=jnp.int32),
+            fisher_scalar=jax.tree_util.tree_map(
+                lambda p: jnp.zeros((), dtype=p.dtype), params
+            ),
         )
-        return LayerwiseNaturalGradientState(fisher_scalar=fisher_scalar)
 
     def update_fn(updates, state, params=None):
         del params
+        count = optax.safe_int32_increment(state.count)
         fisher_scalar = jax.tree_util.tree_map(
             lambda f, g: fisher_decay * f + one_minus_decay * jnp.mean(jnp.square(g)),
             state.fisher_scalar,
             updates,
         )
+        fisher_hat = _bias_corrected(fisher_scalar, fisher_decay, count)
+        # Each leaf scalar stands for g.size Fisher entries.
+        leaf_traces = jax.tree_util.tree_map(
+            lambda f, g: f * g.size, fisher_hat, updates
+        )
+        total_damping = (
+            relative_damping * _mean_fisher_entry(leaf_traces, updates) + damping
+        )
         preconditioned_updates = jax.tree_util.tree_map(
-            lambda g, f: g / (f + damping),
+            lambda g, f: _divide_guarded(g, f + total_damping.astype(f.dtype)),
             updates,
-            fisher_scalar,
+            fisher_hat,
         )
         return preconditioned_updates, LayerwiseNaturalGradientState(
-            fisher_scalar=fisher_scalar
+            count=count, fisher_scalar=fisher_scalar
         )
 
     return optax.GradientTransformation(init_fn, update_fn)
 
 
-def _validate_hparams(fisher_decay: float, damping: float) -> None:
+def _bias_corrected(fisher, fisher_decay: float, count: jax.Array):
+    """Divide every Fisher leaf by ``1 - fisher_decay**count``.
+
+    ``count`` is the incremented step count (1 after the first update), so
+    the factor is positive. It is computed once as a float32 scalar and cast
+    to each leaf's dtype.
+    """
+    factor = 1.0 - fisher_decay**count
+    return jax.tree_util.tree_map(lambda f: f / factor.astype(f.dtype), fisher)
+
+
+def _mean_fisher_entry(leaf_traces, updates):
+    """``trace(F) / dim``: the mean Fisher entry over the whole pytree.
+
+    ``leaf_traces`` holds one scalar per leaf, the sum of that leaf's Fisher
+    entries. ``dim`` is the static parameter count read from ``updates``.
+    """
+    trace = jax.tree_util.tree_reduce(operator.add, leaf_traces)
+    dim = sum(g.size for g in jax.tree_util.tree_leaves(updates))
+    return trace / dim
+
+
+def _divide_guarded(g, denominator):
+    """``g / denominator`` with a zero denominator mapped to a zero update.
+
+    With ``damping = 0``, ``f + relative_damping * r`` is zero only when
+    every Fisher entry in the pytree is zero, which requires every gradient
+    seen so far, including this step's, to be zero. Then ``g`` is zero too,
+    and dividing by 1 instead gives the correct update without forming
+    ``0 / 0`` and without adding any constant to the denominator.
+    """
+    return g / jnp.where(denominator > 0, denominator, 1.0)
+
+
+def _validate_hparams(
+    fisher_decay: float, relative_damping: float, damping: float
+) -> None:
     """Validate natural-gradient hyperparameters."""
     if not 0.0 <= fisher_decay < 1.0:
         raise ValueError(f"fisher_decay must be in [0, 1). got {fisher_decay}")
-    if damping <= 0.0:
-        raise ValueError(f"damping must be > 0. got {damping}")
+    if relative_damping < 0.0:
+        raise ValueError(f"relative_damping must be >= 0. got {relative_damping}")
+    if damping < 0.0:
+        raise ValueError(f"damping must be >= 0. got {damping}")
+    if relative_damping == 0.0 and damping == 0.0:
+        raise ValueError(
+            "relative_damping and damping are both 0: at least one must be > 0, "
+            "or the update g / F has no bound as gradients shrink."
+        )

--- a/fabricpc/training/trainer.py
+++ b/fabricpc/training/trainer.py
@@ -147,7 +147,7 @@ def create_causal_mask(seq_len: int) -> jnp.ndarray:
     return jnp.tril(jnp.ones((seq_len, seq_len)))
 
 
-def _batch_size(batch: Dict[str, jnp.ndarray], structure: GraphStructure) -> int:
+def batch_size_of(batch: Dict[str, jnp.ndarray], structure: GraphStructure) -> int:
     """Leading-axis size of the first batch key the ``task_map`` names.
 
     Reading an arbitrary batch value would trust extra keys whose leading
@@ -215,7 +215,7 @@ def build_clamps(
         # The mask node declares (..., seq, seq); read seq from the graph, not
         # from a hard-coded batch key.
         seq_len = structure.nodes[mask_node].node_info.shape[-1]
-        batch_size = _batch_size(batch, structure)
+        batch_size = batch_size_of(batch, structure)
         mask = create_causal_mask(seq_len)[None, None, :, :]
         clamps[mask_node] = jnp.broadcast_to(mask, (batch_size, 1, seq_len, seq_len))
     return clamps
@@ -298,30 +298,23 @@ def grad_denominator(structure: GraphStructure, clamps: Dict[str, jnp.ndarray]) 
     clamp is the class axis: ``build_clamps`` validates every target clamp
     against ``(batch, *node.shape)``, so rank >= 2 holds. A rank-2
     classification target ``(B, C)`` gives N = B; a rank-3 token target
-    ``(B, S, V)`` gives N = B * S. With no clamped target (associative-memory
-    graphs) N is the batch size, read from the leading axis of the first
-    clamp. N is the per-batch total of the per-sample weight that
-    ``metrics._internal_energy_fn`` assigns in ``evaluate``, so the train and
-    eval ``energy`` share one scale. Empty ``clamps`` raises ``ValueError``:
-    nothing is clamped, so there is no objective.
+    ``(B, S, V)`` gives N = B * S. With several target heads N is the sum of
+    their positions (two same-shape heads give N = 2 * B), so adding a head
+    halves the step every shared parameter takes at a fixed learning rate.
+    With no clamped target (associative-memory graphs) N is the batch size,
+    read from the leading axis of the first clamp. Empty ``clamps`` raises
+    ``ValueError``: nothing is clamped, so there is no objective.
 
-    A clamped input node that receives feedback edges has ``in_degree > 0``
-    and counts as a target under this rule. No graph in the repository does
-    this (the cyclic and lateral MNIST demos leave ``pixels`` edge-free on
-    the input side).
+    N is the per-batch total of the per-sample weight that
+    ``metrics._internal_energy_fn`` assigns in ``evaluate``, so the train and
+    eval ``energy`` share one scale. A clamped input node with feedback edges
+    has ``in_degree > 0`` and counts as a target; no graph in the repository
+    does this.
 
     Gradients arrive batch-summed from ``compute_local_weight_gradients``
-    and are divided once by this global count, in ``pc_weight_gradients``.
-    If gradient accumulation over microbatches is added, keep that
-    structure: accumulate the unnormalized sums across microbatches and
-    divide once by the count summed over the whole accumulation window.
-    Dividing per microbatch and averaging overweights predictions in small
-    microbatches when token counts differ. If padded positions gain a
-    validity mask, replace the static shape product with ``jnp.sum(mask)``.
-    Under jit + ``NamedSharding`` (the trainer's data parallelism),
-    trace-time shapes and reductions are global, so this count is already
-    global; a ``shard_map``/``pmap`` port sees per-shard shapes and must
-    ``jax.lax.psum`` the per-shard count over the data axis.
+    and are divided once by this count in ``pc_weight_gradients``.
+    Accumulation over microbatches or a padding mask must keep that shape:
+    sum first, divide once by the window's total count.
     """
     if not clamps:
         raise ValueError(
@@ -355,7 +348,7 @@ def pc_weight_gradients(
 
 def _batch_grads(params, batch, structure, rng_key, *, algorithm):
     """Gradients and metrics for one batch — the only algorithm branch."""
-    batch_size = _batch_size(batch, structure)
+    batch_size = batch_size_of(batch, structure)
     clamps = build_clamps(batch, structure, clamp_target=True)
     target_nodes = _target_node_names(structure, clamps)
     # Static at trace time; global under jit + NamedSharding.
@@ -598,7 +591,7 @@ def train(
                 break
             batch = convert_batch(batch_data)
             if mesh is not None:
-                bsz = _batch_size(batch, structure)
+                bsz = batch_size_of(batch, structure)
                 if bsz % data_axis_size != 0:
                     if not shard_warned:
                         warnings.warn(
@@ -723,7 +716,7 @@ def evaluate(
     metric_names = tuple(metric_map)
 
     def eval_step(p, batch, key, sample_mask):
-        batch_size = _batch_size(batch, structure)
+        batch_size = batch_size_of(batch, structure)
         clamps = build_clamps(batch, structure, clamp_target=False)
         state = initialize_graph_state(
             structure, batch_size, key, clamps=clamps, params=p
@@ -753,7 +746,7 @@ def evaluate(
     totals = {name: (jnp.zeros(()), jnp.zeros(())) for name in metric_names}
     for batch_idx, batch_data in enumerate(test_loader):
         batch = convert_batch(batch_data)
-        bsz = _batch_size(batch, structure)
+        bsz = batch_size_of(batch, structure)
         sample_mask = jnp.ones((bsz,))
         if mesh is not None:
             if bsz % data_axis_size != 0:

--- a/fabricpc/training/trainer.py
+++ b/fabricpc/training/trainer.py
@@ -13,11 +13,18 @@ in exactly three places inside the step:
                       run_inference (settle)               FeedforwardStateInit (single
                                                            forward pass, no inference)
     4 objective       graph_energy over all in_degree>0    graph_energy over target nodes
-                      nodes / batch                        / batch (same function,
+                      nodes / N                            / N (same function,
                                                            different node subset)
-    5 gradients       compute_local_weight_gradients       jax.value_and_grad over steps
-                      (local, per node)                    3-4 (global)
+    5 gradients       pc_weight_gradients (local, per      jax.value_and_grad over steps
+                      node, summed gradients / N)          3-4 (global)
     6 apply update    optax update + apply_updates         (shared)
+
+N is the prediction count from :func:`grad_denominator`: the total number of
+clamped-target prediction positions in the batch (``batch`` for
+classification, ``batch * seq`` for token targets). Both algorithms hand
+optax mean gradients per prediction, so one learning rate, clipping
+threshold, or Adam epsilon means the same under either algorithm and across
+batch sizes and sequence lengths.
 
 The backprop objective is the energy of the clamped target nodes — the
 negative log probability the output node's energy functional assigns to the
@@ -59,7 +66,7 @@ from tqdm.auto import tqdm as _tqdm_cls
 from fabricpc.core.energy import graph_energy
 from fabricpc.core.inference import run_inference
 from fabricpc.core.learning import compute_local_weight_gradients
-from fabricpc.core.types import GraphParams, GraphStructure
+from fabricpc.core.types import GraphParams, GraphState, GraphStructure
 from fabricpc.graph_initialization.state_initializer import (
     FeedforwardStateInit,
     initialize_graph_state,
@@ -281,19 +288,86 @@ def _target_node_names(structure, clamps):
     )
 
 
+def grad_denominator(structure: GraphStructure, clamps: Dict[str, jnp.ndarray]) -> int:
+    """Prediction count N: the single denominator that turns batch-summed
+    energies and weight gradients into means per prediction.
+
+    N is the total number of clamped-target prediction positions in the
+    batch, ``sum(prod(clamps[name].shape[:-1]))`` over the target nodes (the
+    clamped nodes with ``in_degree > 0``). The trailing axis of a target
+    clamp is the class axis: ``build_clamps`` validates every target clamp
+    against ``(batch, *node.shape)``, so rank >= 2 holds. A rank-2
+    classification target ``(B, C)`` gives N = B; a rank-3 token target
+    ``(B, S, V)`` gives N = B * S. With no clamped target (associative-memory
+    graphs) N is the batch size, read from the leading axis of the first
+    clamp. N is the per-batch total of the per-sample weight that
+    ``metrics._internal_energy_fn`` assigns in ``evaluate``, so the train and
+    eval ``energy`` share one scale. Empty ``clamps`` raises ``ValueError``:
+    nothing is clamped, so there is no objective.
+
+    A clamped input node that receives feedback edges has ``in_degree > 0``
+    and counts as a target under this rule. No graph in the repository does
+    this (the cyclic and lateral MNIST demos leave ``pixels`` edge-free on
+    the input side).
+
+    Gradients arrive batch-summed from ``compute_local_weight_gradients``
+    and are divided once by this global count, in ``pc_weight_gradients``.
+    If gradient accumulation over microbatches is added, keep that
+    structure: accumulate the unnormalized sums across microbatches and
+    divide once by the count summed over the whole accumulation window.
+    Dividing per microbatch and averaging overweights predictions in small
+    microbatches when token counts differ. If padded positions gain a
+    validity mask, replace the static shape product with ``jnp.sum(mask)``.
+    Under jit + ``NamedSharding`` (the trainer's data parallelism),
+    trace-time shapes and reductions are global, so this count is already
+    global; a ``shard_map``/``pmap`` port sees per-shard shapes and must
+    ``jax.lax.psum`` the per-shard count over the data axis.
+    """
+    if not clamps:
+        raise ValueError(
+            "grad_denominator: clamps is empty, so nothing is clamped and there "
+            "is no objective to normalize."
+        )
+    target_nodes = _target_node_names(structure, clamps)
+    if target_nodes:
+        return sum(math.prod(clamps[name].shape[:-1]) for name in target_nodes)
+    return next(iter(clamps.values())).shape[0]
+
+
+def pc_weight_gradients(
+    params: GraphParams,
+    state: GraphState,
+    structure: GraphStructure,
+    clamps: Dict[str, jnp.ndarray],
+) -> GraphParams:
+    """Local PC weight gradients as means per prediction: the batch-summed
+    gradients from ``compute_local_weight_gradients`` divided once by
+    ``grad_denominator(structure, clamps)``.
+
+    This is the PC path's optimizer-facing gradient. Custom loops call it in
+    place of ``compute_local_weight_gradients`` so that their learning rate,
+    clipping threshold, and Adam epsilon mean the same as in :func:`train`.
+    """
+    denom = grad_denominator(structure, clamps)
+    grads = compute_local_weight_gradients(params, state, structure)
+    return jax.tree_util.tree_map(lambda g: g / denom, grads)
+
+
 def _batch_grads(params, batch, structure, rng_key, *, algorithm):
     """Gradients and metrics for one batch — the only algorithm branch."""
     batch_size = _batch_size(batch, structure)
     clamps = build_clamps(batch, structure, clamp_target=True)
     target_nodes = _target_node_names(structure, clamps)
+    # Static at trace time; global under jit + NamedSharding.
+    denom = grad_denominator(structure, clamps)
 
     if algorithm == "pc":
         state = initialize_graph_state(
             structure, batch_size, rng_key, clamps=clamps, params=params
         )
         state = run_inference(params, state, clamps, structure)
-        energy = graph_energy(state, structure) / batch_size
-        grads = compute_local_weight_gradients(params, state, structure)
+        energy = graph_energy(state, structure) / denom
+        grads = pc_weight_gradients(params, state, structure, clamps)
     else:  # backprop
         if not target_nodes:
             raise ValueError(
@@ -306,28 +380,21 @@ def _batch_grads(params, batch, structure, rng_key, *, algorithm):
                 structure, batch_size, rng_key, clamps=clamps, params=p
             )
             return (
-                graph_energy(state, structure, node_names=target_nodes) / batch_size,
+                graph_energy(state, structure, node_names=target_nodes) / denom,
                 state,
             )
 
         (energy, state), grads = jax.value_and_grad(objective, has_aux=True)(params)
 
-    # Total prediction positions across target clamps: batch*seq for
-    # sequences, batch for classification. Shapes are static at trace time.
-    # The trailing axis is the class axis: build_clamps validates every
-    # target clamp against (batch, *node.shape), so rank >= 2 holds and this
-    # agrees with metrics._predictions_per_sample's per-sample weight.
-    n_predictions = sum(math.prod(clamps[name].shape[:-1]) for name in target_nodes)
     if target_nodes:
-        target_e = (
-            graph_energy(state, structure, node_names=target_nodes) / n_predictions
-        )
+        target_e = graph_energy(state, structure, node_names=target_nodes) / denom
     else:
         target_e = jnp.zeros(())
-    # Note the two keys use different normalizations: "energy" is per-sample
-    # (/ batch), "target_energy" per-prediction (/ batch*seq for sequences).
-    # "energy" is algorithm-dependent (all internal nodes for PC, target
-    # nodes only for backprop) — cross-algorithm comparison of it is invalid.
+    # Both keys are means per prediction over the same denominator. "energy"
+    # is the optimized objective; its node set is algorithm-dependent (all
+    # internal nodes for PC, target nodes only for backprop), so comparing it
+    # across algorithms compares different node sets. "target_energy" is the
+    # same quantity under both algorithms.
     metrics = {"energy": energy, "target_energy": target_e}
     return grads, metrics, state
 
@@ -366,8 +433,8 @@ def make_train_step(
 
     Returns ``step(params, opt_state, batch, rng_key) -> (params, opt_state,
     metrics, final_state)``. ``metrics`` is a dict of device scalars
-    (``"energy"``: the per-sample objective; ``"target_energy"``: target-node
-    energy per prediction). ``final_state`` is the settled (PC) or
+    (``"energy"``: the objective per prediction; ``"target_energy"``:
+    target-node energy per prediction). ``final_state`` is the settled (PC) or
     feedforward (backprop) GraphState — the escape hatch for dashboards.
     Inputs are NOT donated: callers may reuse the initial params.
 

--- a/fabricpc/utils/dashboarding/inference_tracking.py
+++ b/fabricpc/utils/dashboarding/inference_tracking.py
@@ -15,9 +15,13 @@ from fabricpc.core.types import (
     GraphStructure,
 )
 from fabricpc.core.energy import graph_energy
-from fabricpc.core.learning import compute_local_weight_gradients
 from fabricpc.graph_initialization.state_initializer import initialize_graph_state
-from fabricpc.training.trainer import build_clamps
+from fabricpc.training.trainer import (
+    _batch_size,
+    build_clamps,
+    grad_denominator,
+    pc_weight_gradients,
+)
 
 
 # TODO clarify collect_every refers to either batches or inference steps
@@ -176,9 +180,9 @@ def train_step_with_history(
     """PC training step that also returns inference history.
 
     Same step as the trainer's PC path (build_clamps -> initialize_graph_state
-    -> inference -> graph_energy -> compute_local_weight_gradients -> optax),
-    with run_inference swapped for run_inference_with_history. Use this when
-    you need to track inference dynamics.
+    -> inference -> graph_energy -> pc_weight_gradients -> optax), with
+    run_inference swapped for run_inference_with_history. Use this when you
+    need to track inference dynamics.
 
     Note: This function is designed to be JIT-compiled. The returned energy and
     inference_history are JAX arrays. Use unstack_inference_history() to convert
@@ -196,13 +200,15 @@ def train_step_with_history(
 
     Returns:
         Tuple of (params, opt_state, energy, final_state, stacked_inference_history).
-        ``energy`` is the per-sample internal energy — the training objective:
-        ``graph_energy`` over in_degree>0 nodes divided by the batch size.
+        ``energy`` is the training objective per prediction: ``graph_energy``
+        over in_degree>0 nodes divided by the prediction count
+        (``fabricpc.training.grad_denominator``).
         Call unstack_inference_history() on stacked_inference_history outside JIT.
     """
-    batch_size = next(iter(batch.values())).shape[0]
+    batch_size = _batch_size(batch, structure)
 
     clamps = build_clamps(batch, structure, clamp_target=True)
+    denom = grad_denominator(structure, clamps)
 
     init_state = initialize_graph_state(
         structure,
@@ -217,10 +223,10 @@ def train_step_with_history(
         params, init_state, clamps, structure, collect_every
     )
 
-    energy = graph_energy(final_state, structure) / batch_size
+    energy = graph_energy(final_state, structure) / denom
 
-    # Compute gradients and update
-    grads = compute_local_weight_gradients(params, final_state, structure)
+    # Mean gradients per prediction (summed gradients / denom), as in train().
+    grads = pc_weight_gradients(params, final_state, structure, clamps)
     updates, opt_state = optimizer.update(grads, opt_state, params)
     params = cast(GraphParams, optax.apply_updates(params, updates))
 

--- a/fabricpc/utils/dashboarding/inference_tracking.py
+++ b/fabricpc/utils/dashboarding/inference_tracking.py
@@ -17,7 +17,7 @@ from fabricpc.core.types import (
 from fabricpc.core.energy import graph_energy
 from fabricpc.graph_initialization.state_initializer import initialize_graph_state
 from fabricpc.training.trainer import (
-    _batch_size,
+    batch_size_of,
     build_clamps,
     grad_denominator,
     pc_weight_gradients,
@@ -205,7 +205,7 @@ def train_step_with_history(
         (``fabricpc.training.grad_denominator``).
         Call unstack_inference_history() on stacked_inference_history outside JIT.
     """
-    batch_size = _batch_size(batch, structure)
+    batch_size = batch_size_of(batch, structure)
 
     clamps = build_clamps(batch, structure, clamp_target=True)
     denom = grad_denominator(structure, clamps)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fabricpc"
-version = "0.5.0"
+version = "0.5.1"
 description = "A flexible, performant predictive coding library using JAX"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_inference_tracking.py
+++ b/tests/test_inference_tracking.py
@@ -1,0 +1,48 @@
+"""Parity of the dashboarding training step with the trainer's PC step.
+
+``train_step_with_history`` is a hand copy of the PC step with the inference
+loop swapped for a history-collecting scan. This pins its gradient
+normalization and energy to ``make_train_step``, so the two cannot drift.
+"""
+
+import jax
+import optax
+
+from conftest import make_classification_structure, max_param_diff
+from fabricpc.core.energy import graph_energy
+from fabricpc.graph_initialization import initialize_params
+from fabricpc.training import make_train_step
+from fabricpc.utils.dashboarding import train_step_with_history
+
+
+def test_train_step_with_history_matches_trainer_step(rng_key):
+    """Under optax.sgd(1.0) the applied update is the gradient itself, so a
+    parameter match pins the per-prediction normalization; the returned
+    energy is graph_energy / N with N = B for a rank-2 target."""
+    structure = make_classification_structure()
+    params = initialize_params(structure, rng_key)
+    kx, ky = jax.random.split(rng_key)
+    batch_size = 4
+    batch = {
+        "x": jax.random.normal(kx, (batch_size, 6)),
+        "y": jax.nn.one_hot(jax.random.randint(ky, (batch_size,), 0, 3), 3),
+    }
+    optimizer = optax.sgd(1.0)
+
+    step = make_train_step(structure, optimizer)
+    ref_params, _, ref_metrics, _ = step(params, optimizer.init(params), batch, rng_key)
+
+    tracked = jax.jit(
+        lambda p, o, b, k: train_step_with_history(p, o, b, structure, optimizer, k)
+    )
+    new_params, _, energy, final_state, history = tracked(
+        params, optimizer.init(params), batch, rng_key
+    )
+
+    assert max_param_diff(ref_params, new_params) < 1e-5
+    assert abs(float(energy) - float(ref_metrics["energy"])) < 1e-6
+    expected = float(graph_energy(final_state, structure)) / batch_size
+    assert expected > 0.0
+    assert abs(float(energy) - expected) < 1e-6
+    # One stacked entry per inference step (the fixture settles for 10 steps).
+    assert history["h"]["energy"].shape == (10,)

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -28,8 +28,8 @@ NGD_TRANSFORMS = pytest.mark.parametrize(
 
 
 def _gradient_tree(key, scale=1.0):
-    """Two leaves of different sizes (35 and 3), so the size-weighted damping
-    reference trace(F)/dim differs from an unweighted mean of leaf scalars."""
+    """Two leaves of different sizes (35 and 3), so the layerwise transform's
+    per-leaf Fisher scalars differ from each other."""
     k_w, k_b = jax.random.split(key)
     return {
         "w": scale * jax.random.normal(k_w, (7, 5)),
@@ -42,7 +42,7 @@ def test_ngd_diag_updates():
     grads = jax.tree_util.tree_map(lambda p: jnp.full_like(p, 0.1), params)
 
     optimizer = optax.chain(
-        scale_by_natural_gradient_diag(fisher_decay=0.9, relative_damping=0.1),
+        scale_by_natural_gradient_diag(fisher_decay=0.9, damping=1e-3),
         optax.scale(-1e-2),
     )
     opt_state = optimizer.init(params)
@@ -58,7 +58,7 @@ def test_ngd_layerwise_updates():
     grads = jax.tree_util.tree_map(lambda p: jnp.full_like(p, 0.05), params)
 
     optimizer = optax.chain(
-        scale_by_natural_gradient_layerwise(fisher_decay=0.9, relative_damping=0.1),
+        scale_by_natural_gradient_layerwise(fisher_decay=0.9, damping=1e-3),
         optax.scale(-1e-2),
     )
     opt_state = optimizer.init(params)
@@ -69,16 +69,10 @@ def test_ngd_layerwise_updates():
     assert not jnp.allclose(new_params["w"], params["w"])
 
 
-@pytest.mark.parametrize(
-    "ngd_transform",
-    [
-        lambda: scale_by_natural_gradient_diag(fisher_decay=0.95, relative_damping=0.1),
-        lambda: scale_by_natural_gradient_layerwise(
-            fisher_decay=0.95, relative_damping=0.1
-        ),
-    ],
-)
-def test_natural_gradients_work_in_train_step(rng_key, ngd_transform):
+@NGD_TRANSFORMS
+def test_natural_gradients_work_in_train_step(rng_key, make_transform):
+    """The default-argument transform runs through make_train_step and moves
+    the parameters with a finite objective."""
     x_node = Linear(shape=(6,), name="x")
     hidden = Linear(shape=(4,), activation=SigmoidActivation(), name="hidden")
     y_node = Linear(shape=(3,), activation=SigmoidActivation(), name="y")
@@ -93,10 +87,7 @@ def test_natural_gradients_work_in_train_step(rng_key, ngd_transform):
     )
     params = initialize_params(structure, rng_key)
 
-    optimizer = optax.chain(
-        ngd_transform(),
-        optax.scale(-1e-3),
-    )
+    optimizer = optax.chain(make_transform(fisher_decay=0.95), optax.scale(-1e-3))
     opt_state = optimizer.init(params)
 
     batch_size = 8
@@ -122,90 +113,63 @@ def test_natural_gradient_hparams_validation():
     with pytest.raises(ValueError, match="fisher_decay"):
         scale_by_natural_gradient_diag(fisher_decay=1.1)
 
-    with pytest.raises(ValueError, match="relative_damping"):
-        scale_by_natural_gradient_layerwise(relative_damping=-0.1)
+    with pytest.raises(ValueError, match="damping"):
+        scale_by_natural_gradient_layerwise(damping=0.0)
 
     with pytest.raises(ValueError, match="damping"):
         scale_by_natural_gradient_diag(damping=-1e-3)
-
-    # Both damping terms zero: the update g / F has no bound as gradients shrink.
-    with pytest.raises(ValueError, match="both 0"):
-        scale_by_natural_gradient_layerwise(relative_damping=0.0, damping=0.0)
-
-    # Absolute damping alone (the pre-normalization behavior) is allowed.
-    scale_by_natural_gradient_diag(relative_damping=0.0, damping=1e-3)
-
-
-@NGD_TRANSFORMS
-@pytest.mark.parametrize("c", [1e-4, 1e4])
-def test_natural_gradient_update_is_covariant(rng_key, make_transform, c):
-    """update(c*g) == update(g) / c after several steps: damping is relative to
-    the Fisher and no absolute constant enters the denominator, so scaling the
-    gradients only rescales the update. The only deviation is float32
-    rounding (measured about 2e-7), so rtol=1e-5 leaves a wide margin."""
-    keys = jax.random.split(rng_key, 5)
-    params = jax.tree_util.tree_map(jnp.zeros_like, _gradient_tree(keys[0]))
-
-    def run(scale):
-        transform = make_transform(fisher_decay=0.9, relative_damping=0.1)
-        update = jax.jit(transform.update)  # count is a traced int32 under jit
-        state = transform.init(params)
-        for key in keys:
-            updates, state = update(_gradient_tree(key, scale), state)
-        return updates
-
-    reference = run(1.0)
-    scaled = run(c)
-    for name in reference:
-        assert jnp.allclose(scaled[name] * c, reference[name], rtol=1e-5, atol=0.0)
 
 
 @NGD_TRANSFORMS
 def test_natural_gradient_first_step_is_bias_corrected(rng_key, make_transform):
     """After one step from a fresh state the bias-corrected Fisher equals g**2
     (diag) or mean(g**2) per leaf (layerwise), so the update is
-    g / (F + rho * mean(g**2)) with the mean over the whole pytree. Without
-    bias correction the update would be 1 / (1 - 0.95) = 20x larger."""
-    rho = 0.1
+    g / (F + damping). Without bias correction the EMA would hold only
+    (1 - 0.95) * g**2 and the update would be about 20x larger."""
+    damping = 1e-3
     grads = _gradient_tree(rng_key)
     params = jax.tree_util.tree_map(jnp.zeros_like, grads)
-    transform = make_transform(fisher_decay=0.95, relative_damping=rho)
+    transform = make_transform(fisher_decay=0.95, damping=damping)
     updates, state = transform.update(grads, transform.init(params))
 
     squares = jax.tree_util.tree_map(jnp.square, grads)
-    leaves = jax.tree_util.tree_leaves(squares)
-    r = sum(jnp.sum(s) for s in leaves) / sum(s.size for s in leaves)
     if make_transform is scale_by_natural_gradient_diag:
         fisher_hat = squares
     else:
         fisher_hat = jax.tree_util.tree_map(jnp.mean, squares)
-    expected = jax.tree_util.tree_map(lambda g, f: g / (f + rho * r), grads, fisher_hat)
+    expected = jax.tree_util.tree_map(lambda g, f: g / (f + damping), grads, fisher_hat)
+    uncorrected = jax.tree_util.tree_map(
+        lambda g, f: g / (0.05 * f + damping), grads, fisher_hat
+    )
 
     assert int(state.count) == 1
     for name in grads:
         assert jnp.allclose(updates[name], expected[name], rtol=1e-5, atol=0.0)
+        assert not jnp.allclose(updates[name], uncorrected[name], rtol=1e-2, atol=0.0)
 
 
 @NGD_TRANSFORMS
-def test_natural_gradient_zero_gradient_gives_zero_update(make_transform):
-    """All-zero gradients give a zero Fisher and a zero damping reference; the
-    update is zero and finite (no 0/0)."""
-    zeros = {"w": jnp.zeros((4, 3)), "b": jnp.zeros((3,))}
-    transform = make_transform()
-    updates, _ = transform.update(zeros, transform.init(zeros))
-    for leaf in jax.tree_util.tree_leaves(updates):
-        assert bool(jnp.all(leaf == 0.0))
-
-
-@NGD_TRANSFORMS
-def test_absolute_damping_reduces_to_sgd_where_it_dominates(rng_key, make_transform):
-    """With an absolute `damping` far above the Fisher entries, the update is
-    g / damping: plain SGD with rate scale / damping. This pins the documented
-    limitation that the demo presets train only in that regime."""
+def test_damping_dominated_update_is_sgd(rng_key, make_transform):
+    """Where `damping` dominates the Fisher entries the update is g / damping:
+    plain SGD with rate scale / damping. This is the regime the demo presets
+    train in (see the module docstring)."""
     damping = 1.0
     grads = _gradient_tree(rng_key, scale=1e-3)  # F ~ 1e-6 << damping
     params = jax.tree_util.tree_map(jnp.zeros_like, grads)
-    transform = make_transform(fisher_decay=0.95, relative_damping=0.1, damping=damping)
+    transform = make_transform(fisher_decay=0.95, damping=damping)
     updates, _ = transform.update(grads, transform.init(params))
     for name in grads:
         assert jnp.allclose(updates[name], grads[name] / damping, rtol=1e-5, atol=0.0)
+
+
+def test_fisher_dominated_diag_update_is_inverse_gradient(rng_key):
+    """Where the Fisher dominates `damping` the diagonal update is about 1 / g:
+    the Fisher is the squared mean gradient, so g / F inverts the gradient.
+    This pins the documented defect of the estimator."""
+    damping = 1e-12
+    grads = _gradient_tree(rng_key)  # entries of order 1, F ~ 1 >> damping
+    params = jax.tree_util.tree_map(jnp.zeros_like, grads)
+    transform = scale_by_natural_gradient_diag(fisher_decay=0.95, damping=damping)
+    updates, _ = transform.update(grads, transform.init(params))
+    for name in grads:
+        assert jnp.allclose(updates[name], 1.0 / grads[name], rtol=1e-4, atol=0.0)

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -20,13 +20,29 @@ from fabricpc.graph_initialization import initialize_params
 from fabricpc.core.activations import SigmoidActivation
 from fabricpc.core.inference import InferenceSGD
 
+NGD_TRANSFORMS = pytest.mark.parametrize(
+    "make_transform",
+    [scale_by_natural_gradient_diag, scale_by_natural_gradient_layerwise],
+    ids=["diag", "layerwise"],
+)
+
+
+def _gradient_tree(key, scale=1.0):
+    """Two leaves of different sizes (35 and 3), so the size-weighted damping
+    reference trace(F)/dim differs from an unweighted mean of leaf scalars."""
+    k_w, k_b = jax.random.split(key)
+    return {
+        "w": scale * jax.random.normal(k_w, (7, 5)),
+        "b": scale * jax.random.normal(k_b, (3,)),
+    }
+
 
 def test_ngd_diag_updates():
     params = {"w": jnp.ones((4, 3)), "b": jnp.ones((3,))}
     grads = jax.tree_util.tree_map(lambda p: jnp.full_like(p, 0.1), params)
 
     optimizer = optax.chain(
-        scale_by_natural_gradient_diag(fisher_decay=0.9, damping=1e-3),
+        scale_by_natural_gradient_diag(fisher_decay=0.9, relative_damping=0.1),
         optax.scale(-1e-2),
     )
     opt_state = optimizer.init(params)
@@ -42,7 +58,7 @@ def test_ngd_layerwise_updates():
     grads = jax.tree_util.tree_map(lambda p: jnp.full_like(p, 0.05), params)
 
     optimizer = optax.chain(
-        scale_by_natural_gradient_layerwise(fisher_decay=0.9, damping=1e-3),
+        scale_by_natural_gradient_layerwise(fisher_decay=0.9, relative_damping=0.1),
         optax.scale(-1e-2),
     )
     opt_state = optimizer.init(params)
@@ -56,8 +72,10 @@ def test_ngd_layerwise_updates():
 @pytest.mark.parametrize(
     "ngd_transform",
     [
-        lambda: scale_by_natural_gradient_diag(fisher_decay=0.95, damping=1e-3),
-        lambda: scale_by_natural_gradient_layerwise(fisher_decay=0.95, damping=1e-3),
+        lambda: scale_by_natural_gradient_diag(fisher_decay=0.95, relative_damping=0.1),
+        lambda: scale_by_natural_gradient_layerwise(
+            fisher_decay=0.95, relative_damping=0.1
+        ),
     ],
 )
 def test_natural_gradients_work_in_train_step(rng_key, ngd_transform):
@@ -104,5 +122,90 @@ def test_natural_gradient_hparams_validation():
     with pytest.raises(ValueError, match="fisher_decay"):
         scale_by_natural_gradient_diag(fisher_decay=1.1)
 
+    with pytest.raises(ValueError, match="relative_damping"):
+        scale_by_natural_gradient_layerwise(relative_damping=-0.1)
+
     with pytest.raises(ValueError, match="damping"):
-        scale_by_natural_gradient_layerwise(damping=0.0)
+        scale_by_natural_gradient_diag(damping=-1e-3)
+
+    # Both damping terms zero: the update g / F has no bound as gradients shrink.
+    with pytest.raises(ValueError, match="both 0"):
+        scale_by_natural_gradient_layerwise(relative_damping=0.0, damping=0.0)
+
+    # Absolute damping alone (the pre-normalization behavior) is allowed.
+    scale_by_natural_gradient_diag(relative_damping=0.0, damping=1e-3)
+
+
+@NGD_TRANSFORMS
+@pytest.mark.parametrize("c", [1e-4, 1e4])
+def test_natural_gradient_update_is_covariant(rng_key, make_transform, c):
+    """update(c*g) == update(g) / c after several steps: damping is relative to
+    the Fisher and no absolute constant enters the denominator, so scaling the
+    gradients only rescales the update. The only deviation is float32
+    rounding (measured about 2e-7), so rtol=1e-5 leaves a wide margin."""
+    keys = jax.random.split(rng_key, 5)
+    params = jax.tree_util.tree_map(jnp.zeros_like, _gradient_tree(keys[0]))
+
+    def run(scale):
+        transform = make_transform(fisher_decay=0.9, relative_damping=0.1)
+        update = jax.jit(transform.update)  # count is a traced int32 under jit
+        state = transform.init(params)
+        for key in keys:
+            updates, state = update(_gradient_tree(key, scale), state)
+        return updates
+
+    reference = run(1.0)
+    scaled = run(c)
+    for name in reference:
+        assert jnp.allclose(scaled[name] * c, reference[name], rtol=1e-5, atol=0.0)
+
+
+@NGD_TRANSFORMS
+def test_natural_gradient_first_step_is_bias_corrected(rng_key, make_transform):
+    """After one step from a fresh state the bias-corrected Fisher equals g**2
+    (diag) or mean(g**2) per leaf (layerwise), so the update is
+    g / (F + rho * mean(g**2)) with the mean over the whole pytree. Without
+    bias correction the update would be 1 / (1 - 0.95) = 20x larger."""
+    rho = 0.1
+    grads = _gradient_tree(rng_key)
+    params = jax.tree_util.tree_map(jnp.zeros_like, grads)
+    transform = make_transform(fisher_decay=0.95, relative_damping=rho)
+    updates, state = transform.update(grads, transform.init(params))
+
+    squares = jax.tree_util.tree_map(jnp.square, grads)
+    leaves = jax.tree_util.tree_leaves(squares)
+    r = sum(jnp.sum(s) for s in leaves) / sum(s.size for s in leaves)
+    if make_transform is scale_by_natural_gradient_diag:
+        fisher_hat = squares
+    else:
+        fisher_hat = jax.tree_util.tree_map(jnp.mean, squares)
+    expected = jax.tree_util.tree_map(lambda g, f: g / (f + rho * r), grads, fisher_hat)
+
+    assert int(state.count) == 1
+    for name in grads:
+        assert jnp.allclose(updates[name], expected[name], rtol=1e-5, atol=0.0)
+
+
+@NGD_TRANSFORMS
+def test_natural_gradient_zero_gradient_gives_zero_update(make_transform):
+    """All-zero gradients give a zero Fisher and a zero damping reference; the
+    update is zero and finite (no 0/0)."""
+    zeros = {"w": jnp.zeros((4, 3)), "b": jnp.zeros((3,))}
+    transform = make_transform()
+    updates, _ = transform.update(zeros, transform.init(zeros))
+    for leaf in jax.tree_util.tree_leaves(updates):
+        assert bool(jnp.all(leaf == 0.0))
+
+
+@NGD_TRANSFORMS
+def test_absolute_damping_reduces_to_sgd_where_it_dominates(rng_key, make_transform):
+    """With an absolute `damping` far above the Fisher entries, the update is
+    g / damping: plain SGD with rate scale / damping. This pins the documented
+    limitation that the demo presets train only in that regime."""
+    damping = 1.0
+    grads = _gradient_tree(rng_key, scale=1e-3)  # F ~ 1e-6 << damping
+    params = jax.tree_util.tree_map(jnp.zeros_like, grads)
+    transform = make_transform(fisher_decay=0.95, relative_damping=0.1, damping=damping)
+    updates, _ = transform.update(grads, transform.init(params))
+    for name in grads:
+        assert jnp.allclose(updates[name], grads[name] / damping, rtol=1e-5, atol=0.0)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -19,7 +19,12 @@ import jax.numpy as jnp
 import optax
 import pytest
 
-from conftest import ListLoader, make_classification_structure, max_param_diff
+from conftest import (
+    ListLoader,
+    make_classification_structure,
+    max_param_diff,
+    with_inference,
+)
 from fabricpc.core.activations import (
     IdentityActivation,
     SigmoidActivation,
@@ -44,8 +49,10 @@ from fabricpc.training import (
     build_clamps,
     evaluate,
     generate,
+    grad_denominator,
     make_train_step,
     metrics as metrics_mod,
+    pc_weight_gradients,
     train,
 )
 
@@ -164,7 +171,7 @@ def test_pc_parity_hand_rolled_reference(rng_key, graph_kind):
             structure, batch["x"].shape[0], key, clamps=clamps, params=p
         )
         state = run_inference(p, state, clamps, structure)
-        grads = compute_local_weight_gradients(p, state, structure)
+        grads = pc_weight_gradients(p, state, structure, clamps)
         updates, opt_state = optimizer.update(grads, opt_state, p)
         return optax.apply_updates(p, updates), opt_state
 
@@ -210,7 +217,8 @@ def test_backprop_gradient_matches_reference_ce(rng_key):
         b2 = p.nodes["y"].biases["b"]
         hidden = jax.nn.sigmoid(x @ w1 + b1)
         probs = jax.nn.softmax(hidden @ w2 + b2, axis=-1)
-        # CrossEntropyEnergy: -sum y*log(clip(mu, 1e-7, 1)), summed then /batch
+        # CrossEntropyEnergy: -sum y*log(clip(mu, 1e-7, 1)), summed then
+        # / prediction count (= batch for a rank-2 target)
         return -jnp.sum(y * jnp.log(jnp.clip(probs, 1e-7, 1.0))) / x.shape[0]
 
     ref_grads = jax.grad(reference_loss)(params)
@@ -228,8 +236,9 @@ def test_backprop_gradient_matches_reference_ce(rng_key):
 
 
 def test_backprop_gaussian_objective_is_precision_sse(rng_key):
-    """A GaussianEnergy output's backprop objective is 0.5*precision*SSE/batch,
-    not an element-mean MSE."""
+    """A GaussianEnergy output's backprop objective is 0.5*precision*SSE
+    / prediction count (= batch for a rank-2 target), not an element-mean
+    MSE."""
     precision = 2.0
     structure = classification_structure(
         output_energy=GaussianEnergy(precision=precision),
@@ -674,9 +683,10 @@ def test_custom_metric_weighted_aggregation_uneven_batches(rng_key):
 
 
 def test_eval_energy_matches_graph_energy(rng_key):
-    """evaluate's default 'energy' metric must agree with graph_energy /
-    batch_size — metrics._internal_energy_fn re-implements graph_energy's
-    node ordering, so a divergence would otherwise be silent. GlobalStateInit
+    """evaluate's default 'energy' metric must agree with graph_energy / N
+    (N = B for a rank-2 target) — metrics._internal_energy_fn re-implements
+    graph_energy's node ordering, so a divergence would otherwise be silent.
+    GlobalStateInit
     keeps the eval energy nonzero (a free feedforward output sits at its
     zero-error fixed point)."""
     structure = rng_sensitive_structure()
@@ -696,11 +706,9 @@ def test_eval_energy_matches_graph_energy(rng_key):
     assert abs(out["energy"] - expected) < 1e-5
 
 
-def test_multi_target_metric_accumulation(rng_key):
-    """Two target nodes: each default metric sums values AND weights across
-    targets, so the mean is per prediction over both heads — pins the
-    accumulation loops in metrics.py, which single-target tests never
-    iterate twice."""
+def two_target_structure():
+    """x(4) feeding two softmax + CE heads y1(3) and y2(5); task keys
+    ``y`` -> y1 and ``y2`` -> y2."""
     x_node = Linear(shape=(4,), name="x")
     y1 = Linear(
         shape=(3,),
@@ -714,7 +722,7 @@ def test_multi_target_metric_accumulation(rng_key):
         energy=CrossEntropyEnergy(),
         name="y2",
     )
-    structure = graph(
+    return graph(
         nodes=[x_node, y1, y2],
         edges=[
             Edge(source=x_node, target=y1.slot("in")),
@@ -723,6 +731,14 @@ def test_multi_target_metric_accumulation(rng_key):
         task_map=TaskMap(x=x_node, y=y1, y2=y2),
         inference=InferenceSGD(eta_infer=0.05, infer_steps=5),
     )
+
+
+def test_multi_target_metric_accumulation(rng_key):
+    """Two target nodes: each default metric sums values AND weights across
+    targets, so the mean is per prediction over both heads — pins the
+    accumulation loops in metrics.py, which single-target tests never
+    iterate twice."""
+    structure = two_target_structure()
     params = initialize_params(structure, rng_key)
     kx, k1, k2 = jax.random.split(rng_key, 3)
     batch = {
@@ -749,6 +765,205 @@ def test_multi_target_metric_accumulation(rng_key):
     assert abs(out["accuracy"] - correct / 8.0) < 1e-5
     assert abs(out["cross_entropy"] - ce_total / 8.0) < 1e-4
     assert abs(out["perplexity"] - math.exp(ce_total / 8.0)) < 1e-3
+
+
+# ---------------------------------------------------------------------------
+# Gradient normalization: one global prediction count N
+# ---------------------------------------------------------------------------
+
+
+def make_v1_token_batch(rng_key, *, batch_size=3, seq_len=5, vocab=7):
+    """Float (B, S, V) input and int (B, S) targets for v1_masked_structure."""
+    kx, ky = jax.random.split(rng_key)
+    return {
+        "x": jax.random.normal(kx, (batch_size, seq_len, vocab)),
+        "y": jax.random.randint(ky, (batch_size, seq_len), 0, vocab),
+    }
+
+
+def _relative_deviation(node_grads, reference) -> float:
+    """||a - b|| / ||b|| over all leaves of one node's parameters."""
+    diff = jax.tree_util.tree_map(
+        lambda a, b: jnp.sum((a - b) ** 2), node_grads, reference
+    )
+    norm = jax.tree_util.tree_map(lambda b: jnp.sum(b**2), reference)
+    num = jax.tree_util.tree_reduce(lambda x, y: x + y, diff, jnp.zeros(()))
+    den = jax.tree_util.tree_reduce(lambda x, y: x + y, norm, jnp.zeros(()))
+    return float(jnp.sqrt(num) / jnp.sqrt(den))
+
+
+def test_backprop_rank3_objective_divides_by_batch_times_seq(rng_key):
+    """A (B, S, V) token target has N = B*S prediction positions: the
+    backprop objective, both metrics, and the applied gradient are the target
+    energy / (B*S), not / B."""
+    seq_len, vocab, batch_size = 5, 7, 3
+    structure = v1_masked_structure(seq_len, vocab)
+    params = initialize_params(structure, rng_key)
+    batch = make_v1_token_batch(rng_key, batch_size=batch_size)
+    clamps = build_clamps(batch, structure, clamp_target=True)
+    n_predictions = batch_size * seq_len
+    assert grad_denominator(structure, clamps) == n_predictions
+
+    optimizer = optax.sgd(1.0)
+    step = make_train_step(structure, optimizer, algorithm="backprop")
+    new_params, _, metrics, state = step(params, optimizer.init(params), batch, rng_key)
+    expected = float(graph_energy(state, structure, node_names=("out",)))
+    expected /= n_predictions
+    assert expected > 0.0
+    assert abs(float(metrics["energy"]) - expected) < 1e-5
+    assert abs(float(metrics["target_energy"]) - expected) < 1e-5
+
+    def objective(p):
+        st = initialize_graph_state(
+            structure, batch_size, rng_key, clamps=clamps, params=p
+        )
+        return graph_energy(st, structure, node_names=("out",)) / n_predictions
+
+    ref_grads = jax.grad(objective)(params)
+    applied = jax.tree_util.tree_map(lambda o, n: o - n, params, new_params)
+    assert max_param_diff(ref_grads, applied) < 1e-5
+
+
+def test_pc_energy_rank3_target_is_per_prediction(rng_key):
+    """PC 'energy' on a (B, S, V) target is graph_energy / (B*S), the same
+    scale as 'target_energy'."""
+    seq_len, vocab, batch_size = 5, 7, 3
+    structure = v1_masked_structure(seq_len, vocab)
+    params = initialize_params(structure, rng_key)
+    batch = make_v1_token_batch(rng_key, batch_size=batch_size)
+    optimizer = optax.sgd(0.1)
+    step = make_train_step(structure, optimizer)
+    _, _, metrics, state = step(params, optimizer.init(params), batch, rng_key)
+    expected = float(graph_energy(state, structure)) / (batch_size * seq_len)
+    assert expected > 0.0
+    assert abs(float(metrics["energy"]) - expected) < 1e-5
+
+
+def test_target_free_pc_graph_normalizes_by_batch(rng_key):
+    """With no clamped target N = B: the optimizer-facing gradients are the raw
+    sums / B and 'energy' is graph_energy / B. The energy comes from the
+    internal node h (x -> h -> g): a free terminal node such as g is held at
+    its projection with zero energy, and GlobalStateInit keeps h's error
+    nonzero (a feedforward-initialized free node sits at its zero-error fixed
+    point)."""
+    x_node = Linear(shape=(4,), name="x")
+    h = Linear(shape=(5,), activation=SigmoidActivation(), name="h")
+    g = Linear(shape=(3,), activation=SigmoidActivation(), name="g")
+    structure = graph(
+        nodes=[x_node, h, g],
+        edges=[
+            Edge(source=x_node, target=h.slot("in")),
+            Edge(source=h, target=g.slot("in")),
+        ],
+        task_map=TaskMap(x=x_node),
+        inference=InferenceSGD(eta_infer=0.05, infer_steps=3),
+        graph_state_initializer=GlobalStateInit(),
+    )
+    params = initialize_params(structure, rng_key)
+    batch_size = 6
+    batch = {"x": jax.random.normal(rng_key, (batch_size, 4))}
+    clamps = build_clamps(batch, structure, clamp_target=True)
+    assert grad_denominator(structure, clamps) == batch_size
+
+    state = initialize_graph_state(
+        structure, batch_size, rng_key, clamps=clamps, params=params
+    )
+    state = run_inference(params, state, clamps, structure)
+    raw = compute_local_weight_gradients(params, state, structure)
+    normalized = pc_weight_gradients(params, state, structure, clamps)
+    assert max_param_diff(raw, normalized) > 0.0
+    scaled = jax.tree_util.tree_map(lambda g: g / batch_size, raw)
+    assert max_param_diff(scaled, normalized) == 0.0
+
+    optimizer = optax.sgd(0.1)
+    step = make_train_step(structure, optimizer)
+    _, _, metrics, final_state = step(params, optimizer.init(params), batch, rng_key)
+    expected = float(graph_energy(final_state, structure)) / batch_size
+    assert expected > 0.0
+    assert abs(float(metrics["energy"]) - expected) < 1e-5
+    assert float(metrics["target_energy"]) == 0.0
+
+
+def test_grad_denominator_raises_on_empty_clamps():
+    structure = classification_structure()
+    with pytest.raises(ValueError, match="clamps"):
+        grad_denominator(structure, {})
+
+
+def test_grad_denominator_matches_eval_energy_weights(rng_key):
+    """grad_denominator equals the batch total of _internal_energy_fn's
+    per-sample weight, for a sequence batch (N = B*S) and a two-target batch
+    (N = B * 2): the train and eval 'energy' divide by the same count."""
+    cases = [
+        (v1_masked_structure(5, 7), make_v1_token_batch(rng_key), 3 * 5),
+    ]
+    kx, k1, k2 = jax.random.split(rng_key, 3)
+    two_target_batch = {
+        "x": jax.random.normal(kx, (4, 4)),
+        "y": jax.random.randint(k1, (4,), 0, 3),
+        "y2": jax.random.randint(k2, (4,), 0, 5),
+    }
+    cases.append((two_target_structure(), two_target_batch, 4 * 2))
+    for structure, batch, expected in cases:
+        clamps = build_clamps(batch, structure, clamp_target=True)
+        params = initialize_params(structure, rng_key)
+        batch_size = batch["x"].shape[0]
+        state = initialize_graph_state(
+            structure, batch_size, rng_key, clamps=clamps, params=params
+        )
+        _, weight = metrics_mod._internal_energy_fn(state, batch, structure)
+        assert weight.shape == (batch_size,)
+        assert grad_denominator(structure, clamps) == expected
+        assert float(jnp.sum(weight)) == expected
+
+
+def test_one_step_pc_gradients_vs_backprop(rng_key):
+    """One InferenceSGD step from the feedforward state moves only the hidden
+    latent, by -eta * dE/dz_h (its own error is zero there), so the hidden
+    node's local weight gradient is exactly eta times the backprop gradient
+    of the target energy, for any eta. The output node's local gradient is
+    re-evaluated at the moved hidden latent and differs from backprop by
+    O(eta); the deviation shrinks with eta. Both sides divide by N = B.
+
+    The hidden identity is checked at eta = 0.1: the hidden error is formed
+    as (mu_h - eta * grad) - mu_h in float32, whose rounding error is
+    ulp(mu_h) / (eta * |grad|), about 1e-6 at eta = 0.1 and 1e-3 at
+    eta = 1e-4, so smaller eta would measure rounding, not the identity.
+    """
+    base = classification_structure()
+    params = initialize_params(base, rng_key)
+    kx, ky = jax.random.split(rng_key)
+    batch_size = 4
+    batch = {
+        "x": jax.random.normal(kx, (batch_size, 6)),
+        "y": jax.nn.one_hot(jax.random.randint(ky, (batch_size,), 0, 3), 3),
+    }
+    clamps = build_clamps(batch, base, clamp_target=True)
+
+    optimizer = optax.sgd(1.0)
+    bp_step = make_train_step(base, optimizer, algorithm="backprop")
+    new_params, *_ = bp_step(params, optimizer.init(params), batch, rng_key)
+    bp_grads = jax.tree_util.tree_map(lambda o, n: o - n, params, new_params)
+
+    def pc_grads(eta):
+        structure = with_inference(base, eta_infer=eta, infer_steps=1)
+        state = initialize_graph_state(
+            structure, batch_size, rng_key, clamps=clamps, params=params
+        )
+        state = run_inference(params, state, clamps, structure)
+        return pc_weight_gradients(params, state, structure, clamps)
+
+    eta = 0.1
+    hidden_ref = jax.tree_util.tree_map(lambda g: eta * g, bp_grads.nodes["h"])
+    assert _relative_deviation(pc_grads(eta).nodes["h"], hidden_ref) < 1e-5
+
+    deviations = [
+        _relative_deviation(pc_grads(eta).nodes["y"], bp_grads.nodes["y"])
+        for eta in (1e-1, 1e-2, 1e-3)
+    ]
+    for eta, dev in zip((1e-1, 1e-2, 1e-3), deviations):
+        assert 0.0 < dev < 10.0 * eta
+    assert deviations[0] > deviations[1] > deviations[2]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #68. This PR documents the estimator defect in the existing
natural-gradient transforms; the issue was updated with the learnings from the
measurements below and the requirements for the redesign (a per-sample
Monte-Carlo diagonal Fisher, generic through `NodeBase`).

Design document: `docs/dev_plans_archive/mean_gradient_normalization.md` (on
this branch). It records the design, the alternatives considered, the reduced
route taken for the natural-gradient transforms, every measurement below with
the command that produced it, and a Revisions section summarizing the branch
review and the decisions taken from it.

Releases as 0.5.1 (`pyproject.toml`; CHANGELOG `[0.5.1] - 2026-09-07`).

### Problem

`compute_local_weight_gradients` returns batch-summed gradients, and the PC
path fed them to optax as they were, while the backprop path divided its
objective by `batch_size`. The same learning rate, Adam epsilon, or clipping
threshold therefore meant different things under `algorithm="pc"` and
`"backprop"`, and the gradient scale changed with batch size and sequence
length.

### Change

Both paths divide once, in one trainer function, by the prediction count N:
the total number of clamped-target prediction positions in the batch. A
rank-2 classification target `(B, C)` gives N = B; a rank-3 token target
`(B, S, V)` gives N = B·S; several target heads sum their positions; a graph
with no clamped target uses B.

- `fabricpc.training.grad_denominator(structure, clamps) -> int`,
  `fabricpc.training.pc_weight_gradients(params, state, structure, clamps)`
  (the batch-summed gradients divided by N), and
  `fabricpc.training.batch_size_of(batch, structure)`. `_batch_grads` uses
  them on the PC path and divides the backprop objective by the same N.
- The training `energy` metric is the objective per prediction under both
  algorithms (its node set is still algorithm-dependent); `target_energy` is
  unchanged. For rank-2 targets every reported number equals the parent's; for
  sequence targets PC `energy` moves from per sample to per token.
- `evaluate`'s default PC `energy` weights each sample by its prediction
  count, so eval and training `energy` share one scale.
- `train_step_with_history` (dashboarding) normalizes the same way. New
  `tests/test_inference_tracking.py` pins it to `make_train_step` under
  `optax.sgd(1.0)`.
- `compute_local_weight_gradients` keeps returning sums; its docstring states
  the contract and points to the trainer functions.

### Natural-gradient transforms

The `damping` default of `scale_by_natural_gradient_diag` and
`scale_by_natural_gradient_layerwise` depends on the gradient scale (the
Fisher EMA scales with g²), so this PR owns it. Re-choosing it exposed a
quality gap in the existing transforms, which this PR documents rather than
fixes.

Both transforms gain a bias-corrected Fisher EMA (`f / (1 - fisher_decay**t)`;
both state tuples gain an int32 `count`) and a `damping` default of 1e-8,
swept on the per-prediction gradient scale. Their update `g / (f + damping)`
has two regimes, now stated in the module docstring, the optimizers guide, and
the demo: where `damping` dominates the Fisher entry the update is SGD with
rate `scale / damping`; where the Fisher dominates it is about `1 / g`, because
`f` is the squared *mean* gradient of the batch rather than a per-sample
Fisher. No damping value yields a natural-gradient step. At the default, 95%
of the Fisher entries on the MNIST demo sit below the damping at step 1 and
99.7% after one epoch, so the presets run as SGD on almost every weight.

A relative-damping design (`g / (f̂ + ρ·trace(F̂)/dim)`) was built first and
reverted after review: with the squared-mean Fisher it holds the `1 / g` ratio
at every scale and cannot converge (48 MNIST runs at chance). The design
document records it under Alternatives; issue #68 carries the estimator
redesign that would make it correct.

### Migration

| Changed | Replacement |
|---|---|
| `compute_local_weight_gradients` fed directly to an optimizer in a custom loop | `pc_weight_gradients(params, state, structure, clamps)` |
| SGD-family learning rates tuned on summed PC gradients | multiply `lr` by N; divide a coupled `add_decayed_weights` rate by N (Adam/AdamW rates unchanged) |
| Training `energy` read as per sample | per prediction, same scale as `target_energy` |
| NGD optimizer states saved under 0.5.0 | do not restore (new `count` field) |

### Examples and docs

- `examples/mnist_advanced.py`: `--num_epochs` (default 10); `sgd` preset
  rescaled exactly (lr 0.01 → 2.0, wd 0.1 → 5e-4 at N = 200); `ngd_diag` and
  `ngd_layerwise` use the swept constants with the measured regime in the
  comment.
- `examples/transformer_demo.py`: the clip stays at 0.8; the `--lr` default
  becomes mode-dependent (3e-5 for `pc`, 1e-4 for `backprop`); the `Results:`
  block records the new run (PC energy now per token).
- `examples/transformer_v2_demo.py`: the docstring `Results:` block is
  re-measured under the 0.5 trainer and this normalization (default call:
  `--mode pc`, char tokenizer, 5 epochs; jax 0.10.1, RTX 3090). The old block
  carried pre-0.5 numbers marked as a historical baseline; the 0.5 trainer
  changed the eval numerics, so they were not comparable. The demo uses Adam
  with a cosine schedule and no clip, so the rescale itself is Adam-invariant
  here.
- `examples/mnist_aim_tracking.py`: stale normalization comment fixed.
- Guides 03, 06, 07 (new "Gradient Scale" section; natural-gradient section
  rewritten around the two regimes), 08 (N defined, multi-head convention,
  eval-metric table), 09; `CHANGELOG.md` `[0.5.1]`.

### Verification

RTX 3090, JAX 0.10.1, optax 0.2.8. The GPU was shared with another job
during the transformer and ResNet runs, so those timings are not comparable
to the docstrings; perplexities and accuracies are. Tests and linters were run
on `4403c4a`, the branch head, on CPU.

```
JAX_PLATFORMS=cpu pytest -q                     # 408 passed, 5 skipped (163 s)
ruff check fabricpc tests examples scripts      # clean
black --check fabricpc tests examples scripts   # 106 files unchanged
```

MNIST, `python examples/mnist_advanced.py --optimizer <preset> --num_epochs <n>`:

| preset | parent, epoch 2 | parent, epoch 10 | new, epoch 2 | new, epoch 10 |
|---|---|---|---|---|
| `sgd` | 0.4517 / 10.28% | 0.3245 / 24.78% | 0.4517 / 10.28% (identical) | — |
| `adamw` | 0.4432 / 20.95% | — | — | 0.0127 / 97.27% |
| `ngd_diag` | 0.5017 / 8.92% | 0.1786 / 25.25% | — | 0.2208 / 16.27% |
| `ngd_layerwise` | 0.4513 / 10.28% | 0.4514 / 9.74% | — | 0.4509 / 10.28% |

NGD damping sweep on the same demo, 68 runs. Full grid at 2 epochs, both
transforms: `damping` ∈ {1e-8, 1e-7, 1e-6, 1e-5, 1e-4} × `scale / damping` ∈
{20, 60, 200} (30 runs, every one at chance accuracy, as the parent's presets
were at 2 epochs). Then 38 runs at 10 epochs: `damping` ∈ {1e-7, 1e-6, 1e-5,
1e-4} × `scale / damping` ∈ {200, 600, 2000} for both transforms, plus
`damping` ∈ {1e-8, 2.5e-8, 3e-8, 1e-7} at `scale / damping` 60 to 600. Only
the diagonal transform with `damping` ≤ 2.5e-8 and `scale / damping` ≤ 200
leaves chance (12.3 to 16.3%); the layer-wise transform stays at chance in
every run; training energy falls in many settings without accuracy following.
At the chosen default (1e-8, `scale / damping` = 60) the damping exceeds
95.4% of the 242,762 bias-corrected Fisher entries at step 1 and 99.7% after
one epoch, and the entries above it hold essentially all of trace(F). The
`ngd_diag` accuracy is below the parent preset's 25.25%: the parent's damping
acted as SGD on 96.5% of the entries (an exact rescale of it, `damping =
1e-3 / N²` with `scale / N`, reproduces 23.78%), and the new default was
chosen for the best result available on the new scale rather than to
reproduce that preset.

Transformer, `python examples/transformer_demo.py --mode <mode> [--lr <lr>]`
(default 1 epoch = 7841 batches of 128 × 128 tokens):

| mode, lr | parent: test loss / perplexity | new: test loss / perplexity |
|---|---|---|
| backprop, 1e-4 | 1.8844 / 6.58 | 1.8846 / 6.58 |
| pc, 1e-4 | 2.6988 / 14.86 | 4.7353 / 113.90 (diverges after step ~3500) |
| pc, 3e-5 (new default) | — | 2.6846 / 14.65 |
| pc, 1e-5 | — | 2.9998 / 20.08 |

At `--num_epochs 0.1` (784 steps) parent and new PC agree at lr 1e-4
(perplexity 20.66 vs 20.76, 2.64 energy per token on both), so the divergence
is a late-training instability once the 0.8 clip stops normalizing every
step.

Transformer v2, `python examples/transformer_v2_demo.py` (default: `--mode
pc`, char tokenizer, 5 epochs), as recorded in the docstring: train energy
per token 2.1198 at epoch 1 to 1.9691 at epoch 5; test CE 2.3383, perplexity
10.36, accuracy 33.43%. The pre-0.5 docstring numbers (perplexity 9.12) are
not comparable.

ResNet-18, `python examples/resnet18_cifar10_demo.py`: test accuracy 33.58%
against the docstring's 33.71%, within the variation the docstring states.
